### PR TITLE
Add calendar date picker for editor scheduling (#65)

### DIFF
--- a/frontend/src/api/submissions.ts
+++ b/frontend/src/api/submissions.ts
@@ -86,6 +86,19 @@ export async function rescheduleScheduleOccurrence(
   );
 }
 
+export async function addScheduleRequest(
+  submissionId: string,
+  data: { Requested_Date: string; Second_Requested_Date?: string },
+): Promise<SubmissionScheduleRequest> {
+  return apiFetch<SubmissionScheduleRequest>(
+    `/submissions/${submissionId}/schedule`,
+    {
+      method: 'POST',
+      body: JSON.stringify(data),
+    },
+  );
+}
+
 export async function uploadImage(submissionId: string, file: File): Promise<Submission> {
   const formData = new FormData();
   formData.append('file', file);

--- a/frontend/src/components/editor/SubmissionMeta.tsx
+++ b/frontend/src/components/editor/SubmissionMeta.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Submission, TargetNewsletter } from '../../types/submission';
+import { getValidDates } from '../../api/schedule';
 
 interface SubmissionMetaProps {
   submission: Submission;
@@ -10,6 +11,7 @@ interface SubmissionMetaProps {
     occurrenceDate: string,
     newDate: string,
   ) => Promise<void>;
+  onAddScheduleDate?: (newsletter: string, date: string) => Promise<void>;
   occurrenceActionLoading?: boolean;
 }
 
@@ -43,6 +45,7 @@ export default function SubmissionMeta({
   onChangeNewsletter,
   onSkipOccurrence,
   onRescheduleOccurrence,
+  onAddScheduleDate,
   occurrenceActionLoading = false,
 }: SubmissionMetaProps) {
   const [rescheduleTarget, setRescheduleTarget] = useState<{
@@ -51,10 +54,78 @@ export default function SubmissionMeta({
   } | null>(null);
   const [replacementDate, setReplacementDate] = useState('');
 
+  const [showAddDate, setShowAddDate] = useState(false);
+  const [addDateNewsletter, setAddDateNewsletter] = useState('');
+  const [addDateValue, setAddDateValue] = useState('');
+  const [addDateLoading, setAddDateLoading] = useState(false);
+  const [addDateError, setAddDateError] = useState('');
+  const [validDatesSet, setValidDatesSet] = useState<Set<string>>(new Set());
+
   const getMinDate = () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
     return tomorrow.toISOString().split('T')[0];
+  };
+
+  const getMaxDate = () => {
+    const d = new Date();
+    d.setDate(d.getDate() + 90);
+    return d.toISOString().split('T')[0];
+  };
+
+  const resolveNewsletter = () => {
+    if (submission.Target_Newsletter === 'both') return addDateNewsletter;
+    return submission.Target_Newsletter;
+  };
+
+  useEffect(() => {
+    if (!showAddDate) return;
+    const nl = resolveNewsletter();
+    if (!nl) {
+      setValidDatesSet(new Set());
+      return;
+    }
+    let cancelled = false;
+    getValidDates(getMinDate(), getMaxDate(), nl).then((resp) => {
+      if (cancelled) return;
+      const dates = new Set(resp.dates.map((d) => d.date));
+      setValidDatesSet(dates);
+    });
+    return () => { cancelled = true; };
+  }, [showAddDate, addDateNewsletter, submission.Target_Newsletter]);
+
+  const handleOpenAddDate = () => {
+    setShowAddDate(true);
+    setAddDateValue('');
+    setAddDateError('');
+    setAddDateNewsletter(submission.Target_Newsletter === 'both' ? '' : submission.Target_Newsletter);
+  };
+
+  const handleCancelAddDate = () => {
+    setShowAddDate(false);
+    setAddDateValue('');
+    setAddDateError('');
+    setAddDateNewsletter('');
+  };
+
+  const handleSaveAddDate = async () => {
+    const nl = resolveNewsletter();
+    if (!nl || !addDateValue || !onAddScheduleDate) return;
+    if (!validDatesSet.has(addDateValue)) {
+      const label = nl === 'myui' ? 'My UI (Mondays only)' : 'The Daily Register';
+      setAddDateError(`Not a valid publication date for ${label}.`);
+      return;
+    }
+    setAddDateLoading(true);
+    setAddDateError('');
+    try {
+      await onAddScheduleDate(nl, addDateValue);
+      handleCancelAddDate();
+    } catch (err) {
+      setAddDateError(err instanceof Error ? err.message : 'Failed to add date');
+    } finally {
+      setAddDateLoading(false);
+    }
   };
 
   const handleStartReschedule = (scheduleId: string, occurrenceDate: string) => {
@@ -252,6 +323,84 @@ export default function SubmissionMeta({
                 )}
               </dd>
             ))}
