### PR TITLE
Add missing migration for Holiday_Shift_Enabled column

### DIFF
--- a/backend/alembic/versions/d2e3f4a5b6c7_add_holiday_shift_enabled_to_schedule_configs.py
+++ b/backend/alembic/versions/d2e3f4a5b6c7_add_holiday_shift_enabled_to_schedule_configs.py
@@ -1,0 +1,30 @@
+"""add Holiday_Shift_Enabled to schedule_configs
+
+Revision ID: d2e3f4a5b6c7
+Revises: b8f9c2d4e6a1
+Create Date: 2026-03-31 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d2e3f4a5b6c7"
+down_revision: Union[str, Sequence[str], None] = "b8f9c2d4e6a1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "schedule_configs",
+        sa.Column("Holiday_Shift_Enabled", sa.Boolean(), nullable=True, server_default=sa.text("false")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("schedule_configs", "Holiday_Shift_Enabled")


### PR DESCRIPTION
## Summary
- Adds the Alembic migration for the `Holiday_Shift_Enabled` column on `schedule_configs` that was missing, causing the Postgres CI smoke test to fail

## Root cause
The column was added to the `ScheduleConfig` model but no migration was generated. CI runs `alembic upgrade head` which creates the table without this column, then the ORM query fails with `UndefinedColumnError`.

## Test plan
- [ ] CI Postgres smoke test should now pass
- [ ] `cd backend && pytest` — 86 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)