### PR TITLE
Update calendar source URL default to match .env.example

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
     upload_dir: str = "./uploads"
     cors_origins: list[str] = ["http://localhost:5173"]
     calendar_source_url: str = (
-        "https://www.trumba.com/calendars/university-of-idaho.rss"
+        "https://www.qatrumba.com/events-calendar/ui/uidaho/vandals/vandal/event/events/calendar/moscow/idaho/id/university-of-idaho"
     )
     calendar_request_timeout_seconds: float = 10.0
     job_postings_source_url: str = "https://uidaho.peopleadmin.com/postings/search"


### PR DESCRIPTION
## Summary
- The `Settings` default for `calendar_source_url` in [backend/app/config.py](backend/app/config.py) still pointed at the retired `trumba.com/calendars/university-of-idaho.rss` endpoint
- `.env.example` was already updated to the current `qatrumba.com/events-calendar/...` URL, so any environment without an explicit `CALENDAR_SOURCE_URL` override was hitting the dead URL

## Test plan
- [ ] Run backend without `CALENDAR_SOURCE_URL` set; calendar ingestion reaches the live qatrumba endpoint
- [ ] Existing env overrides continue to take precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)