### PR TITLE
Index every foreign key column

### DIFF
--- a/backend/alembic/versions/67a4bd17e12f_add_indexes_on_foreign_key_columns.py
+++ b/backend/alembic/versions/67a4bd17e12f_add_indexes_on_foreign_key_columns.py
@@ -1,7 +1,7 @@
 """add indexes on foreign key columns
 
 Revision ID: 67a4bd17e12f
-Revises: d2e3f4a5b6c7
+Revises: 792c4cd01807
 Create Date: 2026-04-17 14:08:25.645062
 
 """
@@ -12,7 +12,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "67a4bd17e12f"
-down_revision: Union[str, Sequence[str], None] = "d2e3f4a5b6c7"
+down_revision: Union[str, Sequence[str], None] = "792c4cd01807"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/67a4bd17e12f_add_indexes_on_foreign_key_columns.py
+++ b/backend/alembic/versions/67a4bd17e12f_add_indexes_on_foreign_key_columns.py
@@ -1,0 +1,103 @@
+"""add indexes on foreign key columns
+
+Revision ID: 67a4bd17e12f
+Revises: d2e3f4a5b6c7
+Create Date: 2026-04-17 14:08:25.645062
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "67a4bd17e12f"
+down_revision: Union[str, Sequence[str], None] = "d2e3f4a5b6c7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("edit_versions", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_edit_versions_Submission_Id"), ["Submission_Id"], unique=False
+        )
+
+    with op.batch_alter_table("newsletter_external_items", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_newsletter_external_items_Newsletter_Id"),
+            ["Newsletter_Id"], unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_newsletter_external_items_Section_Id"),
+            ["Section_Id"], unique=False,
+        )
+
+    with op.batch_alter_table("newsletter_items", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_newsletter_items_Newsletter_Id"),
+            ["Newsletter_Id"], unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_newsletter_items_Section_Id"),
+            ["Section_Id"], unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_newsletter_items_Submission_Id"),
+            ["Submission_Id"], unique=False,
+        )
+
+    with op.batch_alter_table("recurring_message_issue_overrides", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_recurring_message_issue_overrides_Newsletter_Id"),
+            ["Newsletter_Id"], unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_recurring_message_issue_overrides_Recurring_Message_Id"),
+            ["Recurring_Message_Id"], unique=False,
+        )
+
+    with op.batch_alter_table("recurring_messages", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_recurring_messages_Section_Id"),
+            ["Section_Id"], unique=False,
+        )
+
+    with op.batch_alter_table("submission_links", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_submission_links_Submission_Id"),
+            ["Submission_Id"], unique=False,
+        )
+
+    with op.batch_alter_table("submission_schedule_requests", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_submission_schedule_requests_Submission_Id"),
+            ["Submission_Id"], unique=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("submission_schedule_requests", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_submission_schedule_requests_Submission_Id"))
+
+    with op.batch_alter_table("submission_links", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_submission_links_Submission_Id"))
+
+    with op.batch_alter_table("recurring_messages", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_recurring_messages_Section_Id"))
+
+    with op.batch_alter_table("recurring_message_issue_overrides", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_recurring_message_issue_overrides_Recurring_Message_Id"))
+        batch_op.drop_index(batch_op.f("ix_recurring_message_issue_overrides_Newsletter_Id"))
+
+    with op.batch_alter_table("newsletter_items", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_newsletter_items_Submission_Id"))
+        batch_op.drop_index(batch_op.f("ix_newsletter_items_Section_Id"))
+        batch_op.drop_index(batch_op.f("ix_newsletter_items_Newsletter_Id"))
+
+    with op.batch_alter_table("newsletter_external_items", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_newsletter_external_items_Section_Id"))
+        batch_op.drop_index(batch_op.f("ix_newsletter_external_items_Newsletter_Id"))
+
+    with op.batch_alter_table("edit_versions", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_edit_versions_Submission_Id"))

--- a/backend/app/models/edit_history.py
+++ b/backend/app/models/edit_history.py
@@ -35,7 +35,7 @@ class EditVersion(Base):
         sa.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
     )
     Submission_Id: Mapped[str] = mapped_column(
-        sa.String(36), sa.ForeignKey("submissions.Id"), nullable=False
+        sa.String(36), sa.ForeignKey("submissions.Id"), nullable=False, index=True
     )
     Version_Type: Mapped[str] = mapped_column(sa.String(50), nullable=False)
     Headline: Mapped[str] = mapped_column(sa.Text, nullable=False)

--- a/backend/app/models/newsletter.py
+++ b/backend/app/models/newsletter.py
@@ -68,13 +68,13 @@ class NewsletterItem(Base):
         sa.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
     )
     Newsletter_Id: Mapped[str] = mapped_column(
-        sa.String(36), sa.ForeignKey("newsletters.Id"), nullable=False
+        sa.String(36), sa.ForeignKey("newsletters.Id"), nullable=False, index=True
     )
     Submission_Id: Mapped[str] = mapped_column(
-        sa.String(36), sa.ForeignKey("submissions.Id"), nullable=False
+        sa.String(36), sa.ForeignKey("submissions.Id"), nullable=False, index=True
     )
     Section_Id: Mapped[str] = mapped_column(
-        sa.String(36), sa.ForeignKey("newsletter_sections.Id"), nullable=False
+        sa.String(36), sa.ForeignKey("newsletter_sections.Id"), nullable=False, index=True
     )
     Position: Mapped[int] = mapped_column(sa.Integer, nullable=False, default=0)
     Final_Headline: Mapped[str] = mapped_column(sa.Text, nullable=False)
@@ -97,10 +97,10 @@ class NewsletterExternalItem(Base):
         sa.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
     )
     Newsletter_Id: Mapped[str] = mapped_column(
-        sa.String(36), sa.ForeignKey("newsletters.Id"), nullable=False
+        sa.String(36), sa.ForeignKey("newsletters.Id"), nullable=False, index=True
     )
     Section_Id: Mapped[str] = mapped_column(
-        sa.String(36), sa.ForeignKey("newsletter_sections.Id"), nullable=False
+        sa.String(36), sa.ForeignKey("newsletter_sections.Id"), nullable=False, index=True
     )
     Source_Type: Mapped[str] = mapped_column(sa.String(50), nullable=False)
     Source_Id: Mapped[str] = mapped_column(sa.String(255), nullable=False)

--- a/backend/app/models/recurring_message.py
+++ b/backend/app/models/recurring_message.py
@@ -36,7 +36,7 @@ class RecurringMessage(Base):
     )
     Newsletter_Type: Mapped[str] = mapped_column(sa.String(50), nullable=False)
     Section_Id: Mapped[str] = mapped_column(
-        sa.String(36), sa.ForeignKey("newsletter_sections.Id"), nullable=False
+        sa.String(36), sa.ForeignKey("newsletter_sections.Id"), nullable=False, index=True
     )
     Headline: Mapped[str] = mapped_column(sa.Text, nullable=False)
     Body: Mapped[str] = mapped_column(sa.Text, nullable=False)
@@ -82,10 +82,10 @@ class RecurringMessageIssueOverride(Base):
         sa.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
     )
     Recurring_Message_Id: Mapped[str] = mapped_column(
-        sa.String(36), sa.ForeignKey("recurring_messages.Id"), nullable=False
+        sa.String(36), sa.ForeignKey("recurring_messages.Id"), nullable=False, index=True
     )
     Newsletter_Id: Mapped[str] = mapped_column(
-        sa.String(36), sa.ForeignKey("newsletters.Id"), nullable=False
+        sa.String(36), sa.ForeignKey("newsletters.Id"), nullable=False, index=True
     )
     Override_Action: Mapped[str] = mapped_column(
         sa.String(50), nullable=False, default="skip"

--- a/backend/app/models/submission.py
+++ b/backend/app/models/submission.py
@@ -78,7 +78,7 @@ class SubmissionLink(Base):
         sa.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
     )
     Submission_Id: Mapped[str] = mapped_column(
-        sa.String(36), sa.ForeignKey("submissions.Id"), nullable=False
+        sa.String(36), sa.ForeignKey("submissions.Id"), nullable=False, index=True
     )
     Url: Mapped[str] = mapped_column(sa.Text, nullable=False)
     Anchor_Text: Mapped[str | None] = mapped_column(sa.String(500), nullable=True)
@@ -98,7 +98,7 @@ class SubmissionScheduleRequest(Base):
         sa.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
     )
     Submission_Id: Mapped[str] = mapped_column(
-        sa.String(36), sa.ForeignKey("submissions.Id"), nullable=False
+        sa.String(36), sa.ForeignKey("submissions.Id"), nullable=False, index=True
     )
     Requested_Date: Mapped[date | None] = mapped_column(sa.Date, nullable=True)
     Second_Requested_Date: Mapped[date | None] = mapped_column(sa.Date, nullable=True)


### PR DESCRIPTION
Closes #91.

## Summary

- Adds `index=True` to all 11 FK `mapped_column()` declarations across `edit_history.py`, `newsletter.py`, `recurring_message.py`, and `submission.py`.
- New Alembic migration `67a4bd17e12f` creates the corresponding indexes.
- Uses SQLAlchemy's default `ix_{table}_{column}` naming so future `autogenerate` runs stay clean.

## Why

PostgreSQL does not auto-index foreign key columns (unlike MySQL). Without these, cascading deletes scan entire child tables, FK constraint checks slow down as the archive grows, and editor dashboard joins degrade. These tables are small today — this is cheap insurance as the newsletter archive accumulates across semesters.

## Tables covered

- \`submission_links.Submission_Id\`
- \`submission_schedule_requests.Submission_Id\`
- \`edit_versions.Submission_Id\`
- \`newsletter_items.Newsletter_Id\`, \`Submission_Id\`, \`Section_Id\`
- \`newsletter_external_items.Newsletter_Id\`, \`Section_Id\`
- \`recurring_messages.Section_Id\`
- \`recurring_message_issue_overrides.Recurring_Message_Id\`, \`Newsletter_Id\`

## Verified

Round-trip tested locally against SQLite:

\`\`\`
alembic upgrade head     # creates indexes
alembic downgrade -1     # drops them cleanly
alembic upgrade head     # re-applies
\`\`\`

Full test suite still passes (86 tests; the same 2 pre-existing date-dependent failures on `main` remain — unrelated).

## Note on Postgres locking

This PR uses `op.batch_alter_table` / plain `create_index`. For the current row volumes, the brief ACCESS EXCLUSIVE lock during `CREATE INDEX` is fine. If the archive grows significantly, future migrations should consider `CREATE INDEX CONCURRENTLY` — but that requires disabling the transactional wrapper, which is a larger change.

## Test plan

- [ ] Deploy branch to dev; `\d+ submission_links` in psql shows the new index
- [ ] EXPLAIN on a join query through editor dashboard uses the new indexes
- [ ] Subsequent `alembic revision --autogenerate -m "..."` produces no spurious drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)