### PR TITLE
Submission form quick wins from stakeholder meeting

### DIFF
--- a/backend/app/schemas/submission.py
+++ b/backend/app/schemas/submission.py
@@ -25,8 +25,8 @@ class LinkResponse(BaseModel):
 
 
 class ScheduleRequestCreate(BaseModel):
-    Requested_Date: date | None = None
-    Repeat_Count: int = 1
+    Requested_Date: date
+    Repeat_Count: int = Field(1, ge=1, le=2)
     Repeat_Note: str | None = None
 
 
@@ -43,7 +43,7 @@ class ScheduleRequestResponse(BaseModel):
 
 
 class SubmissionCreate(BaseModel):
-    Category: str = Field(..., pattern=r"^(faculty_staff|student|job_opportunity|kudos|in_memoriam|news_release|calendar_event)$")
+    Category: str = Field(..., pattern=r"^(faculty_staff|student|job_opportunity|kudos|in_memoriam)$")
     Target_Newsletter: str = Field(..., pattern=r"^(tdr|myui|both)$")
     Original_Headline: str = Field(..., min_length=1, max_length=500)
     Original_Body: str = Field(..., min_length=1)
@@ -51,7 +51,7 @@ class SubmissionCreate(BaseModel):
     Submitter_Email: str = Field(..., max_length=255)
     Submitter_Notes: str | None = None
     Links: list[LinkCreate] = []
-    Schedule_Requests: list[ScheduleRequestCreate] = []
+    Schedule_Requests: list[ScheduleRequestCreate] = Field(..., min_length=1)
 
 
 class SubmissionUpdate(BaseModel):
@@ -59,7 +59,7 @@ class SubmissionUpdate(BaseModel):
     Original_Headline: str | None = None
     Original_Body: str | None = None
     Submitter_Notes: str | None = None
-    Category: str | None = Field(None, pattern=r"^(faculty_staff|student|job_opportunity|kudos|in_memoriam|news_release|calendar_event)$")
+    Category: str | None = Field(None, pattern=r"^(faculty_staff|student|job_opportunity|kudos|in_memoriam)$")
     Target_Newsletter: str | None = Field(None, pattern=r"^(tdr|myui|both)$")
 
 

--- a/backend/data/allowed_values/allowed_values.json
+++ b/backend/data/allowed_values/allowed_values.json
@@ -4,8 +4,6 @@
   {"Value_Group": "Submission_Category", "Code": "job_opportunity", "Label": "Job Opportunity", "Display_Order": 3, "Description": "Employment listings"},
   {"Value_Group": "Submission_Category", "Code": "kudos", "Label": "Kudos", "Display_Order": 4, "Description": "Awards, honors, recognition"},
   {"Value_Group": "Submission_Category", "Code": "in_memoriam", "Label": "In Memoriam", "Display_Order": 5, "Description": "Memorial notices"},
-  {"Value_Group": "Submission_Category", "Code": "news_release", "Label": "News Release", "Display_Order": 6, "Description": "Official news releases"},
-  {"Value_Group": "Submission_Category", "Code": "calendar_event", "Label": "Calendar Event", "Display_Order": 7, "Description": "Events and calendar items"},
 
   {"Value_Group": "Newsletter_Type", "Code": "tdr", "Label": "The Daily Register", "Display_Order": 1, "Description": "Faculty and staff newsletter"},
   {"Value_Group": "Newsletter_Type", "Code": "myui", "Label": "My UI", "Display_Order": 2, "Description": "Student newsletter"},

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -74,6 +74,7 @@ def make_submission_data(**overrides) -> dict:
         "Original_Body": "This is the body text of a test submission.",
         "Submitter_Name": "Test User",
         "Submitter_Email": "test@uidaho.edu",
+        "Schedule_Requests": [{"Requested_Date": "2026-03-15", "Repeat_Count": 1}],
     }
     data.update(overrides)
     return data

