### PR TITLE
Fail closed when EXIF stripping fails on image upload

### DIFF
--- a/backend/app/api/v1/submissions.py
+++ b/backend/app/api/v1/submissions.py
@@ -20,7 +20,7 @@ from app.schemas.submission import (
     SubmissionUpdate,
 )
 from app.services import allowed_value_service, schedule_service, submission_service
-from app.services.image_service import save_upload, validate_image
+from app.services.image_service import ImageProcessingError, save_upload, validate_image
 
 router = APIRouter(prefix="/submissions", tags=["submissions"])
 
@@ -358,7 +358,10 @@ async def upload_image(
     if error:
         raise HTTPException(status_code=400, detail=error)
 
-    filename = await save_upload(file.filename or "image.png", content)
+    try:
+        filename = await save_upload(file.filename or "image.png", content)
+    except ImageProcessingError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     submission = await submission_service.set_image(db, submission_id, filename)
     if not submission:
         raise HTTPException(status_code=404, detail="Submission not found")

--- a/backend/app/services/image_service.py
+++ b/backend/app/services/image_service.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import uuid
 from pathlib import Path
@@ -5,6 +6,13 @@ from pathlib import Path
 from PIL import Image
 
 from app.config import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+class ImageProcessingError(Exception):
+    """Raised when an uploaded image cannot be processed safely (e.g., EXIF stripping failed)."""
 
 
 ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
@@ -28,25 +36,49 @@ def check_image_dimensions(filepath: str) -> tuple[int, int]:
 
 
 def _strip_exif(filepath: str) -> None:
-    """Remove EXIF metadata (GPS, camera info, etc.) from an image file."""
-    try:
-        with Image.open(filepath) as img:
-            if img.format == "GIF":
-                return
-            cleaned = Image.new(img.mode, img.size)
-            cleaned.putdata(list(img.getdata()))
-            cleaned.save(filepath, format=img.format)
-    except Exception:
-        pass  # If stripping fails, keep the original file
+    """Remove EXIF metadata (GPS, camera info, etc.) from an image file.
+
+    Raises whatever PIL raises if the file can't be decoded or re-saved; the
+    caller is responsible for cleanup and user-facing error handling.
+    """
+    with Image.open(filepath) as img:
+        if img.format == "GIF":
+            return
+        cleaned = Image.new(img.mode, img.size)
+        cleaned.putdata(list(img.getdata()))
+        cleaned.save(filepath, format=img.format)
 
 
 async def save_upload(filename: str, content: bytes) -> str:
-    """Save uploaded file, strip EXIF metadata, and return the relative path."""
+    """Save uploaded file, strip EXIF metadata, and return the relative path.
+
+    Fails closed: if EXIF stripping fails (corrupt file, unsupported format,
+    or a file whose extension lies about its content), the saved file is
+    deleted and ImageProcessingError is raised. We would rather reject an
+    upload than silently store an image with metadata intact.
+    """
     os.makedirs(settings.upload_dir, exist_ok=True)
     ext = Path(filename).suffix.lower()
     unique_name = f"{uuid.uuid4()}{ext}"
     filepath = os.path.join(settings.upload_dir, unique_name)
     with open(filepath, "wb") as f:
         f.write(content)
-    _strip_exif(filepath)
+    try:
+        _strip_exif(filepath)
+    except Exception as exc:
+        logger.warning(
+            "Failed to strip EXIF from upload %s (stored as %s): %s",
+            filename,
+            unique_name,
+            exc,
+            exc_info=True,
+        )
+        try:
+            os.remove(filepath)
+        except OSError:
+            logger.warning("Failed to clean up unprocessable upload %s", filepath)
+        raise ImageProcessingError(
+            "Unable to process image. The file may be corrupt, not a real image, "
+            "or in an unsupported format."
+        ) from exc
     return unique_name


### PR DESCRIPTION
## Summary
Follow-up to [PR #88](https://github.com/ui-insight/UCMDailyRegister/pull/88) (EXIF stripping).

Previously [\`_strip_exif\`](backend/app/services/image_service.py) wrapped the PIL logic in a bare \`except Exception: pass\`, so any failure (corrupt image, non-image file with a whitelisted extension, unsupported format) left the *original* file on disk — defeating the point of the security improvement.

This PR makes the upload fail closed:

- [\`_strip_exif\`](backend/app/services/image_service.py:33) no longer swallows exceptions
- [\`save_upload\`](backend/app/services/image_service.py:50) deletes the saved file and raises a new \`ImageProcessingError\` on any stripping failure, with a \`logger.warning(..., exc_info=True)\` so operators see what PIL rejected
- [\`upload_image\`](backend/app/api/v1/submissions.py:358) catches it and returns HTTP 422 with a user-friendly message

\`GIF\` handling is unchanged — still a pixel-safe skip.

## Test plan
- [x] \`pytest\` — 88 tests pass
- [x] \`ruff check\` — clean
- [ ] Manual: upload a non-image file renamed to \`.jpg\` → 422 + log entry, no orphaned file
- [ ] Manual: upload a normal JPEG → still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)