### PR TITLE
Fix stale API reference and data model docs

### DIFF
--- a/docs/ai-editing.md
+++ b/docs/ai-editing.md
@@ -131,7 +131,7 @@ The LLM provider is selected at startup via the `LLM_PROVIDER` environment varia
 |--------------|------------------------------|----------------------------|----------------------------------|
 | `claude`     | Anthropic Claude API         | claude-sonnet-4-20250514   | Cloud API, requires API key      |
 | `openai`     | OpenAI API                   | gpt-4o                     | Cloud API, requires API key      |
-| `mindrouter` | U of I MindRouter (on-prem)  | Qwen/Qwen3-32B             | On-prem, OpenAI-compatible API   |
+| `mindrouter` | U of I MindRouter (on-prem)  | openai/gpt-oss-120b        | On-prem, OpenAI-compatible API   |
 
 All providers implement a common `LLMProvider` interface with two methods:
 
@@ -181,5 +181,5 @@ Key implementation details:
     LLM_PROVIDER=mindrouter
     MINDROUTER_API_KEY=mr2_...
     MINDROUTER_ENDPOINT_URL=https://mindrouter.uidaho.edu/v1/chat/completions
-    MINDROUTER_MODEL=Qwen/Qwen3-32B
+    MINDROUTER_MODEL=openai/gpt-oss-120b
     ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -7,6 +7,7 @@ All endpoints are prefixed with `/api/v1`. Responses use JSON. Errors return sta
 | Method | Path              | Description          |
 |--------|-------------------|----------------------|
 | GET    | `/api/v1/health`  | Returns service status and version |
+| GET    | `/api/v1/readyz`  | Readiness probe — verifies load-bearing reference tables are seeded |
 
 ## Submissions
 
@@ -15,7 +16,7 @@ All endpoints are prefixed with `/api/v1`. Responses use JSON. Errors return sta
 | POST   | `/api/v1/submissions`                         | Create a new submission              |
 | GET    | `/api/v1/submissions`                         | List submissions (with filters)      |
 | GET    | `/api/v1/submissions/{id}`                    | Get a single submission              |
-| PUT    | `/api/v1/submissions/{id}`                    | Update a submission                  |
+| PATCH  | `/api/v1/submissions/{id}`                    | Update a submission                  |
 | DELETE | `/api/v1/submissions/{id}`                    | Delete a submission                  |
 
 ### Submission Links
@@ -23,24 +24,25 @@ All endpoints are prefixed with `/api/v1`. Responses use JSON. Errors return sta
 | Method | Path                                                  | Description                  |
 |--------|-------------------------------------------------------|------------------------------|
 | POST   | `/api/v1/submissions/{id}/links`                      | Add a link to a submission   |
-| GET    | `/api/v1/submissions/{id}/links`                      | List links for a submission  |
 | DELETE | `/api/v1/submissions/{id}/links/{link_id}`            | Remove a link                |
 
 ### Schedule Requests
 
-| Method | Path                                                          | Description                          |
-|--------|---------------------------------------------------------------|--------------------------------------|
-| POST   | `/api/v1/submissions/{id}/schedule-requests`                  | Add a schedule request               |
-| GET    | `/api/v1/submissions/{id}/schedule-requests`                  | List schedule requests               |
-| DELETE | `/api/v1/submissions/{id}/schedule-requests/{request_id}`     | Remove a schedule request            |
+| Method | Path                                                              | Description                          |
+|--------|-------------------------------------------------------------------|--------------------------------------|
+| POST   | `/api/v1/submissions/{id}/schedule`                               | Add a schedule request               |
+| DELETE | `/api/v1/submissions/{id}/schedule/{schedule_id}`                 | Remove a schedule request            |
+| POST   | `/api/v1/submissions/{id}/schedule/{schedule_id}/skip`            | Skip a recurring occurrence (staff)  |
+| POST   | `/api/v1/submissions/{id}/schedule/{schedule_id}/reschedule`      | Move a recurring occurrence (staff)  |
 
-### Images
+### Image
+
+Each submission supports at most one image attachment.
 
 | Method | Path                                                  | Description                    |
 |--------|-------------------------------------------------------|--------------------------------|
-| POST   | `/api/v1/submissions/{id}/images`                     | Upload an image attachment     |
-| GET    | `/api/v1/submissions/{id}/images`                     | List images for a submission   |
-| DELETE | `/api/v1/submissions/{id}/images/{image_id}`          | Remove an image                |
+| POST   | `/api/v1/submissions/{id}/image`                      | Upload the image attachment    |
+| GET    | `/api/v1/submissions/{id}/image`                      | Fetch the image bytes          |
 
 ## AI Edits
 
@@ -115,7 +117,7 @@ These endpoints are staff-only and manage centrally maintained editorial content
 | POST   | `/api/v1/style-rules`                         | Create a style rule                  |
 | GET    | `/api/v1/style-rules`                         | List rules (filter by rule set)      |
 | GET    | `/api/v1/style-rules/{id}`                    | Get a single rule                    |
