### PR TITLE
Add recurring submission scheduling

### DIFF
--- a/backend/alembic/versions/c7d6f3416b9e_add_recurrence_fields_to_submission_.py
+++ b/backend/alembic/versions/c7d6f3416b9e_add_recurrence_fields_to_submission_.py
@@ -1,0 +1,73 @@
+"""add_recurrence_fields_to_submission_schedule_requests
+
+Revision ID: c7d6f3416b9e
+Revises: bf1f70f4c8d9
+Create Date: 2026-03-20 09:45:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c7d6f3416b9e"
+down_revision: Union[str, Sequence[str], None] = "bf1f70f4c8d9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("submission_schedule_requests", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "Is_Flexible",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+        batch_op.add_column(
+            sa.Column("Flexible_Deadline", sa.Text(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column(
+                "Recurrence_Type",
+                sa.String(length=50),
+                nullable=False,
+                server_default="once",
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "Recurrence_Interval",
+                sa.Integer(),
+                nullable=False,
+                server_default="1",
+            )
+        )
+        batch_op.add_column(
+            sa.Column("Recurrence_End_Date", sa.Date(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column(
+                "Excluded_Dates",
+                sa.JSON(),
+                nullable=False,
+                server_default="[]",
+            )
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("submission_schedule_requests", schema=None) as batch_op:
+        batch_op.drop_column("Excluded_Dates")
+        batch_op.drop_column("Recurrence_End_Date")
+        batch_op.drop_column("Recurrence_Interval")
+        batch_op.drop_column("Recurrence_Type")
+        batch_op.drop_column("Flexible_Deadline")
+        batch_op.drop_column("Is_Flexible")

--- a/backend/app/api/v1/submissions.py
+++ b/backend/app/api/v1/submissions.py
@@ -10,6 +10,8 @@ from app.config import settings
 from app.schemas.submission import (
     LinkCreate,
     LinkResponse,
+    ScheduleOccurrenceRescheduleRequest,
+    ScheduleOccurrenceSkipRequest,
     ScheduleRequestCreate,
     ScheduleRequestResponse,
     SubmissionCreate,
@@ -21,6 +23,33 @@ from app.services import allowed_value_service, schedule_service, submission_ser
 from app.services.image_service import save_upload, validate_image
 
 router = APIRouter(prefix="/submissions", tags=["submissions"])
+
+
+def _ensure_staff_only_recurrence(
+    submission_role: SubmitterRole,
+    schedule_request: ScheduleRequestCreate,
+) -> None:
+    is_recurring = schedule_request.Recurrence_Type != "once"
+    if is_recurring and submission_role != "staff":
+        raise HTTPException(
+            status_code=403,
+            detail="Recurring scheduling is available to staff editors only.",
+        )
+
+
+async def _validate_schedule_request(
+    db: AsyncSession,
+    target_newsletter: str,
+    schedule_request: ScheduleRequestCreate,
+) -> None:
+    nl_types = ["tdr", "myui"] if target_newsletter == "both" else [target_newsletter]
+    if schedule_request.Requested_Date:
+        for nl_type in nl_types:
+            error = await schedule_service.validate_requested_date(
+                db, schedule_request.Requested_Date, nl_type
+            )
+            if error:
+                raise HTTPException(status_code=422, detail=error)
 
 
 @router.post("/", response_model=SubmissionResponse, status_code=201)
@@ -36,16 +65,9 @@ async def create_submission(
             status_code=422,
             detail="Announcement type is not available for this submitter role.",
         )
-    # Validate requested publication dates against schedule config + blackouts
-    nl_types = ["tdr", "myui"] if data.Target_Newsletter == "both" else [data.Target_Newsletter]
     for sched in data.Schedule_Requests:
-        if sched.Requested_Date:
-            for nl_type in nl_types:
-                error = await schedule_service.validate_requested_date(
-                    db, sched.Requested_Date, nl_type,
-                )
-                if error:
-                    raise HTTPException(status_code=422, detail=error)
+        _ensure_staff_only_recurrence(submission_role, sched)
+        await _validate_schedule_request(db, data.Target_Newsletter, sched)
     submission = await submission_service.create_submission(db, data)
     return submission
 
@@ -132,28 +154,123 @@ async def delete_link(submission_id: str, link_id: str, db: AsyncSession = Depen
 
 @router.post("/{submission_id}/schedule", response_model=ScheduleRequestResponse, status_code=201)
 async def add_schedule_request(
-    submission_id: str, data: ScheduleRequestCreate, db: AsyncSession = Depends(get_db)
+    submission_id: str,
+    data: ScheduleRequestCreate,
+    db: AsyncSession = Depends(get_db),
+    submission_role: SubmitterRole = Depends(get_submitter_role),
 ):
-    # Validate requested date if provided
-    if data.Requested_Date:
-        submission = await submission_service.get_submission(db, submission_id)
-        if not submission:
-            raise HTTPException(status_code=404, detail="Submission not found")
-        error = await schedule_service.validate_requested_date(
-            db, data.Requested_Date, submission.Target_Newsletter,
-        )
-        if error:
-            raise HTTPException(status_code=422, detail=error)
+    submission = await submission_service.get_submission(db, submission_id)
+    if not submission:
+        raise HTTPException(status_code=404, detail="Submission not found")
+
+    _ensure_staff_only_recurrence(submission_role, data)
+    await _validate_schedule_request(db, submission.Target_Newsletter, data)
 
     sched = await submission_service.add_schedule_request(
         db, submission_id,
         requested_date=data.Requested_Date,
         repeat_count=data.Repeat_Count,
         repeat_note=data.Repeat_Note,
+        is_flexible=data.Is_Flexible,
+        flexible_deadline=data.Flexible_Deadline,
+        recurrence_type=data.Recurrence_Type,
+        recurrence_interval=data.Recurrence_Interval,
+        recurrence_end_date=data.Recurrence_End_Date,
+        excluded_dates=data.Excluded_Dates,
     )
     if not sched:
         raise HTTPException(status_code=404, detail="Submission not found")
-    return sched
+    refreshed_submission = await submission_service.get_submission(db, submission_id)
+    if not refreshed_submission:
+        raise HTTPException(status_code=404, detail="Submission not found")
+    refreshed_schedule = next(
+        (schedule for schedule in refreshed_submission.Schedule_Requests if schedule.Id == sched.Id),
+        None,
+    )
+    if not refreshed_schedule:
+        raise HTTPException(status_code=404, detail="Schedule request not found")
+    return refreshed_schedule
+
+
+@router.post(
+    "/{submission_id}/schedule/{schedule_id}/skip",
+    response_model=ScheduleRequestResponse,
+)
+async def skip_schedule_occurrence(
+    submission_id: str,
+    schedule_id: str,
+    data: ScheduleOccurrenceSkipRequest,
+    db: AsyncSession = Depends(get_db),
+    submission_role: SubmitterRole = Depends(get_submitter_role),
+):
+    if submission_role != "staff":
+        raise HTTPException(
+            status_code=403,
+            detail="Only staff editors can change scheduled occurrences.",
+        )
+    sched = await submission_service.skip_schedule_occurrence(
+        db, submission_id, schedule_id, data.Occurrence_Date
+    )
+    if not sched:
+        raise HTTPException(status_code=404, detail="Schedule request not found")
+    refreshed_submission = await submission_service.get_submission(db, submission_id)
+    if not refreshed_submission:
+        raise HTTPException(status_code=404, detail="Submission not found")
+    refreshed_schedule = next(
+        (schedule for schedule in refreshed_submission.Schedule_Requests if schedule.Id == schedule_id),
+        None,
+    )
+    if not refreshed_schedule:
+        raise HTTPException(status_code=404, detail="Schedule request not found")
+    return refreshed_schedule
+
+
+@router.post(
+    "/{submission_id}/schedule/{schedule_id}/reschedule",
+    response_model=ScheduleRequestResponse,
+    status_code=201,
+)
+async def reschedule_schedule_occurrence(
+    submission_id: str,
+    schedule_id: str,
+    data: ScheduleOccurrenceRescheduleRequest,
+    db: AsyncSession = Depends(get_db),
+    submission_role: SubmitterRole = Depends(get_submitter_role),
+):
+    if submission_role != "staff":
+        raise HTTPException(
+            status_code=403,
+            detail="Only staff editors can change scheduled occurrences.",
+        )
+    submission = await submission_service.get_submission(db, submission_id)
+    if not submission:
+        raise HTTPException(status_code=404, detail="Submission not found")
+
+    nl_types = (
+        ["tdr", "myui"]
+        if submission.Target_Newsletter == "both"
+        else [submission.Target_Newsletter]
+    )
+    for nl_type in nl_types:
+        error = await schedule_service.validate_requested_date(db, data.New_Date, nl_type)
+        if error:
+            raise HTTPException(status_code=422, detail=error)
+
+    sched = await submission_service.reschedule_schedule_occurrence(
+        db, submission_id, schedule_id, data.Occurrence_Date, data.New_Date
+    )
+    if not sched:
+        raise HTTPException(status_code=404, detail="Schedule request not found")
+    refreshed_submission = await submission_service.get_submission(db, submission_id)
+    if not refreshed_submission:
+        raise HTTPException(status_code=404, detail="Submission not found")
+    refreshed_schedule = next(
+        (schedule for schedule in refreshed_submission.Schedule_Requests if schedule.Id == sched.Id),
+        None,
+    )
+    if not refreshed_schedule:
+        raise HTTPException(status_code=404, detail="Schedule request not found")
+    return refreshed_schedule
 
 
 @router.delete("/{submission_id}/schedule/{schedule_id}", status_code=204)

--- a/backend/app/models/submission.py
+++ b/backend/app/models/submission.py
@@ -103,6 +103,14 @@ class SubmissionScheduleRequest(Base):
     Repeat_Note: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
     Is_Flexible: Mapped[bool] = mapped_column(sa.Boolean, default=False)
     Flexible_Deadline: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    Recurrence_Type: Mapped[str] = mapped_column(
+        sa.String(50), nullable=False, default="once"
+    )
+    Recurrence_Interval: Mapped[int] = mapped_column(sa.Integer, nullable=False, default=1)
+    Recurrence_End_Date: Mapped[date | None] = mapped_column(sa.Date, nullable=True)
+    Excluded_Dates: Mapped[list[str]] = mapped_column(
+        sa.JSON, nullable=False, default=list
+    )
 
     Submission_Rel: Mapped["Submission"] = relationship(
         back_populates="Schedule_Requests", lazy="selectin"

--- a/backend/app/schemas/submission.py
+++ b/backend/app/schemas/submission.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 # --- Link schemas ---
@@ -30,6 +30,19 @@ class ScheduleRequestCreate(BaseModel):
     Repeat_Note: str | None = None
     Is_Flexible: bool = False
     Flexible_Deadline: str | None = None
+    Recurrence_Type: str = Field(
+        "once",
+        pattern=r"^(once|weekly|monthly_date|monthly_nth_weekday)$",
+    )
+    Recurrence_Interval: int = Field(1, ge=1, le=12)
+    Recurrence_End_Date: date | None = None
+    Excluded_Dates: list[date] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_recurrence_range(self) -> "ScheduleRequestCreate":
+        if self.Recurrence_End_Date and self.Recurrence_End_Date < self.Requested_Date:
+            raise ValueError("Recurrence_End_Date cannot be before Requested_Date")
+        return self
 
 
 class ScheduleRequestResponse(BaseModel):
@@ -39,8 +52,22 @@ class ScheduleRequestResponse(BaseModel):
     Repeat_Note: str | None
     Is_Flexible: bool
     Flexible_Deadline: str | None
+    Recurrence_Type: str
+    Recurrence_Interval: int
+    Recurrence_End_Date: date | None
+    Excluded_Dates: list[date] = Field(default_factory=list)
+    Occurrence_Dates: list[date] = Field(default_factory=list)
 
     model_config = {"from_attributes": True}
+
+
+class ScheduleOccurrenceSkipRequest(BaseModel):
+    Occurrence_Date: date
+
+
+class ScheduleOccurrenceRescheduleRequest(BaseModel):
+    Occurrence_Date: date
+    New_Date: date
 
 
 # --- Submission schemas ---
@@ -85,6 +112,7 @@ class SubmissionResponse(BaseModel):
     Updated_At: datetime
     Links: list[LinkResponse]
     Schedule_Requests: list[ScheduleRequestResponse]
+    Occurrence_Dates: list[date] = Field(default_factory=list)
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services/newsletter_service.py
+++ b/backend/app/services/newsletter_service.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import selectinload
 from app.models.newsletter import Newsletter, NewsletterExternalItem, NewsletterItem
 from app.models.section import NewsletterSection
 from app.models.submission import Submission
+from app.services import submission_service
 
 
 async def create_newsletter(
@@ -285,6 +286,15 @@ async def assemble_newsletter(
 
     for sub in submissions:
         if sub.Id in existing_sub_ids:
+            continue
+        occurrence_dates = await submission_service.get_submission_occurrence_dates(
+            db,
+            sub,
+            publish_date,
+            publish_date,
+            newsletter_type=newsletter_type,
+        )
+        if publish_date not in occurrence_dates:
             continue
 
         headline, body = _get_best_text(sub)

--- a/backend/app/services/recurrence_service.py
+++ b/backend/app/services/recurrence_service.py
@@ -1,0 +1,106 @@
+"""Helpers for expanding recurring submission schedule requests."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from app.models.submission import SubmissionScheduleRequest
+
+
+def expand_schedule_request(
+    schedule_request: SubmissionScheduleRequest,
+    from_date: date,
+    to_date: date,
+) -> list[date]:
+    """Return occurrence dates for a schedule request within a range."""
+    anchor = schedule_request.Requested_Date
+    if anchor is None or from_date > to_date:
+        return []
+
+    recurrence_type = schedule_request.Recurrence_Type or "once"
+    interval = max(schedule_request.Recurrence_Interval or 1, 1)
+    until = schedule_request.Recurrence_End_Date
+    excluded = {
+        excluded_date
+        for excluded_date in (schedule_request.Excluded_Dates or [])
+        if isinstance(excluded_date, str)
+    }
+
+    if until and until < from_date:
+        return []
+
+    upper_bound = min(to_date, until) if until else to_date
+    occurrences: list[date] = []
+
+    if recurrence_type == "once":
+        if from_date <= anchor <= upper_bound and anchor.isoformat() not in excluded:
+            return [anchor]
+        return []
+
+    if recurrence_type == "weekly":
+        current = anchor
+        while current < from_date:
+            current += timedelta(weeks=interval)
+        while current <= upper_bound:
+            if current.isoformat() not in excluded:
+                occurrences.append(current)
+            current += timedelta(weeks=interval)
+        return occurrences
+
+    if recurrence_type == "monthly_date":
+        index = 0
+        while True:
+            current = _monthly_date_occurrence(anchor, interval, index)
+            if current is None:
+                break
+            if current > upper_bound:
+                break
+            if current >= from_date and current.isoformat() not in excluded:
+                occurrences.append(current)
+            index += 1
+        return occurrences
+
+    if recurrence_type == "monthly_nth_weekday":
+        index = 0
+        while True:
+            current = _monthly_nth_weekday_occurrence(anchor, interval, index)
+            if current is None:
+                break
+            if current > upper_bound:
+                break
+            if current >= from_date and current.isoformat() not in excluded:
+                occurrences.append(current)
+            index += 1
+        return occurrences
+
+    return []
+
+
+def _add_months(year: int, month: int, months_to_add: int) -> tuple[int, int]:
+    month_index = (year * 12) + (month - 1) + months_to_add
+    return month_index // 12, (month_index % 12) + 1
+
+
+def _monthly_date_occurrence(anchor: date, interval: int, index: int) -> date | None:
+    year, month = _add_months(anchor.year, anchor.month, interval * index)
+    try:
+        return date(year, month, anchor.day)
+    except ValueError:
+        return None
+
+
+def _monthly_nth_weekday_occurrence(anchor: date, interval: int, index: int) -> date | None:
+    year, month = _add_months(anchor.year, anchor.month, interval * index)
+    first_of_month = date(year, month, 1)
+    weekday_offset = (anchor.weekday() - first_of_month.weekday()) % 7
+    nth = ((anchor.day - 1) // 7) + 1
+    day_number = 1 + weekday_offset + ((nth - 1) * 7)
+
+    try:
+        candidate = date(year, month, day_number)
+    except ValueError:
+        return None
+
+    if candidate.month != month:
+        return None
+    return candidate

--- a/backend/app/services/submission_service.py
+++ b/backend/app/services/submission_service.py
@@ -1,13 +1,15 @@
 """Submission CRUD and related operations."""
 
-from datetime import date
+from datetime import date, timedelta
 
-from sqlalchemy import select, func
+import sqlalchemy as sa
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models.submission import Submission, SubmissionLink, SubmissionScheduleRequest
 from app.schemas.submission import SubmissionCreate, SubmissionUpdate
+from app.services import recurrence_service, schedule_service
 
 
 async def create_submission(db: AsyncSession, data: SubmissionCreate) -> Submission:
@@ -38,6 +40,12 @@ async def create_submission(db: AsyncSession, data: SubmissionCreate) -> Submiss
             Requested_Date=sched_data.Requested_Date,
             Repeat_Count=sched_data.Repeat_Count,
             Repeat_Note=sched_data.Repeat_Note,
+            Is_Flexible=sched_data.Is_Flexible,
+            Flexible_Deadline=sched_data.Flexible_Deadline,
+            Recurrence_Type=sched_data.Recurrence_Type,
+            Recurrence_Interval=sched_data.Recurrence_Interval,
+            Recurrence_End_Date=sched_data.Recurrence_End_Date,
+            Excluded_Dates=[excluded.isoformat() for excluded in sched_data.Excluded_Dates],
         )
         db.add(sched)
 
