### PR TITLE
Use configured database URL for Alembic

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,10 +1,13 @@
+import asyncio
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool
+from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
 
 from app.db.base import Base
+from app.config import settings
 import app.models  # noqa: F401 — register all models
 
 config = context.config
@@ -13,38 +16,55 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 target_metadata = Base.metadata
+database_url = settings.database_url
+config.set_main_option("sqlalchemy.url", database_url)
+
+
+def do_run_migrations(connection) -> None:
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        render_as_batch=database_url.startswith("sqlite"),
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
 
 
 def run_migrations_offline() -> None:
-    url = config.get_main_option("sqlalchemy.url")
     context.configure(
-        url=url,
+        url=database_url,
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
-        render_as_batch=True,
+        render_as_batch=database_url.startswith("sqlite"),
     )
     with context.begin_transaction():
         context.run_migrations()
 
 
-def run_migrations_online() -> None:
-    connectable = engine_from_config(
+async def run_migrations_online() -> None:
+    if not database_url.startswith(("sqlite+aiosqlite", "postgresql+asyncpg")):
+        connectable = engine_from_config(
+            config.get_section(config.config_ini_section, {}),
+            prefix="sqlalchemy.",
+            poolclass=pool.NullPool,
+        )
+        with connectable.connect() as connection:
+            do_run_migrations(connection)
+        return
+
+    connectable = async_engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )
-    with connectable.connect() as connection:
-        context.configure(
-            connection=connection,
-            target_metadata=target_metadata,
-            render_as_batch=True,
-        )
-        with context.begin_transaction():
-            context.run_migrations()
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
 
 
 if context.is_offline_mode():
     run_migrations_offline()
 else:
-    run_migrations_online()
+    asyncio.run(run_migrations_online())


### PR DESCRIPTION
## Summary
- make Alembic use the same configured DATABASE_URL as the application
- support async PostgreSQL migration URLs while preserving SQLite migration support
- prevent deploy-time migration commands from silently falling back to sqlite:///./ucm_newsletter.db

## Notes
- this fixes deployment tooling rather than runtime app connectivity; the running app containers were already pointed at PostgreSQL
- after merge/deploy, the correct follow-up is to stamp the live Postgres databases at head so future migrations are tracked there

## Verification
- DATABASE_URL=sqlite:////tmp/ucm_alembic_smoke.db ./.venv/bin/alembic -c alembic.ini upgrade head

Closes #53