### PR TITLE
Add calendar event import to newsletter builder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,9 @@ MINDROUTER_MODEL=openai/gpt-oss-120b
 # File uploads
 UPLOAD_DIR=./uploads
 
+# University calendar source
+CALENDAR_SOURCE_URL=https://www.qatrumba.com/events-calendar/ui/uidaho/vandals/vandal/event/events/calendar/moscow/idaho/id/university-of-idaho
+CALENDAR_REQUEST_TIMEOUT_SECONDS=10.0
+
 # CORS (comma-separated origins)
 CORS_ORIGINS=http://localhost:5173

--- a/backend/alembic/versions/bf1f70f4c8d9_add_newsletter_external_items.py
+++ b/backend/alembic/versions/bf1f70f4c8d9_add_newsletter_external_items.py
@@ -1,0 +1,46 @@
+"""add_newsletter_external_items
+
+Revision ID: bf1f70f4c8d9
+Revises: 910c2f3c5db4
+Create Date: 2026-03-19 07:25:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "bf1f70f4c8d9"
+down_revision: Union[str, Sequence[str], None] = "910c2f3c5db4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "newsletter_external_items",
+        sa.Column("Id", sa.String(length=36), nullable=False),
+        sa.Column("Newsletter_Id", sa.String(length=36), nullable=False),
+        sa.Column("Section_Id", sa.String(length=36), nullable=False),
+        sa.Column("Source_Type", sa.String(length=50), nullable=False),
+        sa.Column("Source_Id", sa.String(length=255), nullable=False),
+        sa.Column("Source_Url", sa.Text(), nullable=True),
+        sa.Column("Event_Start", sa.DateTime(), nullable=True),
+        sa.Column("Event_End", sa.DateTime(), nullable=True),
+        sa.Column("Location", sa.String(length=255), nullable=True),
+        sa.Column("Position", sa.Integer(), nullable=False),
+        sa.Column("Final_Headline", sa.Text(), nullable=False),
+        sa.Column("Final_Body", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(["Newsletter_Id"], ["newsletters.Id"]),
+        sa.ForeignKeyConstraint(["Section_Id"], ["newsletter_sections.Id"]),
+        sa.PrimaryKeyConstraint("Id"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("newsletter_external_items")

--- a/backend/app/api/v1/newsletters.py
+++ b/backend/app/api/v1/newsletters.py
@@ -1,24 +1,23 @@
 """Newsletter CRUD and assembly API endpoints."""
 
-from datetime import date
-
 import sqlalchemy as sa
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from app.api.deps import get_db
-from app.models.newsletter import Newsletter, NewsletterItem
 from app.models.section import NewsletterSection
-from app.services import newsletter_service
+from app.services import calendar_event_service, newsletter_service
 from app.schemas.newsletter import (
+    CalendarEventCandidateResponse,
+    CalendarEventImportRequest,
     NewsletterCreate,
-    NewsletterResponse,
     NewsletterDetailResponse,
+    NewsletterExternalItemResponse,
     NewsletterItemCreate,
-    NewsletterItemUpdate,
     NewsletterItemResponse,
+    NewsletterItemUpdate,
+    NewsletterResponse,
     AssembleRequest,
 )
 from app.utils.export import export_newsletter_docx
@@ -101,6 +100,93 @@ async def add_item(
     return item
 
 
+@router.get(
+    "/{newsletter_id}/calendar-events",
+    response_model=list[CalendarEventCandidateResponse],
+)
+async def list_calendar_events(
+    newsletter_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """Fetch candidate calendar events for a newsletter issue."""
+    newsletter = await newsletter_service.get_newsletter(db, newsletter_id)
+    if not newsletter:
+        raise HTTPException(status_code=404, detail="Newsletter not found")
+
+    selected_source_ids = [
+        item.Source_Id
+        for item in newsletter.External_Items
+        if item.Source_Type == "calendar_event"
+    ]
+    return await calendar_event_service.fetch_calendar_events(
+        publish_date=newsletter.Publish_Date,
+        newsletter_type=newsletter.Newsletter_Type,
+        selected_source_ids=selected_source_ids,
+    )
+
+
+@router.post(
+    "/{newsletter_id}/calendar-events",
+    response_model=NewsletterExternalItemResponse,
+    status_code=201,
+)
+async def add_calendar_event(
+    newsletter_id: str,
+    data: CalendarEventImportRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Import a calendar event into a newsletter section."""
+    newsletter = await newsletter_service.get_newsletter(db, newsletter_id)
+    if not newsletter:
+        raise HTTPException(status_code=404, detail="Newsletter not found")
+
+    existing = next(
+        (
+            item for item in newsletter.External_Items
+            if item.Source_Type == "calendar_event" and item.Source_Id == data.Source_Id
+        ),
+        None,
+    )
+    if existing:
+        return existing
+
+    section_slug = newsletter_service.get_calendar_section_slug(newsletter.Newsletter_Type)
+    section_result = await db.execute(
+        sa.select(NewsletterSection).where(
+            NewsletterSection.Newsletter_Type == newsletter.Newsletter_Type,
+            NewsletterSection.Slug == section_slug,
+        )
+    )
+    section = section_result.scalar_one_or_none()
+    if not section:
+        raise HTTPException(status_code=422, detail="Calendar section is not configured")
+
+    event = calendar_event_service.CalendarEvent(
+        source_id=data.Source_Id,
+        source_type="calendar_event",
+        url=data.Url,
+        title=data.Title,
+        description=data.Description,
+        location=data.Location,
+        event_start=data.Event_Start,
+        event_end=data.Event_End,
+    )
+    item = await newsletter_service.add_external_item(
+        db,
+        newsletter_id=newsletter_id,
+        section_id=section.Id,
+        source_type=event.source_type,
+        source_id=event.source_id,
+        source_url=event.url,
+        event_start=event.event_start,
+        event_end=event.event_end,
+        location=event.location,
+        final_headline=event.title,
+        final_body=calendar_event_service.build_event_body(event),
+    )
+    return item
+
+
 @router.patch("/{newsletter_id}/items/{item_id}", response_model=NewsletterItemResponse)
 async def update_item(
     newsletter_id: str,
@@ -114,6 +200,17 @@ async def update_item(
     if not item:
         raise HTTPException(status_code=404, detail="Item not found")
     return item
+
+
+@router.delete("/{newsletter_id}/external-items/{item_id}", status_code=204)
+async def remove_external_item(
+    newsletter_id: str,
+    item_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """Remove an imported external item from a newsletter."""
+    if not await newsletter_service.remove_external_item(db, item_id):
+        raise HTTPException(status_code=404, detail="External item not found")
 
 
 @router.delete("/{newsletter_id}/items/{item_id}", status_code=204)
@@ -170,13 +267,15 @@ async def export_newsletter(newsletter_id: str, db: AsyncSession = Depends(get_d
         .order_by(NewsletterSection.Display_Order)
     )
     sections = list(sections_result.scalars().all())
-    section_map = {s.Id: s for s in sections}
 
     # Organize items by section
     export_sections = []
     for section in sections:
         section_items = sorted(
-            [it for it in newsletter.Items if it.Section_Id == section.Id],
+            [
+                *[it for it in newsletter.Items if it.Section_Id == section.Id],
+                *[it for it in newsletter.External_Items if it.Section_Id == section.Id],
+            ],
             key=lambda it: it.Position,
         )
         if section_items:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -24,6 +24,11 @@ class Settings(BaseSettings):
     # App
     upload_dir: str = "./uploads"
     cors_origins: list[str] = ["http://localhost:5173"]
+    calendar_source_url: str = (
+        "https://www.qatrumba.com/events-calendar/ui/uidaho/vandals/"
+        "vandal/event/events/calendar/moscow/idaho/id/university-of-idaho"
+    )
+    calendar_request_timeout_seconds: float = 10.0
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -18,6 +18,7 @@ Models included:
     EditVersion              -- Immutable edit snapshots (original, AI, final)
     Newsletter               -- A single newsletter edition (TDR or My UI)
     NewsletterItem           -- A placed submission within a newsletter
+    NewsletterExternalItem   -- Imported external item placed within a newsletter
     NewsletterSection        -- Section catalog (Announcements, Kudos, etc.)
     StyleRule                -- Writing-style rules for the AI pipeline
     ScheduleConfig           -- Publication cadence and deadline rules
@@ -27,7 +28,7 @@ Models included:
 from app.models.allowed_value import AllowedValue
 from app.models.blackout_date import BlackoutDate
 from app.models.edit_history import EditVersion
-from app.models.newsletter import Newsletter, NewsletterItem
+from app.models.newsletter import Newsletter, NewsletterExternalItem, NewsletterItem
 from app.models.schedule_config import ScheduleConfig
 from app.models.section import NewsletterSection
 from app.models.style_rule import StyleRule
@@ -38,6 +39,7 @@ __all__ = [
     "BlackoutDate",
     "EditVersion",
     "Newsletter",
+    "NewsletterExternalItem",
     "NewsletterItem",
     "NewsletterSection",
     "ScheduleConfig",

--- a/backend/app/models/newsletter.py
+++ b/backend/app/models/newsletter.py
@@ -54,6 +54,9 @@ class Newsletter(Base):
     Items: Mapped[list["NewsletterItem"]] = relationship(
         back_populates="Newsletter_Rel", cascade="all, delete-orphan", lazy="selectin"
     )
+    External_Items: Mapped[list["NewsletterExternalItem"]] = relationship(
+        back_populates="Newsletter_Rel", cascade="all, delete-orphan", lazy="selectin"
+    )
 
 
 class NewsletterItem(Base):
@@ -82,4 +85,34 @@ class NewsletterItem(Base):
         back_populates="Items", lazy="selectin"
     )
     Submission_Rel: Mapped["Submission"] = relationship(lazy="selectin")
+    Section_Rel: Mapped["NewsletterSection"] = relationship(lazy="selectin")
+
+
+class NewsletterExternalItem(Base):
+    """A placed non-submission item imported from an external source such as a calendar."""
+
+    __tablename__ = "newsletter_external_items"
+
+    Id: Mapped[str] = mapped_column(
+        sa.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    Newsletter_Id: Mapped[str] = mapped_column(
+        sa.String(36), sa.ForeignKey("newsletters.Id"), nullable=False
+    )
+    Section_Id: Mapped[str] = mapped_column(
+        sa.String(36), sa.ForeignKey("newsletter_sections.Id"), nullable=False
+    )
+    Source_Type: Mapped[str] = mapped_column(sa.String(50), nullable=False)
+    Source_Id: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    Source_Url: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    Event_Start: Mapped[datetime | None] = mapped_column(sa.DateTime, nullable=True)
+    Event_End: Mapped[datetime | None] = mapped_column(sa.DateTime, nullable=True)
+    Location: Mapped[str | None] = mapped_column(sa.String(255), nullable=True)
+    Position: Mapped[int] = mapped_column(sa.Integer, nullable=False, default=0)
+    Final_Headline: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    Final_Body: Mapped[str] = mapped_column(sa.Text, nullable=False)
+
+    Newsletter_Rel: Mapped["Newsletter"] = relationship(
+        back_populates="External_Items", lazy="selectin"
+    )
     Section_Rel: Mapped["NewsletterSection"] = relationship(lazy="selectin")

--- a/backend/app/schemas/newsletter.py
+++ b/backend/app/schemas/newsletter.py
@@ -69,6 +69,35 @@ class NewsletterItemResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class NewsletterExternalItemCreate(BaseModel):
+    Section_Id: str
+    Source_Type: str = Field(..., min_length=1, max_length=50)
+    Source_Id: str = Field(..., min_length=1, max_length=255)
+    Source_Url: str | None = None
+    Event_Start: datetime | None = None
+    Event_End: datetime | None = None
+    Location: str | None = None
+    Final_Headline: str = Field(..., min_length=1)
+    Final_Body: str = Field(..., min_length=1)
+
+
+class NewsletterExternalItemResponse(BaseModel):
+    Id: str
+    Newsletter_Id: str
+    Section_Id: str
+    Source_Type: str
+    Source_Id: str
+    Source_Url: str | None
+    Event_Start: datetime | None
+    Event_End: datetime | None
+    Location: str | None
+    Position: int
+    Final_Headline: str
+    Final_Body: str
+
+    model_config = {"from_attributes": True}
+
+
 class NewsletterDetailResponse(BaseModel):
     Id: str
     Newsletter_Type: str
@@ -77,6 +106,7 @@ class NewsletterDetailResponse(BaseModel):
     Created_At: datetime
     Updated_At: datetime
     Items: list[NewsletterItemResponse]
+    External_Items: list[NewsletterExternalItemResponse]
 
     model_config = {"from_attributes": True}
 
@@ -136,3 +166,25 @@ class AssembleRequest(BaseModel):
     """Request to auto-populate a newsletter from approved submissions."""
     Newsletter_Type: str = Field(..., pattern=r"^(tdr|myui)$")
     Publish_Date: date
+
+
+class CalendarEventCandidateResponse(BaseModel):
+    Source_Id: str
+    Source_Type: str
+    Url: str | None
+    Title: str
+    Description: str
+    Location: str | None
+    Event_Start: datetime | None
+    Event_End: datetime | None
+    Selected: bool
+
+
+class CalendarEventImportRequest(BaseModel):
+    Source_Id: str = Field(..., min_length=1, max_length=255)
+    Url: str | None = None
+    Title: str = Field(..., min_length=1)
+    Description: str = Field(..., min_length=1)
+    Location: str | None = None
+    Event_Start: datetime | None = None
+    Event_End: datetime | None = None

--- a/backend/app/services/calendar_event_service.py
+++ b/backend/app/services/calendar_event_service.py
@@ -1,0 +1,235 @@
+"""Fetch and normalize external calendar events for newsletter selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from html import unescape
+import re
+from typing import Iterable
+from urllib.parse import urljoin
+
+import httpx
+
+from app.config import settings
+
+_EVENT_BLOCK_RE = re.compile(
+    r"<h2[^>]*>(?P<title>.*?)</h2>(?P<body>.*?)(?=<h2[^>]*>|$)",
+    re.IGNORECASE | re.DOTALL,
+)
+_TAG_RE = re.compile(r"<[^>]+>")
+_LINK_RE = re.compile(r'<a[^>]+href="(?P<href>[^"]+)"[^>]*>', re.IGNORECASE)
+_WHITESPACE_RE = re.compile(r"\s+")
+_DATE_RE = re.compile(
+    r"(?P<start>(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), "
+    r"[A-Z][a-z]+ \d{1,2}, \d{4}(?:, \d{1,2}:\d{2} [AP]M)?)"
+    r"(?:\s*[–-]\s*(?P<end>(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), "
+    r"[A-Z][a-z]+ \d{1,2}, \d{4}(?:, \d{1,2}:\d{2} [AP]M)?|\d{1,2}:\d{2} [AP]M))?",
+)
+
+
+@dataclass(slots=True)
+class CalendarEvent:
+    source_id: str
+    source_type: str
+    url: str | None
+    title: str
+    description: str
+    location: str | None
+    event_start: datetime | None
+    event_end: datetime | None
+
+
+async def fetch_calendar_events(
+    publish_date: date,
+    newsletter_type: str,
+    selected_source_ids: Iterable[str] = (),
+) -> list[dict]:
+    """Fetch upcoming events for a given newsletter date."""
+    source_url = settings.calendar_source_url
+    timeout = settings.calendar_request_timeout_seconds
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+        response = await client.get(source_url)
+        response.raise_for_status()
+
+    selected = set(selected_source_ids)
+    events = parse_trumba_hcalendar(response.text, source_url)
+    end_date = publish_date + timedelta(days=7)
+    filtered = [
+        {
+            "Source_Id": event.source_id,
+            "Source_Type": event.source_type,
+            "Url": event.url,
+            "Title": event.title,
+            "Description": event.description,
+            "Location": event.location,
+            "Event_Start": event.event_start,
+            "Event_End": event.event_end,
+            "Selected": event.source_id in selected,
+        }
+        for event in events
+        if _include_event(event, publish_date, end_date, newsletter_type)
+    ]
+    filtered.sort(
+        key=lambda event: (
+            event["Event_Start"] or datetime.combine(publish_date, time.min),
+            event["Title"].lower(),
+        )
+    )
+    return filtered
+
+
+def parse_trumba_hcalendar(html_text: str, source_url: str) -> list[CalendarEvent]:
+    """Parse the Trumba hCalendar page into normalized events."""
+    events: list[CalendarEvent] = []
+    for match in _EVENT_BLOCK_RE.finditer(html_text):
+        title = _clean_html(match.group("title"))
+        if not title:
+            continue
+        if title.lower() == "contact us":
+            break
+
+        block_html = match.group("body")
+        block_text = _clean_html(block_html)
+        if not _DATE_RE.search(block_text):
+            continue
+
+        start, end = _extract_datetimes(block_text)
+        description = _extract_description(block_text)
+        location = _extract_location(block_text)
+        url = _extract_event_url(match.group("title"), block_html, source_url)
+        source_id = _build_source_id(url, title, start)
+        events.append(
+            CalendarEvent(
+                source_id=source_id,
+                source_type="calendar_event",
+                url=url,
+                title=title,
+                description=description,
+                location=location,
+                event_start=start,
+                event_end=end,
+            )
+        )
+    return events
+
+
+def build_event_body(event: CalendarEvent) -> str:
+    """Build the builder/export body text for an imported calendar event."""
+    parts = [event.description.strip()]
+    details = []
+    if event.event_start:
+        if event.event_end and event.event_end.date() == event.event_start.date():
+            details.append(
+                f"{event.event_start.strftime('%A, %B %-d, %Y, %-I:%M %p')} - "
+                f"{event.event_end.strftime('%-I:%M %p')}"
+            )
+        else:
+            details.append(event.event_start.strftime("%A, %B %-d, %Y, %-I:%M %p"))
+    if event.location:
+        details.append(event.location)
+    if details:
+        parts.append(". ".join(details) + ".")
+    if event.url:
+        parts.append(f'<a href="{event.url}">Event details</a>.')
+    return " ".join(part for part in parts if part).strip()
+
+
+def _include_event(
+    event: CalendarEvent,
+    publish_date: date,
+    end_date: date,
+    newsletter_type: str,
+) -> bool:
+    if event.event_start is None:
+        return False
+    event_date = event.event_start.date()
+    if newsletter_type == "tdr":
+        return publish_date <= event_date <= end_date
+    return publish_date <= event_date <= end_date
+
+
+def _extract_datetimes(text: str) -> tuple[datetime | None, datetime | None]:
+    matches = list(_DATE_RE.finditer(text))
+    if not matches:
+        return None, None
+    match = matches[-1]
+    start_text = match.group("start")
+    end_text = match.group("end")
+    start = _parse_datetime(start_text)
+    end = _parse_end_datetime(end_text, start) if end_text else None
+    return start, end
+
+
+def _extract_description(text: str) -> str:
+    match = _DATE_RE.search(text)
+    if not match:
+        return text.strip()
+    description = text[:match.start()].strip(" .")
+    if "For more info visit" in description:
+        description = description.split("For more info visit", 1)[0].strip(" .")
+    return description or "Imported from the University of Idaho events calendar."
+
+
+def _extract_location(text: str) -> str | None:
+    prefix = text
+    match = _DATE_RE.search(text)
+    if match:
+        prefix = text[:match.start()]
+
+    for label in ("University Location:", "Location:", "Participate Online:"):
+        if label in prefix:
+            value = prefix.rsplit(label, 1)[-1].strip(" .")
+            if value:
+                return value
+
+    sentences = [segment.strip(" .") for segment in prefix.split(".") if segment.strip()]
+    if len(sentences) >= 2:
+        candidate = sentences[-1]
+        if len(candidate) <= 255:
+            return candidate
+    return None
+
+
+def _extract_event_url(title_html: str, block_html: str, source_url: str) -> str | None:
+    for html_fragment in (block_html, title_html):
+        match = _LINK_RE.search(html_fragment)
+        if match:
+            return urljoin(source_url, unescape(match.group("href")))
+    return None
+
+
+def _build_source_id(url: str | None, title: str, start: datetime | None) -> str:
+    if url:
+        return url
+    parts = [title.strip().lower()]
+    if start:
+        parts.append(start.isoformat())
+    return "::".join(parts)
+
+
+def _clean_html(value: str) -> str:
+    text = _TAG_RE.sub(" ", value)
+    text = unescape(text)
+    return _WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _parse_datetime(value: str) -> datetime | None:
+    for fmt in ("%A, %B %d, %Y, %I:%M %p", "%A, %B %d, %Y"):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _parse_end_datetime(value: str, start: datetime | None) -> datetime | None:
+    if start is None:
+        return _parse_datetime(value)
+    for fmt in ("%I:%M %p",):
+        try:
+            parsed = datetime.strptime(value, fmt)
+            return datetime.combine(start.date(), parsed.time())
+        except ValueError:
+            continue
+    return _parse_datetime(value)

--- a/backend/app/services/newsletter_service.py
+++ b/backend/app/services/newsletter_service.py
@@ -6,10 +6,9 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models.newsletter import Newsletter, NewsletterItem
+from app.models.newsletter import Newsletter, NewsletterExternalItem, NewsletterItem
 from app.models.section import NewsletterSection
 from app.models.submission import Submission
-from app.models.edit_history import EditVersion
 
 
 async def create_newsletter(
@@ -33,7 +32,10 @@ async def get_newsletter(db: AsyncSession, newsletter_id: str) -> Newsletter | N
     result = await db.execute(
         sa.select(Newsletter)
         .where(Newsletter.Id == newsletter_id)
-        .options(selectinload(Newsletter.Items))
+        .options(
+            selectinload(Newsletter.Items),
+            selectinload(Newsletter.External_Items),
+        )
     )
     return result.scalar_one_or_none()
 
@@ -44,7 +46,10 @@ async def list_newsletters(
     status: str | None = None,
     limit: int = 20,
 ) -> list[Newsletter]:
-    query = sa.select(Newsletter).options(selectinload(Newsletter.Items))
+    query = sa.select(Newsletter).options(
+        selectinload(Newsletter.Items),
+        selectinload(Newsletter.External_Items),
+    )
     if newsletter_type:
         query = query.where(Newsletter.Newsletter_Type == newsletter_type)
     if status:
@@ -103,6 +108,54 @@ async def add_item(
     return item
 
 
+async def add_external_item(
+    db: AsyncSession,
+    newsletter_id: str,
+    section_id: str,
+    source_type: str,
+    source_id: str,
+    source_url: str | None,
+    event_start,
+    event_end,
+    location: str | None,
+    final_headline: str,
+    final_body: str,
+) -> NewsletterExternalItem:
+    item_max_result = await db.execute(
+        sa.select(sa.func.max(NewsletterItem.Position)).where(
+            NewsletterItem.Newsletter_Id == newsletter_id,
+            NewsletterItem.Section_Id == section_id,
+        )
+    )
+    external_max_result = await db.execute(
+        sa.select(sa.func.max(NewsletterExternalItem.Position)).where(
+            NewsletterExternalItem.Newsletter_Id == newsletter_id,
+            NewsletterExternalItem.Section_Id == section_id,
+        )
+    )
+    max_position = max(
+        item_max_result.scalar_one_or_none() or -1,
+        external_max_result.scalar_one_or_none() or -1,
+    )
+    item = NewsletterExternalItem(
+        Newsletter_Id=newsletter_id,
+        Section_Id=section_id,
+        Source_Type=source_type,
+        Source_Id=source_id,
+        Source_Url=source_url,
+        Event_Start=event_start,
+        Event_End=event_end,
+        Location=location,
+        Position=max_position + 1,
+        Final_Headline=final_headline,
+        Final_Body=final_body,
+    )
+    db.add(item)
+    await db.commit()
+    await db.refresh(item)
+    return item
+
+
 async def update_item(
     db: AsyncSession,
     item_id: str,
@@ -125,6 +178,18 @@ async def update_item(
 async def remove_item(db: AsyncSession, item_id: str) -> bool:
     result = await db.execute(
         sa.select(NewsletterItem).where(NewsletterItem.Id == item_id)
+    )
+    item = result.scalar_one_or_none()
+    if not item:
+        return False
+    await db.delete(item)
+    await db.commit()
+    return True
+
+
+async def remove_external_item(db: AsyncSession, item_id: str) -> bool:
+    result = await db.execute(
+        sa.select(NewsletterExternalItem).where(NewsletterExternalItem.Id == item_id)
     )
     item = result.scalar_one_or_none()
     if not item:
@@ -172,7 +237,10 @@ async def assemble_newsletter(
             Newsletter.Newsletter_Type == newsletter_type,
             Newsletter.Publish_Date == publish_date,
         )
-        .options(selectinload(Newsletter.Items))
+        .options(
+            selectinload(Newsletter.Items),
+            selectinload(Newsletter.External_Items),
+        )
     )
     newsletter = result.scalar_one_or_none()
 
@@ -268,6 +336,11 @@ def _get_category_section_map(newsletter_type: str) -> dict[str, str]:
             "job_opportunity": "help-wanted",
             "in_memoriam": "news-and-updates",
         }
+
+
+def get_calendar_section_slug(newsletter_type: str) -> str:
+    """Return the section slug used for imported calendar events."""
+    return "todays-events" if newsletter_type == "tdr" else "weekly-events"
 
 
 def _get_best_text(submission: Submission) -> tuple[str, str]:

--- a/backend/tests/test_newsletters.py
+++ b/backend/tests/test_newsletters.py
@@ -1,8 +1,13 @@
 """Tests for Newsletter CRUD and assembly endpoints."""
 
+from datetime import datetime
+
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.section import NewsletterSection
+from app.services import calendar_event_service
 from tests.conftest import make_newsletter_data, make_submission_data
 
 
@@ -105,3 +110,105 @@ class TestNewsletterItems:
 
         resp = await client.delete(f"/api/v1/newsletters/{nl_id}/items/{item_id}")
         assert resp.status_code == 204
+
+
+class TestCalendarEventParsing:
+    def test_parse_trumba_hcalendar(self):
+        html = """
+        <html><body>
+          <h2><a href="/event-1">Accessibility Workshop</a></h2>
+          <p>Learn how to build accessible documents. University Location: IRIC 305.
+          Thursday, March 19, 2026, 12:00 PM - 1:00 PM. For more info visit
+          <a href="https://www.uidaho.edu/event-1">event page</a>.</p>
+          <h2>Contact Us</h2>
+        </body></html>
+        """
+
+        events = calendar_event_service.parse_trumba_hcalendar(
+            html,
+            "https://calendar.example.test",
+        )
+
+        assert len(events) == 1
+        event = events[0]
+        assert event.title == "Accessibility Workshop"
+        assert event.location == "IRIC 305"
+        assert event.url == "https://www.uidaho.edu/event-1"
+        assert event.event_start == datetime(2026, 3, 19, 12, 0)
+
+
+@pytest.mark.asyncio
+class TestCalendarEventEndpoints:
+    async def test_list_calendar_event_candidates(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        create_resp = await client.post("/api/v1/newsletters", json=make_newsletter_data())
+        nl_id = create_resp.json()["Id"]
+
+        async def fake_fetch_calendar_events(*args, **kwargs):
+            return [{
+                "Source_Id": "event-1",
+                "Source_Type": "calendar_event",
+                "Url": "https://example.com/event-1",
+                "Title": "Accessibility Workshop",
+                "Description": "Learn accessible PDF output.",
+                "Location": "IRIC 305",
+                "Event_Start": datetime(2026, 3, 19, 12, 0),
+                "Event_End": datetime(2026, 3, 19, 13, 0),
+                "Selected": False,
+            }]
+
+        monkeypatch.setattr(
+            calendar_event_service,
+            "fetch_calendar_events",
+            fake_fetch_calendar_events,
+        )
+
+        resp = await client.get(f"/api/v1/newsletters/{nl_id}/calendar-events")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 1
+        assert body[0]["Source_Id"] == "event-1"
+
+    async def test_import_calendar_event(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+    ):
+        db.add(
+            NewsletterSection(
+                Newsletter_Type="tdr",
+                Name="Today's Events",
+                Slug="todays-events",
+                Display_Order=4,
+                Is_Active=True,
+            )
+        )
+        await db.commit()
+
+        create_resp = await client.post("/api/v1/newsletters", json=make_newsletter_data())
+        nl_id = create_resp.json()["Id"]
+
+        resp = await client.post(
+            f"/api/v1/newsletters/{nl_id}/calendar-events",
+            json={
+                "Source_Id": "event-1",
+                "Url": "https://example.com/event-1",
+                "Title": "Accessibility Workshop",
+                "Description": "Learn accessible PDF output.",
+                "Location": "IRIC 305",
+                "Event_Start": "2026-03-19T12:00:00",
+                "Event_End": "2026-03-19T13:00:00",
+            },
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["Source_Type"] == "calendar_event"
+        assert body["Final_Headline"] == "Accessibility Workshop"
+
+        detail_resp = await client.get(f"/api/v1/newsletters/{nl_id}")
+        assert detail_resp.status_code == 200
+        detail = detail_resp.json()
+        assert len(detail["External_Items"]) == 1

--- a/frontend/src/api/newsletters.ts
+++ b/frontend/src/api/newsletters.ts
@@ -21,8 +21,36 @@ export interface NewsletterItemResponse {
   Run_Number: number;
 }
 
+export interface NewsletterExternalItemResponse {
+  Id: string;
+  Newsletter_Id: string;
+  Section_Id: string;
+  Source_Type: string;
+  Source_Id: string;
+  Source_Url: string | null;
+  Event_Start: string | null;
+  Event_End: string | null;
+  Location: string | null;
+  Position: number;
+  Final_Headline: string;
+  Final_Body: string;
+}
+
+export interface CalendarEventCandidate {
+  Source_Id: string;
+  Source_Type: string;
+  Url: string | null;
+  Title: string;
+  Description: string;
+  Location: string | null;
+  Event_Start: string | null;
+  Event_End: string | null;
+  Selected: boolean;
+}
+
 export interface NewsletterDetailResponse extends NewsletterResponse {
   Items: NewsletterItemResponse[];
+  External_Items: NewsletterExternalItemResponse[];
 }
 
 export async function listNewsletters(params?: {
@@ -102,11 +130,42 @@ export async function updateNewsletterItem(
   });
 }
 
+export async function listCalendarEvents(
+  newsletterId: string,
+): Promise<CalendarEventCandidate[]> {
+  return apiFetch<CalendarEventCandidate[]>(`/newsletters/${newsletterId}/calendar-events`);
+}
+
+export async function addCalendarEvent(
+  newsletterId: string,
+  data: {
+    Source_Id: string;
+    Url?: string | null;
+    Title: string;
+    Description: string;
+    Location?: string | null;
+    Event_Start?: string | null;
+    Event_End?: string | null;
+  },
+): Promise<NewsletterExternalItemResponse> {
+  return apiFetch<NewsletterExternalItemResponse>(`/newsletters/${newsletterId}/calendar-events`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
 export async function removeNewsletterItem(
   newsletterId: string,
   itemId: string,
 ): Promise<void> {
   await apiFetch(`/newsletters/${newsletterId}/items/${itemId}`, { method: 'DELETE' });
+}
+
+export async function removeNewsletterExternalItem(
+  newsletterId: string,
+  itemId: string,
+): Promise<void> {
+  await apiFetch(`/newsletters/${newsletterId}/external-items/${itemId}`, { method: 'DELETE' });
 }
 
 export async function reorderNewsletterItems(

--- a/frontend/src/pages/BuilderPage.tsx
+++ b/frontend/src/pages/BuilderPage.tsx
@@ -1,16 +1,39 @@
 import { useEffect, useState } from 'react';
 import {
+  addCalendarEvent,
   listNewsletters,
+  listCalendarEvents,
   getNewsletter,
   assembleNewsletter,
   updateNewsletterStatus,
+  removeNewsletterExternalItem,
   removeNewsletterItem,
   reorderNewsletterItems,
   getExportUrl,
   listSections,
 } from '../api/newsletters';
-import type { NewsletterDetailResponse, NewsletterItemResponse } from '../api/newsletters';
+import type {
+  CalendarEventCandidate,
+  NewsletterDetailResponse,
+} from '../api/newsletters';
 import type { NewsletterSection } from '../types/newsletter';
+
+interface BuilderSectionItemBase {
+  Id: string;
+  Section_Id: string;
+  Position: number;
+  Final_Headline: string;
+  Final_Body: string;
+}
+
+type BuilderSectionItem =
+  | (BuilderSectionItemBase & { Kind: 'submission'; Run_Number: number })
+  | (BuilderSectionItemBase & {
+    Kind: 'calendar_event';
+    Source_Url: string | null;
+    Location: string | null;
+    Event_Start: string | null;
+  });
 
 export default function BuilderPage() {
   const [newsletterType, setNewsletterType] = useState<'tdr' | 'myui'>('tdr');
@@ -20,14 +43,27 @@ export default function BuilderPage() {
   const [newsletter, setNewsletter] = useState<NewsletterDetailResponse | null>(null);
   const [newsletters, setNewsletters] = useState<NewsletterDetailResponse[]>([]);
   const [sections, setSections] = useState<NewsletterSection[]>([]);
+  const [calendarEvents, setCalendarEvents] = useState<CalendarEventCandidate[]>([]);
+  const [calendarLoading, setCalendarLoading] = useState(false);
+  const [calendarError, setCalendarError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
+  const newsletterId = newsletter?.Id;
 
   useEffect(() => {
     loadSections();
     loadNewsletters();
   }, [newsletterType]);
+
+  useEffect(() => {
+    if (!newsletterId) {
+      setCalendarEvents([]);
+      setCalendarError(null);
+      return;
+    }
+    loadCalendarEvents(newsletterId);
+  }, [newsletterId]);
 
   const loadSections = async () => {
     try {
@@ -44,6 +80,19 @@ export default function BuilderPage() {
       setNewsletters(list as NewsletterDetailResponse[]);
     } catch (err) {
       console.error('Failed to load newsletters:', err);
+    }
+  };
+
+  const loadCalendarEvents = async (newsletterId: string) => {
+    setCalendarLoading(true);
+    setCalendarError(null);
+    try {
+      const events = await listCalendarEvents(newsletterId);
+      setCalendarEvents(events);
+    } catch (err) {
+      setCalendarError(err instanceof Error ? err.message : 'Failed to load calendar events');
+    } finally {
+      setCalendarLoading(false);
     }
   };
 
@@ -87,6 +136,40 @@ export default function BuilderPage() {
       showToast('Item removed');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to remove');
+    }
+  };
+
+  const handleRemoveExternalItem = async (itemId: string) => {
+    if (!newsletter) return;
+    try {
+      await removeNewsletterExternalItem(newsletter.Id, itemId);
+      const nl = await getNewsletter(newsletter.Id);
+      setNewsletter(nl);
+      await loadCalendarEvents(newsletter.Id);
+      showToast('Calendar event removed');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to remove calendar event');
+    }
+  };
+
+  const handleAddCalendarEvent = async (event: CalendarEventCandidate) => {
+    if (!newsletter) return;
+    try {
+      await addCalendarEvent(newsletter.Id, {
+        Source_Id: event.Source_Id,
+        Url: event.Url,
+        Title: event.Title,
+        Description: event.Description,
+        Location: event.Location,
+        Event_Start: event.Event_Start,
+        Event_End: event.Event_End,
+      });
+      const nl = await getNewsletter(newsletter.Id);
+      setNewsletter(nl);
+      await loadCalendarEvents(newsletter.Id);
+      showToast('Calendar event added');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add calendar event');
     }
   };
 
@@ -138,15 +221,28 @@ export default function BuilderPage() {
   };
 
   // Group items by section
-  const sectionMap = new Map<string, NewsletterSection>();
-  sections.forEach((s) => sectionMap.set(s.Id, s));
-
-  const itemsBySection = new Map<string, NewsletterItemResponse[]>();
+  const itemsBySection = new Map<string, BuilderSectionItem[]>();
   if (newsletter) {
+    const submissionItems: BuilderSectionItem[] = newsletter.Items.map((item) => ({
+      ...item,
+      Kind: 'submission',
+    }));
+    const externalItems: BuilderSectionItem[] = newsletter.External_Items.map((item) => ({
+      Id: item.Id,
+      Section_Id: item.Section_Id,
+      Position: item.Position,
+      Final_Headline: item.Final_Headline,
+      Final_Body: item.Final_Body,
+      Kind: 'calendar_event',
+      Source_Url: item.Source_Url,
+      Location: item.Location,
+      Event_Start: item.Event_Start,
+    }));
+    const allItems = [...submissionItems, ...externalItems];
     for (const section of sections) {
-      const items = newsletter.Items
+      const items = allItems
         .filter((i) => i.Section_Id === section.Id)
-        .sort((a, b) => a.Position - b.Position);
+        .sort((a, b) => a.Position - b.Position || a.Final_Headline.localeCompare(b.Final_Headline));
       if (items.length > 0) {
         itemsBySection.set(section.Id, items);
       }
@@ -248,6 +344,90 @@ export default function BuilderPage() {
             </div>
           ) : (
             <div className="space-y-4">
+              <div className="bg-white rounded-lg shadow p-4">
+                <div className="flex items-center justify-between gap-4 mb-3">
+                  <div>
+                    <h3 className="text-sm font-semibold text-gray-900">Calendar Events</h3>
+                      <p className="text-xs text-gray-500">
+                        Import upcoming U of I calendar events into the{' '}
+                        {newsletterType === 'tdr' ? "Today's Events" : 'Weekly Events'} section.
+                      </p>
+                    </div>
+                  <button
+                    onClick={() => loadCalendarEvents(newsletter.Id)}
+                    disabled={calendarLoading}
+                    className="px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                  >
+                    {calendarLoading ? 'Refreshing...' : 'Refresh Events'}
+                  </button>
+                </div>
+                {calendarError && (
+                  <div className="mb-3 rounded-md bg-red-50 border border-red-200 px-3 py-2 text-xs text-red-700">
+                    {calendarError}
+                  </div>
+                )}
+                {calendarEvents.length === 0 ? (
+                  <div className="rounded-md border border-dashed border-gray-200 px-4 py-6 text-center text-xs text-gray-400">
+                    {calendarLoading ? 'Loading candidate events...' : 'No candidate events found for this issue window.'}
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
+                    {calendarEvents.map((event) => (
+                      <div
+                        key={event.Source_Id}
+                        className={`rounded-lg border p-3 ${
+                          event.Selected ? 'border-green-200 bg-green-50' : 'border-gray-200 bg-white'
+                        }`}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium text-gray-900">{event.Title}</p>
+                            <p className="text-xs text-gray-500 mt-1">
+                              {event.Event_Start
+                                ? new Date(event.Event_Start).toLocaleString('en-US', {
+                                  weekday: 'short',
+                                  month: 'short',
+                                  day: 'numeric',
+                                  hour: 'numeric',
+                                  minute: '2-digit',
+                                })
+                                : 'Date unavailable'}
+                            </p>
+                            {event.Location && (
+                              <p className="text-xs text-gray-500 mt-1">{event.Location}</p>
+                            )}
+                          </div>
+                          <button
+                            onClick={() => handleAddCalendarEvent(event)}
+                            disabled={event.Selected}
+                            className={`px-3 py-1.5 text-xs font-medium rounded-md ${
+                              event.Selected
+                                ? 'bg-green-100 text-green-700 cursor-default'
+                                : 'bg-ui-clearwater-600 text-white hover:bg-ui-clearwater-700'
+                            }`}
+                          >
+                            {event.Selected ? 'Added' : 'Add'}
+                          </button>
+                        </div>
+                        <p className="text-xs text-gray-600 mt-2 line-clamp-3">
+                          {event.Description}
+                        </p>
+                        {event.Url && (
+                          <a
+                            href={event.Url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-block mt-2 text-xs text-ui-clearwater-700 hover:text-ui-clearwater-800"
+                          >
+                            View source
+                          </a>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
               {/* Newsletter header */}
               <div className="bg-white rounded-lg shadow p-4 flex items-center justify-between">
                 <div>
@@ -301,37 +481,64 @@ export default function BuilderPage() {
                           >
                             <div className="flex items-start justify-between">
                               <div className="flex-1 min-w-0">
-                                <p className="text-sm font-medium text-gray-900">
-                                  {item.Final_Headline}
-                                </p>
+                                <div className="flex items-center gap-2">
+                                  <p className="text-sm font-medium text-gray-900">
+                                    {item.Final_Headline}
+                                  </p>
+                                  {item.Kind === 'calendar_event' && (
+                                    <span className="inline-flex items-center rounded-full bg-ui-clearwater-100 px-2 py-0.5 text-[11px] font-medium text-ui-clearwater-800">
+                                      Calendar
+                                    </span>
+                                  )}
+                                </div>
                                 <p className="text-xs text-gray-600 mt-1 line-clamp-2">
                                   {item.Final_Body.replace(/<[^>]+>/g, '')}
                                 </p>
-                                {item.Run_Number > 1 && (
+                                {item.Kind === 'submission' && item.Run_Number > 1 && (
                                   <span className="text-xs text-ui-gold-600 mt-1 inline-block">
                                     Run #{item.Run_Number}
                                   </span>
                                 )}
+                                {item.Kind === 'calendar_event' && item.Event_Start && (
+                                  <p className="text-xs text-gray-400 mt-1">
+                                    {new Date(item.Event_Start).toLocaleString('en-US', {
+                                      weekday: 'short',
+                                      month: 'short',
+                                      day: 'numeric',
+                                      hour: 'numeric',
+                                      minute: '2-digit',
+                                    })}
+                                    {item.Location ? ` • ${item.Location}` : ''}
+                                  </p>
+                                )}
                               </div>
                               <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity ml-2">
+                                {item.Kind === 'submission' && (
+                                  <>
+                                    <button
+                                      onClick={() => handleMoveItem(item.Id, 'up')}
+                                      disabled={idx === 0}
+                                      className="p-1 text-gray-400 hover:text-gray-700 disabled:opacity-30"
+                                      title="Move up"
+                                    >
+                                      &#x25B2;
+                                    </button>
+                                    <button
+                                      onClick={() => handleMoveItem(item.Id, 'down')}
+                                      disabled={idx === items.length - 1}
+                                      className="p-1 text-gray-400 hover:text-gray-700 disabled:opacity-30"
+                                      title="Move down"
+                                    >
+                                      &#x25BC;
+                                    </button>
+                                  </>
+                                )}
                                 <button
-                                  onClick={() => handleMoveItem(item.Id, 'up')}
-                                  disabled={idx === 0}
-                                  className="p-1 text-gray-400 hover:text-gray-700 disabled:opacity-30"
-                                  title="Move up"
-                                >
-                                  &#x25B2;
-                                </button>
-                                <button
-                                  onClick={() => handleMoveItem(item.Id, 'down')}
-                                  disabled={idx === items.length - 1}
-                                  className="p-1 text-gray-400 hover:text-gray-700 disabled:opacity-30"
-                                  title="Move down"
-                                >
-                                  &#x25BC;
-                                </button>
-                                <button
-                                  onClick={() => handleRemoveItem(item.Id)}
+                                  onClick={() => (
+                                    item.Kind === 'submission'
+                                      ? handleRemoveItem(item.Id)
+                                      : handleRemoveExternalItem(item.Id)
+                                  )}
                                   className="p-1 text-red-400 hover:text-red-600"
                                   title="Remove"
                                 >

--- a/frontend/src/types/newsletter.ts
+++ b/frontend/src/types/newsletter.ts
@@ -29,3 +29,18 @@ export interface NewsletterItem {
   Final_Body: string;
   Run_Number: number;
 }
+
+export interface NewsletterExternalItem {
+  Id: string;
+  Newsletter_Id: string;
+  Section_Id: string;
+  Source_Type: string;
+  Source_Id: string;
+  Source_Url: string | null;
+  Event_Start: string | null;
+  Event_End: string | null;
+  Location: string | null;
+  Position: number;
+  Final_Headline: string;
+  Final_Body: string;
+}


### PR DESCRIPTION
## Summary
- fetch upcoming University of Idaho events from the public calendar source
- surface calendar candidates in the newsletter builder and allow add/remove per issue
- persist imported external items so selected events appear in the newsletter export

## Testing
- ./backend/.venv/bin/pytest -q
- cd frontend && npm run build
- cd frontend && npm run lint  # same 4 pre-existing warnings only

## Dev
- Deployed for testing at https://ucmnews-dev.insight.uidaho.edu

Closes #34