+          </div>
+        )}
+        {onAddScheduleDate && !showAddDate && (
+          <div>
+            <button
+              type="button"
+              onClick={handleOpenAddDate}
+              className="text-xs rounded border border-dashed border-gray-300 px-3 py-1.5 text-gray-600 hover:border-ui-gold-400 hover:text-ui-gold-700 hover:bg-ui-gold-50 w-full"
+            >
+              + Add Run Date
+            </button>
+          </div>
+        )}
+        {onAddScheduleDate && showAddDate && (
+          <div className="rounded-md border border-ui-gold-200 bg-ui-gold-50 p-3 space-y-2">
+            <div className="text-xs font-medium text-gray-700">Add Run Date</div>
+            {submission.Target_Newsletter === 'both' && (
+              <div className="flex gap-3">
+                <label className="flex items-center gap-1 text-xs text-gray-700">
+                  <input
+                    type="radio"
+                    name="addDateNewsletter"
+                    value="tdr"
+                    checked={addDateNewsletter === 'tdr'}
+                    onChange={() => { setAddDateNewsletter('tdr'); setAddDateValue(''); setAddDateError(''); }}
+                    className="accent-ui-gold-600"
+                  />
+                  Daily Register
+                </label>
+                <label className="flex items-center gap-1 text-xs text-gray-700">
+                  <input
+                    type="radio"
+                    name="addDateNewsletter"
+                    value="myui"
+                    checked={addDateNewsletter === 'myui'}
+                    onChange={() => { setAddDateNewsletter('myui'); setAddDateValue(''); setAddDateError(''); }}
+                    className="accent-ui-gold-600"
+                  />
+                  My UI
+                </label>
+              </div>
+            )}
+            {(submission.Target_Newsletter !== 'both' || addDateNewsletter) && (
+              <>
+                <input
+                  type="date"
+                  value={addDateValue}
+                  min={getMinDate()}
+                  max={getMaxDate()}
+                  onChange={(e) => { setAddDateValue(e.target.value); setAddDateError(''); }}
+                  className="w-full rounded-md border border-gray-300 px-2 py-1 text-xs focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
+                />
+                {addDateValue && validDatesSet.size > 0 && validDatesSet.has(addDateValue) && (
+                  <div className="text-[10px] text-green-600">Valid publication date</div>
+                )}
+                {addDateError && (
+                  <div className="text-[10px] text-red-600">{addDateError}</div>
+                )}
+              </>
+            )}
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleSaveAddDate}
+                disabled={addDateLoading || !addDateValue || !resolveNewsletter()}
+                className="text-xs rounded bg-ui-gold-600 px-3 py-1 text-white hover:bg-ui-gold-700 disabled:opacity-50"
+              >
+                {addDateLoading ? 'Saving...' : 'Save'}
+              </button>
+              <button
+                type="button"
+                onClick={handleCancelAddDate}
+                disabled={addDateLoading}
+                className="text-xs rounded border border-gray-300 px-3 py-1 text-gray-600 hover:bg-white disabled:opacity-50"
+              >
+                Cancel
+              </button>
+            </div>
           </div>
         )}
         <div>

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
+  addScheduleRequest,
   getSubmission,
   rescheduleScheduleOccurrence,
   skipScheduleOccurrence,
@@ -345,6 +346,15 @@ export default function EditPage() {
     }
   };
 
+  const handleAddScheduleDate = async (newsletter: string, date: string) => {
+    if (!id) return;
+    await addScheduleRequest(id, { Requested_Date: date });
+    showToast(
+      `Added run date ${new Date(`${date}T12:00:00`).toLocaleDateString()} for ${newsletter === 'tdr' ? 'Daily Register' : 'My UI'}`,
+    );
+    await loadData();
+  };
+
   const showToast = (message: string, type: 'success' | 'error' = 'success') => {
     setToast({ message, type });
     setTimeout(() => setToast(null), type === 'error' ? 5000 : 3000);
@@ -613,6 +623,7 @@ export default function EditPage() {
             onChangeNewsletter={handleChangeNewsletter}
             onSkipOccurrence={isStaff ? handleSkipOccurrence : undefined}
             onRescheduleOccurrence={isStaff ? handleRescheduleOccurrence : undefined}
+            onAddScheduleDate={isStaff ? handleAddScheduleDate : undefined}
             occurrenceActionLoading={isStaff ? occurrenceActionLoading : false}
           />
 


### PR DESCRIPTION
## Summary
- Adds "Add Run Date" button to the Submission Info panel for staff editors
- Calendar-aware date picker validates against valid publication dates for the selected newsletter (TDR or My UI)
- Supports "Both Newsletters" scenario with TDR/My UI radio selection so editors can schedule different dates per newsletter

Closes #65

## Test plan
- [ ] Open a submission edit page as a staff editor
- [ ] Verify "+ Add Run Date" button appears in Submission Info panel
- [ ] Click it and select a valid TDR date — confirm it saves and appears in Upcoming Occurrences
- [ ] Test with a My UI date (must be Monday) — confirm invalid dates show error
- [ ] Test with a "Both Newsletters" submission — confirm TDR/My UI radio buttons appear
- [ ] Verify non-staff users do not see the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)