### PR TITLE
Add /readyz readiness probe for load-bearing reference tables

### DIFF
--- a/backend/app/api/v1/health.py
+++ b/backend/app/api/v1/health.py
@@ -1,0 +1,58 @@
+"""Liveness and readiness endpoints.
+
+`/health` is a liveness probe — returns 200 unconditionally once the app
+process is running. Use for basic up/down monitoring.
+
+`/readyz` is a readiness probe — returns 503 if any load-bearing reference
+table is empty. Use for orchestrator health checks. An empty reference table
+means seeding failed or was skipped, and the app will serve broken
+dropdowns, validations, and FK lookups.
+"""
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_db
+from app.models.allowed_value import AllowedValue
+from app.models.schedule_config import ScheduleConfig
+from app.models.section import NewsletterSection
+from app.models.style_rule import StyleRule
+
+router = APIRouter(tags=["health"])
+
+REQUIRED_VOCABULARIES = {
+    "allowed_values": AllowedValue,
+    "newsletter_sections": NewsletterSection,
+    "schedule_configs": ScheduleConfig,
+    "style_rules": StyleRule,
+}
+
+
+@router.get("/health")
+async def health_check():
+    return {"status": "ok"}
+
+
+@router.get("/readyz")
+async def readiness_check(db: AsyncSession = Depends(get_db)):
+    counts: dict[str, int] = {}
+    for name, model in REQUIRED_VOCABULARIES.items():
+        result = await db.execute(select(func.count()).select_from(model))
+        counts[name] = result.scalar_one()
+
+    empty = sorted(name for name, count in counts.items() if count == 0)
+
+    if empty:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "not_ready",
+                "empty_tables": empty,
+                "counts": counts,
+                "hint": "run `python -m app.db.seed` or verify entrypoint ran",
+            },
+        )
+
+    return {"status": "ready", "counts": counts}

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from app.api.v1.health import router as health_router
 from app.api.v1.submissions import router as submissions_router
 from app.api.v1.style_rules import router as style_rules_router
 from app.api.v1.ai_edits import router as ai_edits_router
@@ -12,12 +13,7 @@ from app.api.v1.settings import router as settings_router
 
 router = APIRouter(prefix="/api/v1")
 
-
-@router.get("/health")
-async def health_check():
-    return {"status": "ok"}
-
-
+router.include_router(health_router)
 router.include_router(submissions_router)
 router.include_router(style_rules_router)
 router.include_router(ai_edits_router)

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,7 +1,14 @@
-"""Tests for the health check endpoint."""
+"""Tests for the health and readiness endpoints."""
+
+from datetime import time
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.schedule_config import ScheduleConfig
+from app.models.section import NewsletterSection
+from app.models.style_rule import StyleRule
 
 
 @pytest.mark.asyncio
@@ -9,3 +16,55 @@ async def test_health_check(client: AsyncClient):
     resp = await client.get("/api/v1/health")
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_readyz_reports_empty_tables(client: AsyncClient):
+    """Baseline fixture seeds only AllowedValue — other vocabularies are empty."""
+    resp = await client.get("/api/v1/readyz")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "not_ready"
+    assert set(body["empty_tables"]) == {
+        "newsletter_sections",
+        "schedule_configs",
+        "style_rules",
+    }
+    assert body["counts"]["allowed_values"] > 0
+
+
+@pytest.mark.asyncio
+async def test_readyz_passes_when_all_vocabularies_populated(
+    client: AsyncClient, db: AsyncSession
+):
+    db.add_all(
+        [
+            NewsletterSection(
+                Newsletter_Type="tdr",
+                Name="Test Section",
+                Slug="test-section",
+                Display_Order=1,
+            ),
+            StyleRule(
+                Rule_Set="shared",
+                Category="grammar",
+                Rule_Key="readyz_test",
+                Rule_Text="Test rule.",
+                Severity="warning",
+            ),
+            ScheduleConfig(
+                Newsletter_Type="tdr",
+                Mode="academic_year",
+                Submission_Deadline_Description="noon",
+                Deadline_Time=time(12, 0, 0),
+                Is_Daily=True,
+            ),
+        ]
+    )
+    await db.commit()
+
+    resp = await client.get("/api/v1/readyz")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ready"
+    assert all(count > 0 for count in body["counts"].values())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,12 @@ services:
       - ucmnews-net
       - insight-db-net
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "python -c 'import urllib.request,sys; sys.exit(0 if urllib.request.urlopen(\"http://localhost:8001/api/v1/readyz\", timeout=3).status == 200 else 1)'"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   frontend:
     build: ./frontend


### PR DESCRIPTION
Closes #90.

## Summary

- `/api/v1/readyz` returns **503** with a JSON body listing empty tables if any of `AllowedValue`, `NewsletterSection`, `StyleRule`, or `ScheduleConfig` has zero rows. Returns **200** with row counts when all have data.
- `/api/v1/health` stays as the pure liveness probe (always 200). Refactored into its own module for symmetry.
- Adds a `healthcheck:` block to the backend service in `docker-compose.yml` pointing at `/readyz` — orchestrators will now gate traffic on data-plane readiness, not just process liveness.
- Three new tests in `tests/test_health.py`: liveness, 503-when-empty, 200-when-populated.

## Why

Complements #89. Even with automated seeding in the entrypoint, a botched seed run (partial failure, rolled-back JSON, wrong env) could still bring the app up with empty reference tables. Without this probe, the app serves 200s while dropdowns and validations silently break. Now the container reports unhealthy until the data plane is actually ready.

## Verified

\`\`\`
pytest tests/test_health.py -v
# 3 passed
\`\`\`

Full backend suite: 86 pass, 2 pre-existing failures on main (date-dependent tests in `test_submissions.py` — spun off as a separate task).

## Test plan

- [ ] Deploy branch; `curl http://backend:8001/api/v1/readyz` returns 200 with populated counts
- [ ] Manually `TRUNCATE newsletter_sections;` in a test DB; `/readyz` returns 503 listing `newsletter_sections`
- [ ] `docker inspect <backend-container> --format='{{.State.Health.Status}}'` reports `healthy` after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)