### PR TITLE
Fail CI on Alembic migration drift (+ backfill existing drift)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,12 @@ jobs:
         run: pip install -e ".[dev,postgres]"
       - name: Run Alembic migrations
         run: alembic upgrade head
+      - name: Check for migration drift
+        run: |
+          if ! alembic check; then
+            echo "::error::Model metadata drift detected. Run 'alembic revision --autogenerate -m \"description\"' locally, review the generated SQL, and commit the new migration alongside your model change."
+            exit 1
+          fi
       - name: PostgreSQL smoke test
         run: python tests/postgres_smoke.py
 

--- a/backend/alembic/versions/792c4cd01807_backfill_missing_tables_and_fix_.py
+++ b/backend/alembic/versions/792c4cd01807_backfill_missing_tables_and_fix_.py
@@ -1,0 +1,105 @@
+"""backfill missing tables and fix nullable drift
+
+Revision ID: 792c4cd01807
+Revises: d2e3f4a5b6c7
+Create Date: 2026-04-17 14:13:33.806009
+
+Three tables and one NOT NULL constraint exist in the models but not in the
+migration history — drift accumulated from edits that skipped
+`alembic revision --autogenerate`. Existing deployments already have these
+tables via `Base.metadata.create_all()` at app startup; fresh deployments
+that rely only on `alembic upgrade head` will not. This migration is
+idempotent — it inspects the live schema and only creates what's missing —
+so it is safe to run against both.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "792c4cd01807"
+down_revision: Union[str, Sequence[str], None] = "d2e3f4a5b6c7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _existing_tables() -> set[str]:
+    return set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _column_nullable(table: str, column: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    for col in inspector.get_columns(table):
+        if col["name"] == column:
+            return bool(col.get("nullable", True))
+    return True
+
+
+def upgrade() -> None:
+    existing = _existing_tables()
+
+    if "blackout_dates" not in existing:
+        op.create_table(
+            "blackout_dates",
+            sa.Column("Id", sa.String(length=36), nullable=False),
+            sa.Column("Blackout_Date", sa.Date(), nullable=False),
+            sa.Column("Newsletter_Type", sa.String(length=50), nullable=True),
+            sa.Column("Description", sa.Text(), nullable=True),
+            sa.Column("Is_Active", sa.Boolean(), nullable=False),
+            sa.PrimaryKeyConstraint("Id"),
+            sa.UniqueConstraint(
+                "Blackout_Date", "Newsletter_Type", name="uq_blackout_date_newsletter"
+            ),
+        )
+
+    if "custom_publish_dates" not in existing:
+        op.create_table(
+            "custom_publish_dates",
+            sa.Column("Id", sa.String(length=36), nullable=False),
+            sa.Column("Newsletter_Type", sa.String(length=50), nullable=False),
+            sa.Column("Publish_Date", sa.Date(), nullable=False),
+            sa.Column("Description", sa.Text(), nullable=True),
+            sa.Column("Created_At", sa.DateTime(), nullable=False),
+            sa.PrimaryKeyConstraint("Id"),
+            sa.UniqueConstraint(
+                "Newsletter_Type", "Publish_Date", name="uq_custom_publish_date"
+            ),
+        )
+
+    if "schedule_mode_overrides" not in existing:
+        op.create_table(
+            "schedule_mode_overrides",
+            sa.Column("Id", sa.String(length=36), nullable=False),
+            sa.Column("Newsletter_Type", sa.String(length=50), nullable=False),
+            sa.Column("Override_Mode", sa.String(length=50), nullable=False),
+            sa.Column("Start_Date", sa.Date(), nullable=False),
+            sa.Column("End_Date", sa.Date(), nullable=False),
+            sa.Column("Description", sa.Text(), nullable=True),
+            sa.Column("Created_At", sa.DateTime(), nullable=False),
+            sa.PrimaryKeyConstraint("Id"),
+        )
+
+    if _column_nullable("schedule_configs", "Holiday_Shift_Enabled"):
+        with op.batch_alter_table("schedule_configs", schema=None) as batch_op:
+            batch_op.alter_column(
+                "Holiday_Shift_Enabled",
+                existing_type=sa.Boolean(),
+                nullable=False,
+                existing_server_default=sa.text("(false)"),
+            )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("schedule_configs", schema=None) as batch_op:
+        batch_op.alter_column(
+            "Holiday_Shift_Enabled",
+            existing_type=sa.Boolean(),
+            nullable=True,
+            existing_server_default=sa.text("(false)"),
+        )
+
+    op.drop_table("schedule_mode_overrides")
+    op.drop_table("custom_publish_dates")
+    op.drop_table("blackout_dates")


### PR DESCRIPTION
Closes #92.

## Summary

- Adds an `alembic check` step to the `backend-postgres` CI job. Fails the PR if model metadata diverges from the migration history, with a GitHub Actions error annotation telling the developer how to fix it.
- Adds migration `792c4cd01807` to backfill drift that the new check surfaced on `main`. Idempotent — safe to run against deployments that already have the tables via \`Base.metadata.create_all()\`.

## Why

Two recent commits on `main` — \`5231963\` and \`3281359\` — were retroactive "missing migration" patch-ups. Developers were editing models without running `alembic revision --autogenerate`. A CI gate prevents this from recurring.

## What the check surfaced

Running `alembic check` on `main` revealed **pre-existing drift** that was masked by \`Base.metadata.create_all()\` at startup:

- Three model tables had **no migration at all**:
  - `blackout_dates` (used by seed.py!)
  - `custom_publish_dates`
  - `schedule_mode_overrides`
- `schedule_configs.Holiday_Shift_Enabled` was `NOT NULL` in the model but `nullable=True` in the prior migration.

A fresh Postgres deployment that relies only on `alembic upgrade head` (which is now the entrypoint — see PR #93) would be missing these tables entirely.

## Idempotency

The backfill migration uses the same \`sa.inspect(op.get_bind())\` pattern as \`6f4e8a2c1b7d_backfill_missing_recurrence_columns.py\`. It checks the live schema before each \`create_table\` and \`alter_column\`, so:

- Fresh DB → tables get created.
- Existing DB (tables already made by \`create_all\`) → \`create_table\` calls are skipped; only the NOT NULL fix runs if needed.

## Verified locally

\`\`\`
# Fresh DB
rm ucm_newsletter.db
alembic upgrade head          # all migrations apply including 792c4cd01807
alembic check                  # "No new upgrade operations detected"

# Pre-existing-tables path
Base.metadata.create_all(...) # simulate create_all state
alembic stamp d2e3f4a5b6c7    # mark pre-drift head
alembic upgrade head          # skips create_table calls, runs clean
alembic check                  # no drift

# Round trip
alembic downgrade -1
alembic upgrade head
alembic check                  # no drift
\`\`\`

Full pytest suite: 84 pass, 2 pre-existing date-dependent failures on main (spun off as separate task).

## Test plan

- [ ] CI green on this PR
- [ ] Next PR that changes a model without a migration → CI fails with the annotation
- [ ] Deploy to dev → `alembic upgrade head` runs in entrypoint, no errors, `\\d blackout_dates` in psql exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)