### PR TITLE
Freeze clock in submission tests to prevent date-aged failures

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=5.0.0",
     "ruff>=0.6.0",
+    "freezegun>=1.5.0",
 ]
 postgres = [
     "asyncpg>=0.29.0",

--- a/backend/tests/test_submissions.py
+++ b/backend/tests/test_submissions.py
@@ -1,12 +1,20 @@
 """Tests for Submission CRUD endpoints."""
 
 import pytest
+from freezegun import freeze_time
 from httpx import AsyncClient
 
 from tests.conftest import make_submission_data
 
 
+# Freeze the clock for date-sensitive tests. Recurrence previews filter past
+# occurrences via date.today(); the expected Occurrence_Dates assertions below
+# were written assuming "today" falls in early April 2026.
+FROZEN_TODAY = "2026-04-01"
+
+
 @pytest.mark.asyncio
+@freeze_time(FROZEN_TODAY)
 class TestSubmissionCRUD:
     async def test_create_submission(self, client: AsyncClient):
         data = make_submission_data()
@@ -294,6 +302,7 @@ class TestSubmissionCRUD:
 
 
 @pytest.mark.asyncio
+@freeze_time(FROZEN_TODAY)
 class TestSubmissionLinks:
     async def test_add_link(self, client: AsyncClient):
         create_resp = await client.post("/api/v1/submissions/", json=make_submission_data())
@@ -319,6 +328,7 @@ class TestSubmissionLinks:
 
 
 @pytest.mark.asyncio
+@freeze_time(FROZEN_TODAY)
 class TestSubmissionSchedule:
     async def test_add_schedule_request(self, client: AsyncClient):
         create_resp = await client.post("/api/v1/submissions/", json=make_submission_data())


### PR DESCRIPTION
## Summary
- Two submission tests asserted on hardcoded `Occurrence_Dates` and began failing in April 2026 as the recurrence preview filtered those dates out via `date.today()`
- Adds `freezegun` as a dev dep and applies `@freeze_time` at class level so assertions remain valid regardless of when the suite runs

## Test plan
- [ ] `cd backend && pytest tests/test_submissions.py` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)