@@ -48,6 +56,7 @@ async def create_submission(db: AsyncSession, data: SubmissionCreate) -> Submiss
 async def get_submission(db: AsyncSession, submission_id: str) -> Submission | None:
     result = await db.execute(
         select(Submission)
+        .execution_options(populate_existing=True)
         .where(Submission.Id == submission_id)
         .options(
             selectinload(Submission.Links),
@@ -55,7 +64,14 @@ async def get_submission(db: AsyncSession, submission_id: str) -> Submission | N
             selectinload(Submission.Edit_Versions),
         )
     )
-    return result.scalar_one_or_none()
+    submission = result.scalar_one_or_none()
+    if not submission:
+        return None
+
+    preview_from = date.today()
+    preview_to = preview_from + timedelta(days=365)
+    await hydrate_submission_occurrences(db, submission, preview_from, preview_to)
+    return submission
 
 
 async def list_submissions(
@@ -89,22 +105,59 @@ async def list_submissions(
         search_filter = Submission.Original_Headline.ilike(pattern) | Submission.Original_Body.ilike(pattern) | Submission.Submitter_Name.ilike(pattern)
         query = query.where(search_filter)
         count_query = count_query.where(search_filter)
+    query = query.order_by(Submission.Created_At.desc())
+
     if date_from or date_to:
-        conditions = []
-        if date_from:
-            conditions.append(SubmissionScheduleRequest.Requested_Date >= date_from)
-        if date_to:
-            conditions.append(SubmissionScheduleRequest.Requested_Date <= date_to)
-        from sqlalchemy import and_
-        date_filter = Submission.Schedule_Requests.any(and_(*conditions))
-        query = query.where(date_filter)
-        count_query = count_query.where(date_filter)
+        effective_from = date_from or date.today()
+        effective_to = date_to or effective_from
+        recurrence_filter = Submission.Schedule_Requests.any(
+            sa.and_(
+                SubmissionScheduleRequest.Requested_Date <= effective_to,
+                sa.or_(
+                    SubmissionScheduleRequest.Recurrence_End_Date.is_(None),
+                    SubmissionScheduleRequest.Recurrence_End_Date >= effective_from,
+                ),
+            )
+        )
+        query = query.where(recurrence_filter)
+        candidates = list((await db.execute(query)).scalars().all())
+        filtered_items: list[Submission] = []
+        for submission in candidates:
+            occurrence_dates = await get_submission_occurrence_dates(
+                db,
+                submission,
+                effective_from,
+                effective_to,
+                newsletter_type=target_newsletter,
+            )
+            if occurrence_dates:
+                await hydrate_submission_occurrences(
+                    db,
+                    submission,
+                    effective_from,
+                    effective_to,
+                    newsletter_type=target_newsletter,
+                )
+                filtered_items.append(submission)
+        total = len(filtered_items)
+        return filtered_items[offset:offset + limit], total
 
-    query = query.order_by(Submission.Created_At.desc()).offset(offset).limit(limit)
+    total = (await db.execute(count_query)).scalar() or 0
+    items = list((await db.execute(query.offset(offset).limit(limit))).scalars().all())
 
-    total = (await db.execute(count_query)).scalar()
-    items = (await db.execute(query)).scalars().all()
-    return list(items), total
+    preview_from = date.today()
+    preview_to = preview_from + timedelta(days=180)
+    for submission in items:
+        await hydrate_submission_occurrences(
+            db,
+            submission,
+            preview_from,
+            preview_to,
+            newsletter_type=target_newsletter,
+            max_occurrences=3,
+        )
+
+    return items, total
 
 
 async def update_submission(
@@ -172,6 +225,12 @@ async def add_schedule_request(
     requested_date=None,
     repeat_count: int = 1,
     repeat_note: str | None = None,
+    is_flexible: bool = False,
+    flexible_deadline: str | None = None,
+    recurrence_type: str = "once",
+    recurrence_interval: int = 1,
+    recurrence_end_date: date | None = None,
+    excluded_dates: list[date] | None = None,
 ) -> SubmissionScheduleRequest | None:
     submission = await get_submission(db, submission_id)
     if not submission:
@@ -181,6 +240,12 @@ async def add_schedule_request(
         Requested_Date=requested_date,
         Repeat_Count=repeat_count,
         Repeat_Note=repeat_note,
+        Is_Flexible=is_flexible,
+        Flexible_Deadline=flexible_deadline,
+        Recurrence_Type=recurrence_type,
+        Recurrence_Interval=recurrence_interval,
+        Recurrence_End_Date=recurrence_end_date,
+        Excluded_Dates=[excluded.isoformat() for excluded in (excluded_dates or [])],
     )
     db.add(sched)
     await db.commit()
@@ -198,6 +263,206 @@ async def delete_schedule_request(db: AsyncSession, schedule_id: str) -> bool:
     await db.delete(sched)
     await db.commit()
     return True
+
+
+async def get_schedule_request(
+    db: AsyncSession, submission_id: str, schedule_id: str
+) -> SubmissionScheduleRequest | None:
+    result = await db.execute(
+        select(SubmissionScheduleRequest).where(
+            SubmissionScheduleRequest.Id == schedule_id,
+            SubmissionScheduleRequest.Submission_Id == submission_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def skip_schedule_occurrence(
+    db: AsyncSession,
+    submission_id: str,
+    schedule_id: str,
+    occurrence_date: date,
+) -> SubmissionScheduleRequest | None:
+    schedule_request = await get_schedule_request(db, submission_id, schedule_id)
+    if not schedule_request:
+        return None
+
+    excluded_dates = set(schedule_request.Excluded_Dates or [])
+    excluded_dates.add(occurrence_date.isoformat())
+    schedule_request.Excluded_Dates = sorted(excluded_dates)
+    await db.commit()
+    await db.refresh(schedule_request)
+    return schedule_request
+
+
+async def reschedule_schedule_occurrence(
+    db: AsyncSession,
+    submission_id: str,
+    schedule_id: str,
+    occurrence_date: date,
+    new_date: date,
+) -> SubmissionScheduleRequest | None:
+    schedule_request = await skip_schedule_occurrence(
+        db, submission_id, schedule_id, occurrence_date
+    )
+    if not schedule_request:
+        return None
+
+    return await add_schedule_request(
+        db,
+        submission_id,
+        requested_date=new_date,
+        repeat_count=1,
+        repeat_note=f"Rescheduled from {occurrence_date.isoformat()}",
+    )
+
+
+async def get_submission_occurrence_dates(
+    db: AsyncSession,
+    submission: Submission,
+    from_date: date,
+    to_date: date,
+    newsletter_type: str | None = None,
+) -> list[date]:
+    """Return valid occurrence dates for a submission within a range."""
+    if from_date > to_date:
+        return []
+
+    candidate_dates: set[date] = set()
+    for schedule_request in submission.Schedule_Requests:
+        candidate_dates.update(
+            recurrence_service.expand_schedule_request(
+                schedule_request,
+                from_date,
+                to_date,
+            )
+        )
+
+    if not candidate_dates:
+        return []
+
+    relevant_newsletters = (
+        [newsletter_type]
+        if newsletter_type
+        else (
+            ["tdr", "myui"]
+            if submission.Target_Newsletter == "both"
+            else [submission.Target_Newsletter]
+        )
+    )
+    relevant_newsletters = [nl for nl in relevant_newsletters if nl]
+
+    if not relevant_newsletters:
+        return sorted(candidate_dates)
+
+    has_configs = False
+    valid_dates: set[date] = set()
+    for nl_type in relevant_newsletters:
+        configs = await schedule_service.list_configs(db, nl_type)
+        if not configs:
+            continue
+        has_configs = True
+        valid_for_newsletter = await schedule_service.get_valid_publication_dates(
+            db,
+            from_date,
+            to_date,
+            nl_type,
+        )
+        valid_dates.update(item["date"] for item in valid_for_newsletter)
+
+    if not has_configs:
+        return sorted(candidate_dates)
+
+    return sorted(candidate_dates & valid_dates)
+
+
+async def hydrate_submission_occurrences(
+    db: AsyncSession,
+    submission: Submission,
+    from_date: date,
+    to_date: date,
+    newsletter_type: str | None = None,
+    max_occurrences: int | None = None,
+) -> Submission:
+    """Attach occurrence previews to a submission and each schedule request."""
+    all_occurrences: list[date] = []
+    for schedule_request in submission.Schedule_Requests:
+        occurrences = recurrence_service.expand_schedule_request(
+            schedule_request,
+            from_date,
+            to_date,
+        )
+        valid_occurrences = await get_submission_occurrence_dates_for_request(
+            db,
+            submission,
+            schedule_request,
+            occurrences,
+            from_date,
+            to_date,
+            newsletter_type=newsletter_type,
+        )
+        if max_occurrences is not None:
+            valid_occurrences = valid_occurrences[:max_occurrences]
+        schedule_request.Occurrence_Dates = [
+            occurrence.isoformat() for occurrence in valid_occurrences
+        ]
+        all_occurrences.extend(valid_occurrences)
+
+    unique_occurrences = sorted(set(all_occurrences))
+    if max_occurrences is not None:
+        unique_occurrences = unique_occurrences[:max_occurrences]
+    submission.Occurrence_Dates = [
+        occurrence.isoformat() for occurrence in unique_occurrences
+    ]
+    return submission
+
+
+async def get_submission_occurrence_dates_for_request(
+    db: AsyncSession,
+    submission: Submission,
+    schedule_request: SubmissionScheduleRequest,
+    candidate_dates: list[date],
+    from_date: date,
+    to_date: date,
+    newsletter_type: str | None = None,
+) -> list[date]:
+    """Filter occurrence candidates to valid publication dates."""
+    if not candidate_dates:
+        return []
+
+    relevant_newsletters = (
+        [newsletter_type]
+        if newsletter_type
+        else (
+            ["tdr", "myui"]
+            if submission.Target_Newsletter == "both"
+            else [submission.Target_Newsletter]
+        )
+    )
+    relevant_newsletters = [nl for nl in relevant_newsletters if nl]
+
+    if not relevant_newsletters:
+        return sorted(candidate_dates)
+
+    has_configs = False
+    valid_dates: set[date] = set()
+    for nl_type in relevant_newsletters:
+        configs = await schedule_service.list_configs(db, nl_type)
+        if not configs:
+            continue
+        has_configs = True
+        valid_for_newsletter = await schedule_service.get_valid_publication_dates(
+            db,
+            from_date,
+            to_date,
+            nl_type,
+        )
+        valid_dates.update(item["date"] for item in valid_for_newsletter)
+
+    if not has_configs:
+        return sorted(candidate_dates)
+
+    return sorted(date_value for date_value in candidate_dates if date_value in valid_dates)
 
 
 # --- Image management ---

--- a/backend/tests/test_newsletters.py
+++ b/backend/tests/test_newsletters.py
@@ -111,6 +111,65 @@ class TestNewsletterItems:
         resp = await client.delete(f"/api/v1/newsletters/{nl_id}/items/{item_id}")
         assert resp.status_code == 204
 
+    async def test_assemble_newsletter_uses_matching_recurring_occurrence(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+    ):
+        db.add(
+            NewsletterSection(
+                Newsletter_Type="tdr",
+                Name="Employee News",
+                Slug="employee-news",
+                Display_Order=1,
+                Is_Active=True,
+            )
+        )
+        await db.commit()
+
+        recurring_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Original_Headline="Recurring feature",
+                Schedule_Requests=[
+                    {
+                        "Requested_Date": "2026-03-02",
+                        "Recurrence_Type": "monthly_nth_weekday",
+                        "Recurrence_Interval": 1,
+                        "Recurrence_End_Date": "2026-06-01",
+                    }
+                ],
+            ),
+            headers={"X-User-Role": "staff"},
+        )
+        recurring_id = recurring_resp.json()["Id"]
+        await client.patch(
+            f"/api/v1/submissions/{recurring_id}",
+            json={"Status": "approved"},
+        )
+
+        one_off_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Original_Headline="Wrong date",
+                Schedule_Requests=[{"Requested_Date": "2026-04-07"}],
+            ),
+        )
+        one_off_id = one_off_resp.json()["Id"]
+        await client.patch(
+            f"/api/v1/submissions/{one_off_id}",
+            json={"Status": "approved"},
+        )
+
+        assemble_resp = await client.post(
+            "/api/v1/newsletters/assemble",
+            json={"Newsletter_Type": "tdr", "Publish_Date": "2026-04-06"},
+        )
+        assert assemble_resp.status_code == 200
+        items = assemble_resp.json()["Items"]
+        assert len(items) == 1
+        assert items[0]["Submission_Id"] == recurring_id
+
 
 class TestCalendarEventParsing:
     def test_parse_trumba_hcalendar(self):

--- a/backend/tests/test_submissions.py
+++ b/backend/tests/test_submissions.py
@@ -38,6 +38,54 @@ class TestSubmissionCRUD:
         assert len(body["Schedule_Requests"]) == 1
         assert body["Schedule_Requests"][0]["Repeat_Count"] == 2
 
+    async def test_create_submission_with_recurring_schedule(self, client: AsyncClient):
+        data = make_submission_data(
+            Schedule_Requests=[
+                {
+                    "Requested_Date": "2026-03-02",
+                    "Recurrence_Type": "monthly_nth_weekday",
+                    "Recurrence_Interval": 1,
+                    "Recurrence_End_Date": "2026-06-01",
+                }
+            ]
+        )
+        resp = await client.post(
+            "/api/v1/submissions/",
+            json=data,
+            headers={"X-User-Role": "staff"},
+        )
+        assert resp.status_code == 201
+        schedule = resp.json()["Schedule_Requests"][0]
+        assert schedule["Recurrence_Type"] == "monthly_nth_weekday"
+        assert schedule["Recurrence_End_Date"] == "2026-06-01"
+        assert schedule["Occurrence_Dates"] == [
+            "2026-04-06",
+            "2026-05-04",
+            "2026-06-01",
+        ]
+        assert resp.json()["Occurrence_Dates"] == [
+            "2026-04-06",
+            "2026-05-04",
+            "2026-06-01",
+        ]
+
+    async def test_public_submitter_cannot_create_recurring_schedule(
+        self, client: AsyncClient
+    ):
+        data = make_submission_data(
+            Schedule_Requests=[
+                {
+                    "Requested_Date": "2026-03-02",
+                    "Recurrence_Type": "monthly_nth_weekday",
+                    "Recurrence_Interval": 1,
+                    "Recurrence_End_Date": "2026-06-01",
+                }
+            ]
+        )
+        resp = await client.post("/api/v1/submissions/", json=data)
+        assert resp.status_code == 403
+        assert "staff editors only" in resp.json()["detail"]
+
     async def test_public_submitter_cannot_use_staff_only_category(self, client: AsyncClient):
         data = make_submission_data(Category="news_release")
         resp = await client.post("/api/v1/submissions/", json=data)
@@ -75,6 +123,41 @@ class TestSubmissionCRUD:
 
         resp = await client.get("/api/v1/submissions/?status=approved")
         assert resp.json()["Total"] == 0
+
+    async def test_list_submissions_includes_recurring_occurrences_in_range(
+        self, client: AsyncClient
+    ):
+        recurring = make_submission_data(
+            Original_Headline="Recurring feature",
+            Schedule_Requests=[
+                {
+                    "Requested_Date": "2026-03-02",
+                    "Recurrence_Type": "monthly_nth_weekday",
+                    "Recurrence_Interval": 1,
+                    "Recurrence_End_Date": "2026-06-01",
+                }
+            ],
+        )
+        one_off = make_submission_data(
+            Original_Headline="One off",
+            Schedule_Requests=[{"Requested_Date": "2026-03-15"}],
+        )
+
+        await client.post(
+            "/api/v1/submissions/",
+            json=recurring,
+            headers={"X-User-Role": "staff"},
+        )
+        await client.post("/api/v1/submissions/", json=one_off)
+
+        resp = await client.get(
+            "/api/v1/submissions/?date_from=2026-04-01&date_to=2026-04-30"
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["Total"] == 1
+        assert body["Items"][0]["Original_Headline"] == "Recurring feature"
+        assert body["Items"][0]["Occurrence_Dates"] == ["2026-04-06"]
 
     async def test_get_submission(self, client: AsyncClient):
         create_resp = await client.post("/api/v1/submissions/", json=make_submission_data())
@@ -148,6 +231,23 @@ class TestSubmissionSchedule:
         assert resp.status_code == 201
         assert resp.json()["Repeat_Count"] == 2
 
+    async def test_public_submitter_cannot_add_recurring_schedule_request(
+        self, client: AsyncClient
+    ):
+        create_resp = await client.post("/api/v1/submissions/", json=make_submission_data())
+        sub_id = create_resp.json()["Id"]
+
+        resp = await client.post(
+            f"/api/v1/submissions/{sub_id}/schedule",
+            json={
+                "Requested_Date": "2026-04-06",
+                "Recurrence_Type": "weekly",
+                "Recurrence_Interval": 1,
+            },
+        )
+        assert resp.status_code == 403
+        assert "staff editors only" in resp.json()["detail"]
+
     async def test_delete_schedule_request(self, client: AsyncClient):
         data = make_submission_data(
             Schedule_Requests=[{"Requested_Date": "2026-05-01", "Repeat_Count": 1}]
@@ -158,3 +258,102 @@ class TestSubmissionSchedule:
 
         resp = await client.delete(f"/api/v1/submissions/{sub_id}/schedule/{sched_id}")
         assert resp.status_code == 204
+
+    async def test_skip_schedule_occurrence(self, client: AsyncClient):
+        data = make_submission_data(
+            Schedule_Requests=[
+                {
+                    "Requested_Date": "2026-03-02",
+                    "Recurrence_Type": "monthly_nth_weekday",
+                    "Recurrence_Interval": 1,
+                    "Recurrence_End_Date": "2026-06-01",
+                }
+            ]
+        )
+        create_resp = await client.post(
+            "/api/v1/submissions/",
+            json=data,
+            headers={"X-User-Role": "staff"},
+        )
+        sched_id = create_resp.json()["Schedule_Requests"][0]["Id"]
+        sub_id = create_resp.json()["Id"]
+
+        resp = await client.post(
+            f"/api/v1/submissions/{sub_id}/schedule/{sched_id}/skip",
+            json={"Occurrence_Date": "2026-04-06"},
+            headers={"X-User-Role": "staff"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["Excluded_Dates"] == ["2026-04-06"]
+        assert resp.json()["Occurrence_Dates"] == ["2026-05-04", "2026-06-01"]
+
+        list_resp = await client.get(
+            "/api/v1/submissions/?date_from=2026-04-01&date_to=2026-04-30"
+        )
+        assert list_resp.status_code == 200
+        assert list_resp.json()["Total"] == 0
+
+    async def test_reschedule_schedule_occurrence(self, client: AsyncClient):
+        data = make_submission_data(
+            Schedule_Requests=[
+                {
+                    "Requested_Date": "2026-03-02",
+                    "Recurrence_Type": "monthly_nth_weekday",
+                    "Recurrence_Interval": 1,
+                    "Recurrence_End_Date": "2026-06-01",
+                }
+            ]
+        )
+        create_resp = await client.post(
+            "/api/v1/submissions/",
+            json=data,
+            headers={"X-User-Role": "staff"},
+        )
+        sched_id = create_resp.json()["Schedule_Requests"][0]["Id"]
+        sub_id = create_resp.json()["Id"]
+
+        resp = await client.post(
+            f"/api/v1/submissions/{sub_id}/schedule/{sched_id}/reschedule",
+            json={
+                "Occurrence_Date": "2026-04-06",
+                "New_Date": "2026-04-08",
+            },
+            headers={"X-User-Role": "staff"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["Requested_Date"] == "2026-04-08"
+        assert resp.json()["Occurrence_Dates"] == ["2026-04-08"]
+
+        list_resp = await client.get(
+            "/api/v1/submissions/?date_from=2026-04-01&date_to=2026-04-30"
+        )
+        assert list_resp.status_code == 200
+        body = list_resp.json()
+        assert body["Total"] == 1
+        assert body["Items"][0]["Occurrence_Dates"] == ["2026-04-08"]
+
+    async def test_public_submitter_cannot_skip_occurrence(self, client: AsyncClient):
+        data = make_submission_data(
+            Schedule_Requests=[
+                {
+                    "Requested_Date": "2026-03-02",
+                    "Recurrence_Type": "monthly_nth_weekday",
+                    "Recurrence_Interval": 1,
+                    "Recurrence_End_Date": "2026-06-01",
+                }
+            ]
+        )
+        create_resp = await client.post(
+            "/api/v1/submissions/",
+            json=data,
+            headers={"X-User-Role": "staff"},
+        )
+        sched_id = create_resp.json()["Schedule_Requests"][0]["Id"]
+        sub_id = create_resp.json()["Id"]
+
+        resp = await client.post(
+            f"/api/v1/submissions/{sub_id}/schedule/{sched_id}/skip",
+            json={"Occurrence_Date": "2026-04-06"},
+        )
+        assert resp.status_code == 403
+        assert "staff editors" in resp.json()["detail"]

--- a/frontend/src/api/submissions.ts
+++ b/frontend/src/api/submissions.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from './client';
-import type { Submission, SubmissionCreate } from '../types/submission';
+import type { Submission, SubmissionCreate, SubmissionScheduleRequest } from '../types/submission';
 import { getSubmitterRoleHeaders } from '../utils/submitterRole';
 
 interface SubmissionListResponse {
@@ -52,6 +52,38 @@ export async function updateSubmission(
 
 export async function deleteSubmission(id: string): Promise<void> {
   await apiFetch(`/submissions/${id}`, { method: 'DELETE' });
+}
+
+export async function skipScheduleOccurrence(
+  submissionId: string,
+  scheduleId: string,
+  occurrenceDate: string,
+): Promise<SubmissionScheduleRequest> {
+  return apiFetch<SubmissionScheduleRequest>(
+    `/submissions/${submissionId}/schedule/${scheduleId}/skip`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ Occurrence_Date: occurrenceDate }),
+    },
+  );
+}
+
+export async function rescheduleScheduleOccurrence(
+  submissionId: string,
+  scheduleId: string,
+  occurrenceDate: string,
+  newDate: string,
+): Promise<SubmissionScheduleRequest> {
+  return apiFetch<SubmissionScheduleRequest>(
+    `/submissions/${submissionId}/schedule/${scheduleId}/reschedule`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        Occurrence_Date: occurrenceDate,
+        New_Date: newDate,
+      }),
+    },
+  );
 }
 
 export async function uploadImage(submissionId: string, file: File): Promise<Submission> {

--- a/frontend/src/components/dashboard/CalendarView.tsx
+++ b/frontend/src/components/dashboard/CalendarView.tsx
@@ -1,4 +1,5 @@
 import type { Submission } from '../../types/submission';
+import { getOccurrenceDates } from '../../utils/submissionOccurrences';
 
 const DAYS_OF_WEEK = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
@@ -32,12 +33,9 @@ function toISODate(d: Date): string {
 function getSubmissionsByDate(submissions: Submission[]): Map<string, Submission[]> {
   const map = new Map<string, Submission[]>();
   for (const sub of submissions) {
-    for (const sched of sub.Schedule_Requests) {
-      if (sched.Requested_Date) {
-        const dateKey = sched.Requested_Date;
-        if (!map.has(dateKey)) map.set(dateKey, []);
-        map.get(dateKey)!.push(sub);
-      }
+    for (const dateKey of getOccurrenceDates(sub)) {
+      if (!map.has(dateKey)) map.set(dateKey, []);
+      map.get(dateKey)!.push(sub);
     }
   }
   return map;

--- a/frontend/src/components/dashboard/DayDetail.tsx
+++ b/frontend/src/components/dashboard/DayDetail.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import type { Submission, SubmissionStatus } from '../../types/submission';
+import { getOccurrenceDates } from '../../utils/submissionOccurrences';
 
 const STATUS_COLORS: Record<string, string> = {
   new: 'bg-blue-100 text-blue-800',
@@ -71,7 +72,7 @@ export default function DayDetail({ date, submissions }: DayDetailProps) {
 
   // Filter to submissions that have this date in their schedule
   const daySubs = submissions.filter((sub) =>
-    sub.Schedule_Requests.some((sr) => sr.Requested_Date === date),
+    getOccurrenceDates(sub).includes(date),
   );
 
   return (

--- a/frontend/src/components/editor/SubmissionMeta.tsx
+++ b/frontend/src/components/editor/SubmissionMeta.tsx
@@ -1,8 +1,16 @@
+import { useState } from 'react';
 import type { Submission, TargetNewsletter } from '../../types/submission';
 
 interface SubmissionMetaProps {
   submission: Submission;
   onChangeNewsletter?: (target: TargetNewsletter) => void;
+  onSkipOccurrence?: (scheduleId: string, occurrenceDate: string) => Promise<void>;
+  onRescheduleOccurrence?: (
+    scheduleId: string,
+    occurrenceDate: string,
+    newDate: string,
+  ) => Promise<void>;
+  occurrenceActionLoading?: boolean;
 }
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -23,7 +31,42 @@ const TARGET_LABELS: Record<string, string> = {
   both: 'Both Newsletters',
 };
 
-export default function SubmissionMeta({ submission, onChangeNewsletter }: SubmissionMetaProps) {
+const RECURRENCE_LABELS: Record<string, string> = {
+  once: 'One time',
+  weekly: 'Weekly',
+  monthly_date: 'Monthly',
+  monthly_nth_weekday: 'Monthly (nth weekday)',
+};
+
+export default function SubmissionMeta({
+  submission,
+  onChangeNewsletter,
+  onSkipOccurrence,
+  onRescheduleOccurrence,
+  occurrenceActionLoading = false,
+}: SubmissionMetaProps) {
+  const [rescheduleTarget, setRescheduleTarget] = useState<{
+    scheduleId: string;
+    occurrenceDate: string;
+  } | null>(null);
+  const [replacementDate, setReplacementDate] = useState('');
+
+  const getMinDate = () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    return tomorrow.toISOString().split('T')[0];
+  };
+
+  const handleStartReschedule = (scheduleId: string, occurrenceDate: string) => {
+    setRescheduleTarget({ scheduleId, occurrenceDate });
+    setReplacementDate(occurrenceDate);
+  };
+
+  const handleCancelReschedule = () => {
+    setRescheduleTarget(null);
+    setReplacementDate('');
+  };
+
   return (
     <div className="bg-white rounded-lg border p-4">
       <h3 className="text-sm font-semibold text-gray-900 mb-3">Submission Info</h3>
@@ -83,26 +126,125 @@ export default function SubmissionMeta({ submission, onChangeNewsletter }: Submi
           <div>
             <dt className="text-xs text-gray-500">Requested Run Date</dt>
             {submission.Schedule_Requests.map((req) => (
-              <dd key={req.Id} className="text-gray-900 font-medium">
-                {req.Requested_Date
-                  ? new Date(req.Requested_Date).toLocaleDateString(undefined, {
-                      weekday: 'short',
-                      year: 'numeric',
-                      month: 'short',
-                      day: 'numeric',
-                    })
-                  : 'No specific date'}
-                {req.Repeat_Count > 1 && (
-                  <span className="font-normal text-gray-500"> &middot; Run {req.Repeat_Count}x</span>
+              <dd key={req.Id} className="mt-1 text-gray-900 font-medium">
+                <div>
+                  {req.Requested_Date
+                    ? new Date(req.Requested_Date).toLocaleDateString(undefined, {
+                        weekday: 'short',
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric',
+                      })
+                    : 'No specific date'}
+                  {req.Repeat_Count > 1 && (
+                    <span className="font-normal text-gray-500"> &middot; Run {req.Repeat_Count}x</span>
+                  )}
+                  {req.Recurrence_Type !== 'once' && (
+                    <span className="font-normal text-gray-500">
+                      {' '}
+                      &middot; {RECURRENCE_LABELS[req.Recurrence_Type] || req.Recurrence_Type}
+                      {req.Recurrence_Interval > 1 ? ` every ${req.Recurrence_Interval}` : ''}
+                    </span>
+                  )}
+                  {req.Is_Flexible && (
+                    <span className="ml-1 inline-block px-1.5 py-0.5 text-xs font-normal bg-amber-100 text-amber-700 rounded">Flexible</span>
+                  )}
+                  {req.Repeat_Note && (
+                    <span className="font-normal text-gray-500"> ({req.Repeat_Note})</span>
+                  )}
+                </div>
+                {req.Recurrence_End_Date && (
+                  <div className="text-xs text-gray-500 font-normal mt-0.5">
+                    Ends: {new Date(req.Recurrence_End_Date).toLocaleDateString()}
+                  </div>
                 )}
-                {req.Is_Flexible && (
-                  <span className="ml-1 inline-block px-1.5 py-0.5 text-xs font-normal bg-amber-100 text-amber-700 rounded">Flexible</span>
-                )}
-                {req.Repeat_Note && (
-                  <span className="font-normal text-gray-500"> ({req.Repeat_Note})</span>
+                {req.Excluded_Dates.length > 0 && (
+                  <div className="text-xs text-gray-500 font-normal mt-0.5">
+                    Skips: {req.Excluded_Dates.join(', ')}
+                  </div>
                 )}
                 {req.Is_Flexible && req.Flexible_Deadline && (
-                  <dd className="text-xs text-gray-500 font-normal mt-0.5">Deadline: {req.Flexible_Deadline}</dd>
+                  <div className="text-xs text-gray-500 font-normal mt-0.5">Deadline: {req.Flexible_Deadline}</div>
+                )}
+                {req.Occurrence_Dates.length > 0 && (
+                  <div className="mt-2 rounded-md bg-gray-50 p-2">
+                    <div className="text-[11px] uppercase tracking-wide text-gray-500 mb-1">
+                      Upcoming occurrences
+                    </div>
+                    <div className="space-y-2">
+                      {req.Occurrence_Dates.map((occurrenceDate) => (
+                        <div key={`${req.Id}-${occurrenceDate}`} className="flex flex-col gap-2">
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="text-xs font-normal text-gray-700">
+                              {new Date(`${occurrenceDate}T12:00:00`).toLocaleDateString(undefined, {
+                                weekday: 'short',
+                                year: 'numeric',
+                                month: 'short',
+                                day: 'numeric',
+                              })}
+                            </span>
+                            {(onSkipOccurrence || onRescheduleOccurrence) && (
+                              <div className="flex items-center gap-2">
+                                {onSkipOccurrence && (
+                                  <button
+                                    type="button"
+                                    onClick={() => onSkipOccurrence(req.Id, occurrenceDate)}
+                                    disabled={occurrenceActionLoading}
+                                    className="text-xs rounded border border-gray-300 px-2 py-1 text-gray-700 hover:bg-white disabled:opacity-50"
+                                  >
+                                    Skip
+                                  </button>
+                                )}
+                                {onRescheduleOccurrence && (
+                                  <button
+                                    type="button"
+                                    onClick={() => handleStartReschedule(req.Id, occurrenceDate)}
+                                    disabled={occurrenceActionLoading}
+                                    className="text-xs rounded border border-ui-gold-200 bg-ui-gold-50 px-2 py-1 text-ui-gold-700 hover:bg-ui-gold-100 disabled:opacity-50"
+                                  >
+                                    Move
+                                  </button>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                          {rescheduleTarget?.scheduleId === req.Id
+                            && rescheduleTarget.occurrenceDate === occurrenceDate
+                            && onRescheduleOccurrence && (
+                              <div className="flex items-center gap-2">
+                                <input
+                                  type="date"
+                                  value={replacementDate}
+                                  min={getMinDate()}
+                                  onChange={(e) => setReplacementDate(e.target.value)}
+                                  className="flex-1 rounded-md border border-gray-300 px-2 py-1 text-xs focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
+                                />
+                                <button
+                                  type="button"
+                                  onClick={async () => {
+                                    if (!replacementDate) return;
+                                    await onRescheduleOccurrence(req.Id, occurrenceDate, replacementDate);
+                                    handleCancelReschedule();
+                                  }}
+                                  disabled={occurrenceActionLoading || !replacementDate}
+                                  className="text-xs rounded bg-ui-gold-600 px-2 py-1 text-white hover:bg-ui-gold-700 disabled:opacity-50"
+                                >
+                                  Save
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={handleCancelReschedule}
+                                  disabled={occurrenceActionLoading}
+                                  className="text-xs rounded border border-gray-300 px-2 py-1 text-gray-600 hover:bg-white disabled:opacity-50"
+                                >
+                                  Cancel
+                                </button>
+                              </div>
+                            )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
                 )}
               </dd>
             ))}

--- a/frontend/src/components/submission/SchedulePrefs.tsx
+++ b/frontend/src/components/submission/SchedulePrefs.tsx
@@ -6,6 +6,9 @@ interface ScheduleEntry {
   Repeat_Note: string;
   Is_Flexible: boolean;
   Flexible_Deadline: string;
+  Recurrence_Type: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday';
+  Recurrence_Interval: number;
+  Recurrence_End_Date: string;
 }
 
 interface Props {
@@ -13,6 +16,7 @@ interface Props {
   onChange: (schedule: ScheduleEntry) => void;
   targetNewsletter: TargetNewsletter;
   validDates?: Set<string>;
+  showRecurrenceControls?: boolean;
 }
 
 function validateDate(
@@ -48,12 +52,23 @@ function getMinDate(): string {
   return tomorrow.toISOString().split('T')[0];
 }
 
-export default function SchedulePrefs({ schedule, onChange, targetNewsletter, validDates }: Props) {
+export default function SchedulePrefs({
+  schedule,
+  onChange,
+  targetNewsletter,
+  validDates,
+  showRecurrenceControls = false,
+}: Props) {
   const update = (field: keyof ScheduleEntry, value: string | number | boolean) => {
     onChange({ ...schedule, [field]: value });
   };
 
   const dateError = validateDate(schedule.Requested_Date, targetNewsletter, validDates);
+  const recurrenceEndError = schedule.Recurrence_Type !== 'once'
+    && schedule.Recurrence_End_Date
+    && schedule.Recurrence_End_Date < schedule.Requested_Date
+      ? 'End date cannot be before the first run date.'
+      : null;
 
   return (
     <div>
@@ -102,6 +117,88 @@ export default function SchedulePrefs({ schedule, onChange, targetNewsletter, va
           </select>
         </div>
       </div>
+      {showRecurrenceControls ? (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-3">
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">
+              Repeat on a cadence
+            </label>
+            <select
+              value={schedule.Recurrence_Type}
+              onChange={(e) => {
+                const recurrenceType = e.target.value as ScheduleEntry['Recurrence_Type'];
+                onChange({
+                  ...schedule,
+                  Recurrence_Type: recurrenceType,
+                  Recurrence_Interval: 1,
+                  ...(recurrenceType === 'once' ? { Recurrence_End_Date: '' } : {}),
+                });
+              }}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
+            >
+              <option value="once">One time</option>
+              <option value="weekly">Weekly</option>
+              <option value="monthly_date">Monthly on this date</option>
+              <option value="monthly_nth_weekday">Monthly on this weekday pattern</option>
+            </select>
+            <p className="text-xs text-gray-400 mt-1">
+              Use this for recurring items like every Friday or first Monday.
+            </p>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">
+              Interval
+            </label>
+            <input
+              type="number"
+              min={1}
+              max={12}
+              value={schedule.Recurrence_Interval}
+              onChange={(e) => update('Recurrence_Interval', parseInt(e.target.value, 10) || 1)}
+              disabled={schedule.Recurrence_Type === 'once'}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500 disabled:bg-gray-50 disabled:text-gray-400"
+            />
+            <p className="text-xs text-gray-400 mt-1">
+              {schedule.Recurrence_Type === 'weekly'
+                ? 'Every N weeks'
+                : schedule.Recurrence_Type === 'once'
+                  ? 'Not used for one-time requests'
+                  : 'Every N months'}
+            </p>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">
+              Stop after
+            </label>
+            <input
+              type="date"
+              value={schedule.Recurrence_End_Date}
+              onChange={(e) => update('Recurrence_End_Date', e.target.value)}
+              disabled={schedule.Recurrence_Type === 'once'}
+              min={schedule.Requested_Date || getMinDate()}
+              className={`w-full rounded-md border px-3 py-2 text-sm focus:ring-1 disabled:bg-gray-50 disabled:text-gray-400 ${
+                recurrenceEndError
+                  ? 'border-red-400 focus:border-red-500 focus:ring-red-500'
+                  : 'border-gray-300 focus:border-ui-gold-500 focus:ring-ui-gold-500'
+              }`}
+            />
+            {recurrenceEndError && (
+              <p className="text-xs text-red-600 mt-1">{recurrenceEndError}</p>
+            )}
+            {!recurrenceEndError && (
+              <p className="text-xs text-gray-400 mt-1">
+                Optional. Leave blank to keep running.
+              </p>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="mt-3 rounded-md border border-gray-200 bg-gray-50 px-3 py-2">
+          <p className="text-xs text-gray-600">
+            Recurring scheduling is managed by UCM staff after submission when needed.
+          </p>
+        </div>
+      )}
       <div className="mt-3">
         <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
           <input
@@ -135,7 +232,7 @@ export default function SchedulePrefs({ schedule, onChange, targetNewsletter, va
         </label>
         <input
           type="text"
-          placeholder="e.g., 'Please run on April 3 and again on April 10'"
+          placeholder="e.g., 'Please skip finals week if needed'"
           value={schedule.Repeat_Note}
           onChange={(e) => update('Repeat_Note', e.target.value)}
           className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"

--- a/frontend/src/components/submission/SubmissionForm.tsx
+++ b/frontend/src/components/submission/SubmissionForm.tsx
@@ -32,6 +32,9 @@ interface ScheduleEntry {
   Repeat_Note: string;
   Is_Flexible: boolean;
   Flexible_Deadline: string;
+  Recurrence_Type: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday';
+  Recurrence_Interval: number;
+  Recurrence_End_Date: string;
 }
 
 const FALLBACK_CATEGORIES: AllowedValue[] = [
@@ -126,6 +129,9 @@ export default function SubmissionForm() {
     Repeat_Note: '',
     Is_Flexible: false,
     Flexible_Deadline: '',
+    Recurrence_Type: 'once',
+    Recurrence_Interval: 1,
+    Recurrence_End_Date: '',
   });
 
   const [validDates, setValidDates] = useState<Set<string>>(new Set());
@@ -226,10 +232,21 @@ export default function SubmissionForm() {
     return false;
   };
 
+  const hasRecurrenceEndError = (): boolean => (
+    schedule.Recurrence_Type !== 'once'
+    && !!schedule.Recurrence_End_Date
+    && !!schedule.Requested_Date
+    && schedule.Recurrence_End_Date < schedule.Requested_Date
+  );
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (hasDateError()) {
       setError('Please select a valid run date for the chosen newsletter.');
+      return;
+    }
+    if (hasRecurrenceEndError()) {
+      setError('Please choose a recurrence end date on or after the first run date.');
       return;
     }
     setSubmitting(true);
@@ -256,6 +273,9 @@ export default function SubmissionForm() {
             Repeat_Note: schedule.Repeat_Note || undefined,
             Is_Flexible: schedule.Is_Flexible || undefined,
             Flexible_Deadline: schedule.Flexible_Deadline || undefined,
+            Recurrence_Type: isStaff ? schedule.Recurrence_Type : 'once',
+            Recurrence_Interval: isStaff ? schedule.Recurrence_Interval : 1,
+            Recurrence_End_Date: isStaff ? schedule.Recurrence_End_Date || undefined : undefined,
           },
         ],
       };
@@ -269,7 +289,16 @@ export default function SubmissionForm() {
       setNotes('');
       setSurveyEndDate('');
       setLinks([]);
-      setSchedule({ Requested_Date: '', Repeat_Count: 1, Repeat_Note: '', Is_Flexible: false, Flexible_Deadline: '' });
+      setSchedule({
+        Requested_Date: '',
+        Repeat_Count: 1,
+        Repeat_Note: '',
+        Is_Flexible: false,
+        Flexible_Deadline: '',
+        Recurrence_Type: 'once',
+        Recurrence_Interval: 1,
+        Recurrence_End_Date: '',
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Submission failed');
     } finally {
@@ -377,7 +406,13 @@ export default function SubmissionForm() {
         <h3 className="text-lg font-semibold text-gray-900 border-b pb-3">
           Scheduling
         </h3>
-        <SchedulePrefs schedule={schedule} onChange={setSchedule} targetNewsletter={targetNewsletter} validDates={validDates.size > 0 ? validDates : undefined} />
+        <SchedulePrefs
+          schedule={schedule}
+          onChange={setSchedule}
+          targetNewsletter={targetNewsletter}
+          validDates={validDates.size > 0 ? validDates : undefined}
+          showRecurrenceControls={isStaff}
+        />
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
             Additional Notes for Editors

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -5,6 +5,7 @@ import { getValidDates } from '../api/schedule';
 import type { Submission, SubmissionStatus } from '../types/submission';
 import CalendarView from '../components/dashboard/CalendarView';
 import DayDetail from '../components/dashboard/DayDetail';
+import { getPrimaryOccurrenceDate } from '../utils/submissionOccurrences';
 
 const STATUS_COLORS: Record<string, string> = {
   new: 'bg-blue-100 text-blue-800',
@@ -312,8 +313,8 @@ export default function DashboardPage() {
                     {sub.Has_Image && <span>Has image</span>}
                     {sub.Schedule_Requests.length > 0 && (
                       <span>
-                        {sub.Schedule_Requests[0].Requested_Date
-                          ? `Run: ${new Date(sub.Schedule_Requests[0].Requested_Date + 'T12:00:00').toLocaleDateString()}`
+                        {getPrimaryOccurrenceDate(sub)
+                          ? `Run: ${new Date(getPrimaryOccurrenceDate(sub)! + 'T12:00:00').toLocaleDateString()}`
                           : 'Schedule prefs'}
                       </span>
                     )}

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { getSubmission, updateSubmission } from '../api/submissions';
+import {
+  getSubmission,
+  rescheduleScheduleOccurrence,
+  skipScheduleOccurrence,
+  updateSubmission,
+} from '../api/submissions';
 import { triggerAIEdit, listEditVersions, saveEditorFinal } from '../api/aiEdits';
 import type { Submission, TargetNewsletter } from '../types/submission';
 import type { AIEditResponse, EditVersion, AIFlag, TextDiff } from '../types/aiEdit';
@@ -13,6 +18,7 @@ import ChangesList from '../components/editor/ChangesList';
 import SideBySideView from '../components/editor/SideBySideView';
 import SubmissionMeta from '../components/editor/SubmissionMeta';
 import RichBody from '../components/editor/RichBody';
+import { getSubmitterRole } from '../utils/submitterRole';
 
 type Tab = 'original' | 'ai_edit' | 'editor';
 type ViewMode = 'diff' | 'side_by_side';
@@ -41,12 +47,14 @@ export default function EditPage() {
   const [saveLoading, setSaveLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+  const [occurrenceActionLoading, setOccurrenceActionLoading] = useState(false);
 
   const [viewMode, setViewMode] = useState<ViewMode>('diff');
 
   // Editor state
   const [editHeadline, setEditHeadline] = useState('');
   const [editBody, setEditBody] = useState('');
+  const isStaff = getSubmitterRole() === 'staff';
 
   useEffect(() => {
     if (id) loadData();
@@ -229,6 +237,40 @@ export default function EditPage() {
       await loadData();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to change newsletter');
+    }
+  };
+
+  const handleSkipOccurrence = async (scheduleId: string, occurrenceDate: string) => {
+    if (!id) return;
+    setOccurrenceActionLoading(true);
+    try {
+      await skipScheduleOccurrence(id, scheduleId, occurrenceDate);
+      showToast(`Skipped occurrence on ${new Date(`${occurrenceDate}T12:00:00`).toLocaleDateString()}`);
+      await loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to skip occurrence');
+    } finally {
+      setOccurrenceActionLoading(false);
+    }
+  };
+
+  const handleRescheduleOccurrence = async (
+    scheduleId: string,
+    occurrenceDate: string,
+    newDate: string,
+  ) => {
+    if (!id) return;
+    setOccurrenceActionLoading(true);
+    try {
+      await rescheduleScheduleOccurrence(id, scheduleId, occurrenceDate, newDate);
+      showToast(
+        `Moved ${new Date(`${occurrenceDate}T12:00:00`).toLocaleDateString()} to ${new Date(`${newDate}T12:00:00`).toLocaleDateString()}`,
+      );
+      await loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to move occurrence');
+    } finally {
+      setOccurrenceActionLoading(false);
     }
   };
 
@@ -493,7 +535,13 @@ export default function EditPage() {
             targetNewsletter={submission.Target_Newsletter}
             confidence={confidence}
           />
-          <SubmissionMeta submission={submission} onChangeNewsletter={handleChangeNewsletter} />
+          <SubmissionMeta
+            submission={submission}
+            onChangeNewsletter={handleChangeNewsletter}
+            onSkipOccurrence={isStaff ? handleSkipOccurrence : undefined}
+            onRescheduleOccurrence={isStaff ? handleRescheduleOccurrence : undefined}
+            occurrenceActionLoading={isStaff ? occurrenceActionLoading : false}
+          />
 
           {/* Request More Info / Pending Info controls */}
           {submission.Status === 'pending_info' ? (

--- a/frontend/src/types/submission.ts
+++ b/frontend/src/types/submission.ts
@@ -38,6 +38,11 @@ export interface SubmissionScheduleRequest {
   Repeat_Note: string | null;
   Is_Flexible: boolean;
   Flexible_Deadline: string | null;
+  Recurrence_Type: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday';
+  Recurrence_Interval: number;
+  Recurrence_End_Date: string | null;
+  Excluded_Dates: string[];
+  Occurrence_Dates: string[];
 }
 
 export interface Submission {
@@ -57,6 +62,7 @@ export interface Submission {
   Updated_At: string;
   Links: SubmissionLink[];
   Schedule_Requests: SubmissionScheduleRequest[];
+  Occurrence_Dates: string[];
 }
 
 export interface SubmissionCreate {
@@ -69,5 +75,15 @@ export interface SubmissionCreate {
   Submitter_Notes?: string;
   Survey_End_Date?: string;
   Links?: { Url: string; Anchor_Text?: string }[];
-  Schedule_Requests?: { Requested_Date?: string; Repeat_Count?: number; Repeat_Note?: string; Is_Flexible?: boolean; Flexible_Deadline?: string }[];
+  Schedule_Requests?: {
+    Requested_Date?: string;
+    Repeat_Count?: number;
+    Repeat_Note?: string;
+    Is_Flexible?: boolean;
+    Flexible_Deadline?: string;
+    Recurrence_Type?: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday';
+    Recurrence_Interval?: number;
+    Recurrence_End_Date?: string;
+    Excluded_Dates?: string[];
+  }[];
 }

--- a/frontend/src/utils/submissionOccurrences.ts
+++ b/frontend/src/utils/submissionOccurrences.ts
@@ -1,0 +1,22 @@
+import type { Submission } from '../types/submission';
+
+export function getOccurrenceDates(submission: Submission): string[] {
+  if (submission.Occurrence_Dates.length > 0) {
+    return submission.Occurrence_Dates;
+  }
+
+  const scheduleOccurrences = submission.Schedule_Requests.flatMap((request) => (
+    request.Occurrence_Dates.length > 0
+      ? request.Occurrence_Dates
+      : [request.Requested_Date]
+  ));
+
+  return scheduleOccurrences
+    .filter((date): date is string => Boolean(date));
+}
+
+
+export function getPrimaryOccurrenceDate(submission: Submission): string | null {
+  const dates = getOccurrenceDates(submission);
+  return dates.length > 0 ? dates[0] : null;
+}


### PR DESCRIPTION
## Summary
- add recurring schedule support for submissions, including weekly and monthly patterns
- expand recurring occurrences into dashboard/calendar views and newsletter assembly
- add staff-only skip and reschedule controls for individual occurrences, plus an Alembic migration for the new schedule fields

## Scope notes
- recurring scheduling is enforced as a staff-only capability in the API
- public submitters still submit one-off date preferences; recurrence is managed by staff/editor workflows

## Testing
- backend/.venv/bin/pytest tests/test_submissions.py tests/test_newsletters.py
- backend/.venv/bin/ruff check app/api/v1/submissions.py tests/test_submissions.py
- frontend/npm run build
- frontend/npm run lint -- --quiet

Closes #23