-| PUT    | `/api/v1/style-rules/{id}`                    | Update a rule                        |
+| PATCH  | `/api/v1/style-rules/{id}`                    | Update a rule                        |
 | DELETE | `/api/v1/style-rules/{id}`                    | Delete a rule                        |
 
 ## Sections
@@ -155,7 +157,7 @@ The settings endpoint returns read-only configuration data for the frontend Sett
     ```json
     {
       "active_provider": "mindrouter",
-      "active_model": "GPT-OSS-120B",
+      "active_model": "openai/gpt-oss-120b",
       "endpoint_url": "https://mindrouter.uidaho.edu/v1/chat/completions",
       "providers": {
         "claude": {
@@ -167,7 +169,7 @@ The settings endpoint returns read-only configuration data for the frontend Sett
           "configured": false
         },
         "mindrouter": {
-          "model": "GPT-OSS-120B",
+          "model": "openai/gpt-oss-120b",
           "endpoint_url": "https://mindrouter.uidaho.edu/v1/chat/completions",
           "configured": true
         }

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -70,14 +70,19 @@ Requested publication dates. A submission targeting "Both" newsletters may have 
 
 Immutable audit trail of text transformations. Each version captures the text at one stage.
 
-| Key Column          | Type     | Notes                                  |
-|---------------------|----------|----------------------------------------|
-| Version_ID          | UUID PK  |                                        |
-| Submission_ID       | UUID FK  | Parent submission                      |
-| Version_Type        | String   | Original, AI_Suggested, Editor_Final   |
-| Title_Text          | String   | Title at this stage                    |
-| Body_Text           | Text     | Body at this stage                     |
-| Diff_JSON           | JSON     | Computed diff from previous version    |
+| Key Column          | Type     | Notes                                                   |
+|---------------------|----------|---------------------------------------------------------|
+| Id                  | UUID PK  |                                                         |
+| Submission_Id       | UUID FK  | Parent submission                                       |
+| Version_Type        | String   | AllowedValue-governed (Original, AI_Suggested, Final)   |
+| Headline            | Text     | Headline at this stage                                  |
+| Body                | Text     | Body at this stage                                      |
+| Headline_Case       | String   | AllowedValue-governed headline case setting             |
+| Flags               | JSON     | Structured style-rule violations detected by the AI     |
+| Changes_Made        | JSON     | Structured diff summary produced by the AI pipeline     |
+| AI_Provider         | String   | Provider slug (`claude`, `openai`, `mindrouter`)        |
+| AI_Model            | String   | Model identifier returned by the provider               |
+| Created_At          | DateTime | Set by `server_default=now()`                           |
 
 !!! warning "Immutability"
     EditVersion records are never updated after creation. Each editing action produces a new row, preserving the complete history.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -71,7 +71,7 @@ OPENAI_MODEL=gpt-4o
 # MindRouter — University of Idaho on-prem AI (required when LLM_PROVIDER=mindrouter)
 MINDROUTER_API_KEY=mr2_...
 MINDROUTER_ENDPOINT_URL=https://mindrouter.uidaho.edu/v1/chat/completions
-MINDROUTER_MODEL=Qwen/Qwen3-32B
+MINDROUTER_MODEL=openai/gpt-oss-120b
 
 # CORS (development)
 CORS_ORIGINS=http://localhost:5173


### PR DESCRIPTION
## Summary
MkDocs pages drifted from the current code in several concrete ways. All changes verified against the current backend source before editing.

### [docs/api-reference.md](docs/api-reference.md)
- Submission update uses `PATCH`, not `PUT` ([submissions.py:162](backend/app/api/v1/submissions.py:162))
- Style-rule update uses `PATCH`, not `PUT` ([style_rules.py:68](backend/app/api/v1/style_rules.py:68))
- Removed non-existent `GET /submissions/{id}/links` row
- Schedule routes live under `/schedule` (not `/schedule-requests`); GET doesn't exist; added the staff-only `skip` and `reschedule` endpoints ([submissions.py:215-337](backend/app/api/v1/submissions.py:215))
- Image endpoint is singular `/image` with `POST`+`GET` only (no DELETE) ([submissions.py:349-368](backend/app/api/v1/submissions.py:349))
- Added `GET /readyz` (shipped in PR #94)
- Settings example: replaced made-up display name `"GPT-OSS-120B"` with the actual slug `"openai/gpt-oss-120b"` the service returns

### [docs/data-model.md](docs/data-model.md)
- `EditVersion` column list was fabricated (`Title_Text`, `Body_Text`, `Diff_JSON`). Replaced with the real schema from [edit_history.py](backend/app/models/edit_history.py): `Headline`, `Body`, `Flags`, `Changes_Made`, `AI_Provider`, `AI_Model`, `Created_At`, etc.

### [docs/ai-editing.md](docs/ai-editing.md) + [docs/deployment.md](docs/deployment.md)
- MindRouter default model aligned with [config.py](backend/app/config.py) (`openai/gpt-oss-120b`), replacing the stale `Qwen/Qwen3-32B` references

## Test plan
- [ ] `cd docs && mkdocs build --strict` succeeds
- [ ] Spot-check rendered tables and example blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)