### PR TITLE
Automate migrations and seeding in backend container entrypoint

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,8 +12,9 @@ RUN pip install --no-cache-dir . ".[postgres]"
 
 COPY . .
 
-RUN mkdir -p /app/uploads
+RUN mkdir -p /app/uploads && chmod +x /app/docker-entrypoint.sh
 
 EXPOSE 8001
 
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# When starting the server, run migrations and seed reference data first.
+# Other commands (shell, one-off python, alembic revision, etc.) run without
+# the startup preamble.
+if [[ "${1:-}" == "uvicorn" ]]; then
+  echo "[entrypoint] alembic upgrade head"
+  alembic upgrade head
+
+  echo "[entrypoint] seeding reference data"
+  python -m app.db.seed
+
+  echo "[entrypoint] starting server"
+fi
+
+exec "$@"

--- a/deploy.sh
+++ b/deploy.sh
@@ -76,8 +76,8 @@ smoke_check() {
 echo "Deploying ${ENVIRONMENT} with project ${PROJECT_NAME}"
 "${COMPOSE[@]}" up -d --build
 
-echo "Applying database migrations"
-"${COMPOSE[@]}" exec -T backend alembic upgrade head
+# Migrations and seeding run automatically in the backend container entrypoint.
+# See backend/docker-entrypoint.sh.
 
 echo "Container status"
 "${COMPOSE[@]}" ps

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -82,7 +82,24 @@ CORS_ORIGINS=http://localhost:5173
 
 ## Database Seeding
 
-The seed script populates the database with initial reference data:
+The seed script populates the database with controlled vocabularies and
+reference data: `AllowedValue` records, newsletter sections, style rules,
+schedule configs, and blackout dates. **These tables are load-bearing** —
+empty tables break dropdowns, validations, and FK lookups across the app.
+
+### Docker deployments
+
+Seeding runs automatically on every backend container start via
+`backend/docker-entrypoint.sh`. No manual step required. The entrypoint
+runs in order: `alembic upgrade head` → `python -m app.db.seed` → `uvicorn`.
+
+Seeding is idempotent — it updates existing records where appropriate and
+skips rows that already exist.
+
+### Local development
+
+For a local (non-Docker) dev server, run the seed script once after creating
+your venv:
 
 ```bash
 cd backend
@@ -90,15 +107,16 @@ source .venv/bin/activate
 python -m app.db.seed
 ```
 
-This creates:
+### Running one-off commands in the container
 
-- **14 newsletter sections** (9 for TDR, 5 for My UI)
-- **37 style rules** (shared + newsletter-specific)
-- **4 schedule configs** (daily weekday for TDR, weekly Monday for My UI)
-- **AllowedValue records** across all 10 value groups
+The entrypoint only runs the migrate-and-seed preamble when the container
+is starting the server (CMD begins with `uvicorn`). Other commands skip it:
 
-!!! note "Idempotent Seeding"
-    The seed script checks for existing data before inserting. It is safe to run multiple times.
+```bash
+docker compose exec backend alembic revision --autogenerate -m "..."
+docker compose exec backend python -m app.db.seed    # re-seed manually
+docker compose exec backend bash
+```
 
 ## Running Dev Servers
 
@@ -183,8 +201,9 @@ git pull origin main
 ./deploy.sh dev
 ```
 
-The deploy script rebuilds the stack, runs `alembic upgrade head`, and then
-smoke-tests the frontend and key API routes before returning success.
+The deploy script rebuilds the stack, which triggers the backend entrypoint
+to run `alembic upgrade head` and seed reference data, and then smoke-tests
+the frontend and key API routes before returning success.
 
 ### Environment File Template
 
@@ -247,5 +266,5 @@ curl http://localhost:9280/api/v1/submissions/?limit=1
     - **File uploads** -- configure persistent storage for submission images (Docker volume or mounted directory)
     - **HTTPS** -- terminate TLS at a reverse proxy (nginx, Caddy, or cloud load balancer)
     - **Secrets** -- load API keys from environment variables, not committed `.env` files
-    - **Migrations** -- use `./deploy.sh <dev|prod>` so `alembic upgrade head` runs before smoke checks
+    - **Migrations** -- migrations and seeding run automatically in the backend container entrypoint on every start
     - **Backups** -- the `pgdata` Docker volume should be backed up regularly


### PR DESCRIPTION
Closes #89.

## Summary

- Adds `backend/docker-entrypoint.sh` that runs `alembic upgrade head` then `python -m app.db.seed` before exec'ing the CMD.
- Dockerfile sets it as `ENTRYPOINT`; CMD stays as `uvicorn ...`.
- The preamble only runs when `\$1 == uvicorn`, so one-off commands (`alembic revision`, `bash`, manual re-seed) still work without the migrate-and-seed wrapper.
- Removes the now-redundant `docker compose exec -T backend alembic upgrade head` step from `deploy.sh`.
- Updates `docs/deployment.md` to reflect the automated flow.

## Why

\`seed_all()\` was orphaned — defined in `app/db/seed.py` but never invoked at startup. A fresh Postgres deployment came up with empty `AllowedValue`, `ScheduleConfig`, `StyleRule`, `NewsletterSection`, and `BlackoutDate` tables unless an operator remembered to run \`python -m app.db.seed\` manually. Those tables are load-bearing reference data, not fixtures — empty tables silently break dropdowns, validations, and FK lookups.

## Verified locally

Ran the full chain against the dev SQLite DB:

\`\`\`
alembic upgrade head   # applied two drifted migrations
python -m app.db.seed  # all five seeders succeeded idempotently
\`\`\`

Both completed cleanly. The passthrough branch also verified — running the entrypoint with a non-uvicorn command skips the preamble and execs directly.

## Test plan

- [ ] On dev server: `./deploy.sh dev` on a fresh DB → backend comes up with all reference tables populated, no manual seed step
- [ ] Re-deploy (existing DB) → seed runs idempotently, no duplicate rows, no errors
- [ ] `docker compose exec backend alembic revision --autogenerate -m "test"` → skips the preamble, runs just the alembic command
- [ ] `docker compose exec backend python -m app.db.seed` → manual re-seed still works
- [ ] Existing pytest suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)