### PR TITLE
Add date validation by newsletter target and improve editor info panel

### DIFF
--- a/frontend/src/components/editor/SubmissionMeta.tsx
+++ b/frontend/src/components/editor/SubmissionMeta.tsx
@@ -14,6 +14,12 @@ const CATEGORY_LABELS: Record<string, string> = {
   calendar_event: 'Calendar Event',
 };
 
+const TARGET_LABELS: Record<string, string> = {
+  tdr: 'The Daily Register',
+  myui: 'My UI',
+  both: 'Both Newsletters',
+};
+
 export default function SubmissionMeta({ submission }: SubmissionMetaProps) {
   return (
     <div className="bg-white rounded-lg border p-4">
@@ -25,11 +31,40 @@ export default function SubmissionMeta({ submission }: SubmissionMetaProps) {
           <dd className="text-xs text-gray-500">{submission.Submitter_Email}</dd>
         </div>
         <div>
+          <dt className="text-xs text-gray-500">Target Newsletter</dt>
+          <dd className="text-gray-900">
+            {TARGET_LABELS[submission.Target_Newsletter] || submission.Target_Newsletter}
+          </dd>
+        </div>
+        <div>
           <dt className="text-xs text-gray-500">Category</dt>
           <dd className="text-gray-900">
             {CATEGORY_LABELS[submission.Category] || submission.Category}
           </dd>
         </div>
+        {submission.Schedule_Requests.length > 0 && (
+          <div>
+            <dt className="text-xs text-gray-500">Requested Run Date</dt>
+            {submission.Schedule_Requests.map((req) => (
+              <dd key={req.Id} className="text-gray-900 font-medium">
+                {req.Requested_Date
+                  ? new Date(req.Requested_Date).toLocaleDateString(undefined, {
+                      weekday: 'short',
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                    })
+                  : 'No specific date'}
+                {req.Repeat_Count > 1 && (
+                  <span className="font-normal text-gray-500"> &middot; Run {req.Repeat_Count}x</span>
+                )}
+                {req.Repeat_Note && (
+                  <span className="font-normal text-gray-500"> ({req.Repeat_Note})</span>
+                )}
+              </dd>
+            ))}
+          </div>
+        )}
         <div>
           <dt className="text-xs text-gray-500">Submitted</dt>
           <dd className="text-gray-900">
@@ -59,20 +94,6 @@ export default function SubmissionMeta({ submission }: SubmissionMetaProps) {
             <dd className="text-gray-700 text-xs bg-gray-50 p-2 rounded mt-1">
               {submission.Submitter_Notes}
             </dd>
-          </div>
-        )}
-        {submission.Schedule_Requests.length > 0 && (
-          <div>
-            <dt className="text-xs text-gray-500">Schedule Requests</dt>
-            {submission.Schedule_Requests.map((req) => (
-              <dd key={req.Id} className="text-xs text-gray-700">
-                {req.Requested_Date
-                  ? new Date(req.Requested_Date).toLocaleDateString()
-                  : 'No specific date'}{' '}
-                &middot; Run {req.Repeat_Count}x
-                {req.Repeat_Note && ` (${req.Repeat_Note})`}
-              </dd>
-            ))}
           </div>
         )}
       </dl>

--- a/frontend/src/components/submission/SchedulePrefs.tsx
+++ b/frontend/src/components/submission/SchedulePrefs.tsx
@@ -1,3 +1,5 @@
+import type { TargetNewsletter } from '../../types/submission';
+
 interface ScheduleEntry {
   Requested_Date: string;
   Repeat_Count: number;
@@ -7,12 +9,34 @@ interface ScheduleEntry {
 interface Props {
   schedule: ScheduleEntry;
   onChange: (schedule: ScheduleEntry) => void;
+  targetNewsletter: TargetNewsletter;
 }
 
-export default function SchedulePrefs({ schedule, onChange }: Props) {
+function validateDate(dateStr: string, target: TargetNewsletter): string | null {
+  if (!dateStr) return null;
+  const d = new Date(dateStr + 'T00:00:00');
+  const day = d.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
+
+  if (target === 'myui' || target === 'both') {
+    if (day !== 1) return 'My UI publishes on Mondays only.';
+  } else if (target === 'tdr') {
+    if (day === 0 || day === 6) return 'The Daily Register does not publish on weekends.';
+  }
+  return null;
+}
+
+function getMinDate(): string {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return tomorrow.toISOString().split('T')[0];
+}
+
+export default function SchedulePrefs({ schedule, onChange, targetNewsletter }: Props) {
   const update = (field: keyof ScheduleEntry, value: string | number) => {
     onChange({ ...schedule, [field]: value });
   };
+
+  const dateError = validateDate(schedule.Requested_Date, targetNewsletter);
 
   return (
     <div>
@@ -29,8 +53,21 @@ export default function SchedulePrefs({ schedule, onChange }: Props) {
             value={schedule.Requested_Date}
             onChange={(e) => update('Requested_Date', e.target.value)}
             required
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
+            min={getMinDate()}
+            className={`w-full rounded-md border px-3 py-2 text-sm focus:ring-1 ${
+              dateError
+                ? 'border-red-400 focus:border-red-500 focus:ring-red-500'
+                : 'border-gray-300 focus:border-ui-gold-500 focus:ring-ui-gold-500'
+            }`}
           />
+          {dateError && (
+            <p className="text-xs text-red-600 mt-1">{dateError}</p>
+          )}
+          <p className="text-xs text-gray-400 mt-1">
+            {targetNewsletter === 'myui' || targetNewsletter === 'both'
+              ? 'My UI publishes Mondays only'
+              : 'Mon–Fri only'}
+          </p>
         </div>
         <div>
           <label className="block text-xs text-gray-500 mb-1">

--- a/frontend/src/components/submission/SubmissionForm.tsx
+++ b/frontend/src/components/submission/SubmissionForm.tsx
@@ -36,8 +36,36 @@ export default function SubmissionForm() {
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Clear date when newsletter target changes (previously valid date may now be invalid)
+  const handleTargetChange = (target: TargetNewsletter) => {
+    setTargetNewsletter(target);
+    if (schedule.Requested_Date) {
+      const d = new Date(schedule.Requested_Date + 'T00:00:00');
+      const day = d.getDay();
+      const invalid =
+        (target === 'myui' || target === 'both') ? day !== 1 :
+        (target === 'tdr') ? (day === 0 || day === 6) : false;
+      if (invalid) {
+        setSchedule({ ...schedule, Requested_Date: '' });
+      }
+    }
+  };
+
+  const hasDateError = (): boolean => {
+    if (!schedule.Requested_Date) return false;
+    const d = new Date(schedule.Requested_Date + 'T00:00:00');
+    const day = d.getDay();
+    if (targetNewsletter === 'myui' || targetNewsletter === 'both') return day !== 1;
+    if (targetNewsletter === 'tdr') return day === 0 || day === 6;
+    return false;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (hasDateError()) {
+      setError('Please select a valid run date for the chosen newsletter.');
+      return;
+    }
     setSubmitting(true);
     setError(null);
     setSuccess(false);
@@ -98,7 +126,7 @@ export default function SubmissionForm() {
         <h3 className="text-lg font-semibold text-gray-900 border-b pb-3">
           About Your Announcement
         </h3>
-        <NewsletterTargetSelect value={targetNewsletter} onChange={setTargetNewsletter} />
+        <NewsletterTargetSelect value={targetNewsletter} onChange={handleTargetChange} />
         <CategorySelect value={category} onChange={setCategory} />
       </div>
 
@@ -141,7 +169,7 @@ export default function SubmissionForm() {
         <h3 className="text-lg font-semibold text-gray-900 border-b pb-3">
           Scheduling
         </h3>
-        <SchedulePrefs schedule={schedule} onChange={setSchedule} />
+        <SchedulePrefs schedule={schedule} onChange={setSchedule} targetNewsletter={targetNewsletter} />
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
             Additional Notes for Editors


### PR DESCRIPTION
## Summary
- **#10**: Date picker now enforces weekdays-only for TDR and Mondays-only for My UI/Both, with inline error messages, hint text, and a minimum date of tomorrow. Invalid dates are auto-cleared when the user switches newsletter target.
- **#15**: Editor info panel now shows Requested Run Date prominently (moved above "Submitted" timestamp) with improved formatting, and displays the Target Newsletter.
- Closed #5, #6, #7, #8, #12 as already implemented by PR #29.

Closes #10, closes #15

## Test plan
- [ ] Select TDR → pick a Saturday or Sunday → verify red error appears and form won't submit
- [ ] Select My UI → pick a non-Monday → verify error appears
- [ ] Select Both → pick a non-Monday → verify error appears
- [ ] Switch from TDR (with a Tuesday selected) to My UI → verify date clears
- [ ] Verify editor info panel shows Target Newsletter and run date near top

🤖 Generated with [Claude Code](https://claude.com/claude-code)