--- a/backend/tests/test_submissions.py
+++ b/backend/tests/test_submissions.py
@@ -30,13 +30,13 @@ class TestSubmissionCRUD:
 
     async def test_create_submission_with_schedule(self, client: AsyncClient):
         data = make_submission_data(
-            Schedule_Requests=[{"Requested_Date": "2026-03-15", "Repeat_Count": 3}]
+            Schedule_Requests=[{"Requested_Date": "2026-03-15", "Repeat_Count": 2}]
         )
         resp = await client.post("/api/v1/submissions/", json=data)
         assert resp.status_code == 201
         body = resp.json()
         assert len(body["Schedule_Requests"]) == 1
-        assert body["Schedule_Requests"][0]["Repeat_Count"] == 3
+        assert body["Schedule_Requests"][0]["Repeat_Count"] == 2
 
     async def test_list_submissions(self, client: AsyncClient):
         # Create two submissions

--- a/frontend/src/components/submission/CategorySelect.tsx
+++ b/frontend/src/components/submission/CategorySelect.tsx
@@ -6,8 +6,6 @@ const CATEGORIES: { value: SubmissionCategory; label: string }[] = [
   { value: 'job_opportunity', label: 'Job Opportunity' },
   { value: 'kudos', label: 'Acknowledgments and Kudos' },
   { value: 'in_memoriam', label: 'In Memoriam' },
-  { value: 'news_release', label: 'News Release' },
-  { value: 'calendar_event', label: 'Calendar Event' },
 ];
 
 interface Props {

--- a/frontend/src/components/submission/SchedulePrefs.tsx
+++ b/frontend/src/components/submission/SchedulePrefs.tsx
@@ -28,6 +28,7 @@ export default function SchedulePrefs({ schedule, onChange }: Props) {
             type="date"
             value={schedule.Requested_Date}
             onChange={(e) => update('Requested_Date', e.target.value)}
+            required
             className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
           />
         </div>
@@ -42,7 +43,6 @@ export default function SchedulePrefs({ schedule, onChange }: Props) {
           >
             <option value={1}>Once</option>
             <option value={2}>Twice (has RSVP/registration)</option>
-            <option value={3}>Three times</option>
           </select>
         </div>
       </div>

--- a/frontend/src/components/submission/SubmissionForm.tsx
+++ b/frontend/src/components/submission/SubmissionForm.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
 import type { SubmissionCategory, TargetNewsletter, SubmissionCreate } from '../../types/submission';
-import { createSubmission, uploadImage } from '../../api/submissions';
+import { createSubmission } from '../../api/submissions';
 import CategorySelect from './CategorySelect';
 import NewsletterTargetSelect from './NewsletterTargetSelect';
 import LinkEditor from './LinkEditor';
-import ImageUpload from './ImageUpload';
 import SchedulePrefs from './SchedulePrefs';
 
 interface LinkEntry {
@@ -27,7 +26,6 @@ export default function SubmissionForm() {
   const [submitterEmail, setSubmitterEmail] = useState('');
   const [notes, setNotes] = useState('');
   const [links, setLinks] = useState<LinkEntry[]>([]);
-  const [imageFile, setImageFile] = useState<File | null>(null);
   const [schedule, setSchedule] = useState<ScheduleEntry>({
     Requested_Date: '',
     Repeat_Count: 1,
@@ -56,22 +54,16 @@ export default function SubmissionForm() {
         Links: links
           .filter((l) => l.Url.trim())
           .map((l) => ({ Url: l.Url, Anchor_Text: l.Anchor_Text || undefined })),
-        Schedule_Requests: schedule.Requested_Date
-          ? [
-              {
-                Requested_Date: schedule.Requested_Date,
-                Repeat_Count: schedule.Repeat_Count,
-                Repeat_Note: schedule.Repeat_Note || undefined,
-              },
-            ]
-          : [],
+        Schedule_Requests: [
+          {
+            Requested_Date: schedule.Requested_Date,
+            Repeat_Count: schedule.Repeat_Count,
+            Repeat_Note: schedule.Repeat_Note || undefined,
+          },
+        ],
       };
 
-      const submission = await createSubmission(data);
-
-      if (imageFile) {
-        await uploadImage(submission.Id, imageFile);
-      }
+      await createSubmission(data);
 
       setSuccess(true);
       // Reset form
@@ -79,7 +71,6 @@ export default function SubmissionForm() {
       setBody('');
       setNotes('');
       setLinks([]);
-      setImageFile(null);
       setSchedule({ Requested_Date: '', Repeat_Count: 1, Repeat_Note: '' });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Submission failed');
@@ -107,8 +98,8 @@ export default function SubmissionForm() {
         <h3 className="text-lg font-semibold text-gray-900 border-b pb-3">
           About Your Announcement
         </h3>
-        <CategorySelect value={category} onChange={setCategory} />
         <NewsletterTargetSelect value={targetNewsletter} onChange={setTargetNewsletter} />
+        <CategorySelect value={category} onChange={setCategory} />
       </div>
 
       <div className="bg-white rounded-lg shadow p-6 space-y-5">
@@ -144,7 +135,6 @@ export default function SubmissionForm() {
           />
         </div>
         <LinkEditor links={links} onChange={setLinks} />
-        <ImageUpload file={imageFile} onChange={setImageFile} />
       </div>
 
       <div className="bg-white rounded-lg shadow p-6 space-y-5">

--- a/frontend/src/types/submission.ts
+++ b/frontend/src/types/submission.ts
@@ -3,9 +3,10 @@ export type SubmissionCategory =
   | 'student'
   | 'job_opportunity'
   | 'kudos'
-  | 'in_memoriam'
-  | 'news_release'
-  | 'calendar_event';
+  | 'in_memoriam';
+
+/** Legacy categories that may exist on old submissions but are no longer submittable. */
+export type LegacyCategory = 'news_release' | 'calendar_event';
 
 export type TargetNewsletter = 'tdr' | 'myui' | 'both';
 
@@ -34,7 +35,7 @@ export interface SubmissionScheduleRequest {
 
 export interface Submission {
   Id: string;
-  Category: SubmissionCategory;
+  Category: SubmissionCategory | LegacyCategory;
   Target_Newsletter: TargetNewsletter;
   Original_Headline: string;
   Original_Body: string;


### PR DESCRIPTION
## Summary
Implements five low-effort, high-impact changes from the **2026-03-05 stakeholder meeting** with Joy Bauer, Jodi Walker, and Leigh Cooper.

- **Remove "Calendar Event" and "News Release"** from announcement type dropdown — these are never submitted by the public (#5)
- **Move Target Newsletter above Announcement Type** — users should pick the newsletter first (#6)
- **Remove image upload** from submission form — images are sourced from Content Hub, not submitters (#7)
- **Limit run frequency to Once/Twice** — remove 3x option; anything beyond twice requires direct contact (#8)
- **Make preferred run date required** — submissions can no longer be created without a scheduled date (#12)

### Changes span frontend + backend:
| Area | Files |
|------|-------|
| Seed data | `allowed_values.json` — removed 2 category entries |
| Backend schemas | `submission.py` — updated regex patterns, added `le=2` constraint, required schedule |
| Frontend types | `submission.ts` — narrowed `SubmissionCategory`, added `LegacyCategory` for old data |
| Form components | `SubmissionForm.tsx`, `CategorySelect.tsx`, `SchedulePrefs.tsx` — reordered fields, removed image upload, removed 3x option, required date |
| Tests | `conftest.py`, `test_submissions.py` — updated fixtures to match new constraints |

## Test plan
- [ ] Submit a new announcement — verify Calendar Event and News Release are gone from dropdown
- [ ] Verify Target Newsletter appears above Announcement Type
- [ ] Verify no image upload field is shown
- [ ] Verify run frequency only shows Once and Twice
- [ ] Try to submit without a date — should be blocked by validation
- [ ] Verify existing submissions with legacy categories still display correctly on dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)