### PR TITLE
Fix time-dependent recurrence test failures

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import AsyncGenerator
+from datetime import date
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -124,6 +125,29 @@ async def seed_submission_categories(setup_db, db: AsyncSession):
         ),
     ])
     await db.commit()
+
+
+@pytest.fixture
+def freeze_today(monkeypatch):
+    """Freeze ``date.today()`` inside services that preview recurrence occurrences.
+
+    Recurrence expansion filters out occurrences earlier than ``date.today()``,
+    so tests with hardcoded recurrence dates become time-dependent once real-world
+    time advances past them. Call ``freeze_today(date(Y, M, D))`` to pin today.
+    """
+    def _freeze(frozen: date) -> None:
+        class _FrozenDate(date):
+            @classmethod
+            def today(cls) -> date:
+                return frozen
+
+        for module_path in (
+            "app.services.submission_service",
+            "app.services.schedule_service",
+        ):
+            monkeypatch.setattr(f"{module_path}.date", _FrozenDate)
+
+    return _freeze
 
 
 @pytest.fixture

--- a/backend/tests/test_submissions.py
+++ b/backend/tests/test_submissions.py
@@ -1,5 +1,7 @@
 """Tests for Submission CRUD endpoints."""
 
+from datetime import date
+
 import pytest
 from httpx import AsyncClient
 
@@ -66,7 +68,10 @@ class TestSubmissionCRUD:
         assert resp.status_code == 201
         assert resp.json()["Survey_End_Date"] == "2026-04-15"
 
-    async def test_create_submission_with_recurring_schedule(self, client: AsyncClient):
+    async def test_create_submission_with_recurring_schedule(
+        self, client: AsyncClient, freeze_today
+    ):
+        freeze_today(date(2026, 3, 10))
         data = make_submission_data(
             Schedule_Requests=[
                 {
@@ -393,7 +398,10 @@ class TestSubmissionSchedule:
         assert list_resp.status_code == 200
         assert list_resp.json()["Total"] == 0
 
-    async def test_reschedule_schedule_occurrence(self, client: AsyncClient):
+    async def test_reschedule_schedule_occurrence(
+        self, client: AsyncClient, freeze_today
+    ):
+        freeze_today(date(2026, 3, 10))
         data = make_submission_data(
             Schedule_Requests=[
                 {


### PR DESCRIPTION
## Summary
- Two tests in `backend/tests/test_submissions.py` (`test_create_submission_with_recurring_schedule`, `test_reschedule_schedule_occurrence`) hardcode recurrence dates and assert on `Occurrence_Dates`, which the submission service filters against `date.today()`. As real-world time advanced past the hardcoded occurrences, the asserted list shrank and the tests started failing in April 2026 (flagged during review of PRs #93–#96).
- Adds a `freeze_today` fixture to `conftest.py` that monkeypatches `date.today()` in `app.services.submission_service` and `app.services.schedule_service`, and pins both tests to `2026-03-10` — after the `2026-03-02` anchor so it's correctly treated as past, before the first asserted occurrence `2026-04-06`.

## Test plan
- [x] `cd backend && pytest tests/test_submissions.py -v` → 28/28 pass on today's date (2026-04-17)
- [x] `cd backend && pytest` → full suite 88/88 pass
- [ ] CI is green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)