### PR TITLE
Address Joy's feedback batch: UI fixes and AI style rules

### DIFF
--- a/backend/app/services/ai/prompts.py
+++ b/backend/app/services/ai/prompts.py
@@ -87,6 +87,7 @@ Your task is to edit submissions to comply with the university's editorial style
 - Follow submitter notes for link placement (e.g., "Link 'text' to URL").
 - Use action-oriented anchor text: "Register online", "Learn more", "Get your tickets".
 - For email links (mailto:), use `<a href="mailto:email@example.com">display text</a>`. For individual email addresses, use the person's name as the link text. For general/shared addresses, the email address itself is acceptable as link text.
+- NEVER duplicate link anchor text in the surrounding sentence. Integrate the link naturally so the anchor text appears exactly once. BAD: "and online via <a href='...'>online</a>". GOOD: "and <a href='...'>online</a>".
 
 ### Length and Structure
 - Trim verbose submissions to essential information. Produce exactly one paragraph.
@@ -99,7 +100,7 @@ Your task is to edit submissions to comply with the university's editorial style
 
 ## Important Notes
 - Preserve the core meaning and all factual details of the submission.
-- Do not add information that was not in the original.
+- **CRITICAL: Do not add ANY information, facts, names, links, or references that were not in the original submission. Do not combine or reference content from other submissions. Every sentence in your output must trace back to the original submission text. If something was not submitted, do not include it.**
 - When in doubt about a factual claim, preserve it and flag it for human review.
 - Always embed links with meaningful anchor text, never raw URLs in the final text.
 - The submitter notes often contain critical link instructions — always follow them."""

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -220,5 +220,47 @@
     "rule_key": "dei_language_flag",
     "rule_text": "Flag language that could reasonably be read as Diversity, Equity and Inclusion-related for editor review, even if it may ultimately be acceptable.",
     "severity": "warning"
+  },
+  {
+    "category": "content_filtering",
+    "rule_key": "no_fabricated_content",
+    "rule_text": "NEVER add information, facts, names, URLs, or references that are not present in the original submission. Every detail in the edited version must be traceable to the submitted text. Do not merge or cross-reference content from other submissions.",
+    "severity": "error"
+  },
+  {
+    "category": "formatting",
+    "rule_key": "no_duplicate_link_text",
+    "rule_text": "When embedding a hyperlink, do not repeat the anchor text in the surrounding sentence. Integrate the link so the anchor text appears exactly once. Example: write 'and <a>online</a>' not 'and online via <a>online</a>'.",
+    "severity": "warning"
+  },
+  {
+    "category": "formatting",
+    "rule_key": "capitalize_proper_names",
+    "rule_text": "Capitalize proper names, event titles, and program names in both headlines and body text. Example: 'Pizza & the Past' not 'pizza & the past'. This applies even in sentence-case headlines.",
+    "severity": "error"
+  },
+  {
+    "category": "formatting",
+    "rule_key": "online_not_platform",
+    "rule_text": "Use the word 'online' instead of platform names like 'Zoom', 'Teams', or 'Webex' when describing virtual attendance options, unless the platform name is essential (e.g., a Teams-specific training).",
+    "severity": "warning"
+  },
+  {
+    "category": "voice",
+    "rule_key": "short_sentences",
+    "rule_text": "Write short, clear sentences. Avoid run-on sentences and compound-complex structures. Break long sentences into two or more shorter ones for readability.",
+    "severity": "warning"
+  },
+  {
+    "category": "formatting",
+    "rule_key": "research_study_format",
+    "rule_text": "Research participant recruitment announcements should begin with 'Researchers are recruiting participants for a study...' followed by a brief description of the study topic and compensation details.",
+    "severity": "info"
+  },
+  {
+    "category": "headlines",
+    "rule_key": "headline_reader_perspective",
+    "rule_text": "Headlines must be written from the reader's perspective using verbs that address what the reader can do. Example: 'Participate in VR research study' not 'Recruit research participants'. The headline should tell the reader what action they can take.",
+    "severity": "warning"
   }
 ]

--- a/frontend/src/components/dashboard/CalendarView.tsx
+++ b/frontend/src/components/dashboard/CalendarView.tsx
@@ -179,18 +179,44 @@ export default function CalendarView({
       </div>
 
       {/* Legend */}
-      {validDates && (
-        <div className="px-4 py-2 border-t border-gray-100 flex items-center gap-4 text-xs text-gray-500">
+      <div className="px-4 py-2 border-t border-gray-100 space-y-1.5">
+        {validDates && (
+          <div className="flex items-center gap-4 text-xs text-gray-500">
+            <span className="text-gray-400 font-medium">Pub days:</span>
+            <span className="flex items-center gap-1">
+              <span className="w-2 h-2 rounded-full bg-ui-gold-500" />
+              TDR
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="w-2 h-2 rounded-full bg-blue-500" />
+              My UI
+            </span>
+          </div>
+        )}
+        <div className="flex items-center gap-3 text-xs text-gray-500 flex-wrap">
+          <span className="text-gray-400 font-medium">Status:</span>
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-ui-gold-500" />
-            TDR
+            <span className="w-2 h-2 rounded-full bg-blue-400" />
+            New
           </span>
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-blue-500" />
-            My UI
+            <span className="w-2 h-2 rounded-full bg-purple-400" />
+            AI Edited
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-yellow-400" />
+            In Review
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-green-400" />
+            Approved
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-cyan-400" />
+            Scheduled
           </span>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/dashboard/WeekOverview.tsx
+++ b/frontend/src/components/dashboard/WeekOverview.tsx
@@ -74,8 +74,7 @@ export default function WeekOverview({
   return (
     <div className="bg-white rounded-lg shadow p-4">
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-semibold text-gray-900">Week Overview</h3>
-        <span className="text-xs text-gray-500">{weekLabel}</span>
+        <h3 className="text-sm font-semibold text-gray-900">Week of {weekLabel}</h3>
       </div>
 
       <div className="grid grid-cols-5 gap-2">

--- a/frontend/src/components/submission/LinkEditor.tsx
+++ b/frontend/src/components/submission/LinkEditor.tsx
@@ -82,6 +82,7 @@ export default function LinkEditor({ links, onChange }: Props) {
                       placeholder="name@uidaho.edu"
                       value={link.Url.replace(/^mailto:/, '')}
                       onChange={(e) => handleEmailChange(index, e.target.value)}
+                      autoComplete="off"
                       className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
                     />
                   ) : (
@@ -90,6 +91,7 @@ export default function LinkEditor({ links, onChange }: Props) {
                       placeholder="https://..."
                       value={link.Url}
                       onChange={(e) => updateLink(index, 'Url', e.target.value)}
+                      autoComplete="off"
                       className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
                     />
                   )}
@@ -105,6 +107,7 @@ export default function LinkEditor({ links, onChange }: Props) {
                     placeholder={emailMode ? "e.g., Jane Smith" : "e.g., Learn more"}
                     value={link.Anchor_Text}
                     onChange={(e) => updateLink(index, 'Anchor_Text', e.target.value)}
+                    autoComplete="off"
                     className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
                   />
                 </div>

--- a/frontend/src/components/submission/SchedulePrefs.tsx
+++ b/frontend/src/components/submission/SchedulePrefs.tsx
@@ -345,6 +345,7 @@ export default function SchedulePrefs({
           placeholder="e.g., 'Please skip finals week if needed'"
           value={schedule.Repeat_Note}
           onChange={(e) => update('Repeat_Note', e.target.value)}
+          autoComplete="off"
           className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
         />
       </div>

--- a/frontend/src/components/submission/SubmissionForm.tsx
+++ b/frontend/src/components/submission/SubmissionForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { listAllowedValues } from '../../api/allowedValues';
 import type { SubmissionCategory, TargetNewsletter, SubmissionCreate } from '../../types/submission';
 import type { AllowedValue } from '../../types/allowedValue';
@@ -154,6 +154,7 @@ export default function SubmissionForm() {
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const successRef = useRef<HTMLDivElement>(null);
   const isJobOpportunity = category === 'job_opportunity';
   const effectiveTargetNewsletter: TargetNewsletter = isJobOpportunity ? 'tdr' : targetNewsletter;
 
@@ -241,12 +242,20 @@ export default function SubmissionForm() {
   }, [effectiveTargetNewsletter]);
 
   // Filter categories by newsletter target; staff-visibility categories
-  // (already gated by backend) always pass through
-  const filteredCategories = categories.filter(
-    (cat) =>
-      cat.Visibility_Role === 'staff' ||
-      NEWSLETTER_CATEGORY_CODES[effectiveTargetNewsletter]?.has(cat.Code),
-  );
+  // (already gated by backend) always pass through.
+  // When "Both Newsletters" is selected, relabel "Faculty/Staff" as
+  // "News and Updates" so the dropdown matches the My UI section name.
+  const filteredCategories = categories
+    .filter(
+      (cat) =>
+        cat.Visibility_Role === 'staff' ||
+        NEWSLETTER_CATEGORY_CODES[effectiveTargetNewsletter]?.has(cat.Code),
+    )
+    .map((cat) =>
+      effectiveTargetNewsletter === 'both' && cat.Code === 'faculty_staff'
+        ? { ...cat, Label: 'News and Updates' }
+        : cat,
+    );
 
   // Clear date and reset category when newsletter target changes
   const handleTargetChange = (target: TargetNewsletter) => {
@@ -387,6 +396,7 @@ export default function SubmissionForm() {
       await createSubmission(data);
 
       setSuccess(true);
+      setTimeout(() => successRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' }), 100);
       // Reset form
       setHeadline('');
       setBody('');
@@ -679,7 +689,7 @@ export default function SubmissionForm() {
       </div>
 
       {success && (
-        <div className="rounded-md bg-green-50 border border-green-200 p-4">
+        <div ref={successRef} className="rounded-md bg-green-50 border border-green-200 p-4">
           <p className="text-sm text-green-800">
             Submission received! An editor will review it for the newsletter.
           </p>

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -50,7 +50,7 @@ export default function EditPage() {
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
   const [occurrenceActionLoading, setOccurrenceActionLoading] = useState(false);
 
-  const [viewMode, setViewMode] = useState<ViewMode>('diff');
+  const [viewMode, setViewMode] = useState<ViewMode>('side_by_side');
 
   // Editor state
   const [editHeadline, setEditHeadline] = useState('');


### PR DESCRIPTION
## Summary
- **#76** Relabel "Faculty/Staff" → "News and Updates" when Both Newsletters selected
- **#77** Add `autoComplete="off"` to scheduling notes, URL, and anchor text inputs to prevent browser autofill pollution
- **#78** Auto-scroll to success message after submission so it's visible without scrolling
- **#79** Add status dot legend (New, AI Edited, In Review, Approved, Scheduled) to calendar; improve Week Overview header to "Week of Mar 30 — Apr 3" format
- **#80** Default diff view to Side by Side instead of Inline Diff
- **#81** Strengthen anti-hallucination guardrails in AI system prompt to prevent cross-contamination between submissions
- **#82** Add link text duplication prevention rule and prompt guidance
- **#83** Add 8 new style rules: `no_fabricated_content`, `no_duplicate_link_text`, `capitalize_proper_names`, `online_not_platform`, `short_sentences`, `research_study_format`, `headline_reader_perspective`

## Test plan
- [ ] Submit form with "Both Newsletters" selected — verify dropdown shows "News and Updates"
- [ ] Use browser autofill on name/email — verify scheduling notes and link fields are not polluted
- [ ] Submit an announcement — verify success message scrolls into view
- [ ] Check editor dashboard calendar — verify status dot legend is visible
- [ ] Open Edit Submission page — verify Side by Side is the default view
- [ ] Run AI edit on a test submission — verify no cross-contamination and proper link handling
- [ ] `cd backend && pytest` — 86 tests pass
- [ ] `cd frontend && npm run build` — clean build

Closes #76, #77, #78, #79, #80, #81, #82, #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)