### PR TITLE
Make FK-index and Holiday_Shift_Enabled migrations idempotent

### DIFF
--- a/backend/alembic/versions/67a4bd17e12f_add_indexes_on_foreign_key_columns.py
+++ b/backend/alembic/versions/67a4bd17e12f_add_indexes_on_foreign_key_columns.py
@@ -8,6 +8,7 @@ Create Date: 2026-04-17 14:08:25.645062
 from typing import Sequence, Union
 
 from alembic import op
+import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
@@ -17,87 +18,43 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+# Indexes added by this migration, grouped by table.
+# Some long-running deployments already have these indexes from an earlier
+# Base.metadata.create_all() bootstrap (models declare index=True on FK
+# columns). The guarded helpers below let this migration replay safely
+# against drifted DBs.
+TABLE_INDEXES: list[tuple[str, str, str]] = [
+    ("edit_versions", "ix_edit_versions_Submission_Id", "Submission_Id"),
+    ("newsletter_external_items", "ix_newsletter_external_items_Newsletter_Id", "Newsletter_Id"),
+    ("newsletter_external_items", "ix_newsletter_external_items_Section_Id", "Section_Id"),
+    ("newsletter_items", "ix_newsletter_items_Newsletter_Id", "Newsletter_Id"),
+    ("newsletter_items", "ix_newsletter_items_Section_Id", "Section_Id"),
+    ("newsletter_items", "ix_newsletter_items_Submission_Id", "Submission_Id"),
+    ("recurring_message_issue_overrides", "ix_recurring_message_issue_overrides_Newsletter_Id", "Newsletter_Id"),
+    ("recurring_message_issue_overrides", "ix_recurring_message_issue_overrides_Recurring_Message_Id", "Recurring_Message_Id"),
+    ("recurring_messages", "ix_recurring_messages_Section_Id", "Section_Id"),
+    ("submission_links", "ix_submission_links_Submission_Id", "Submission_Id"),
+    ("submission_schedule_requests", "ix_submission_schedule_requests_Submission_Id", "Submission_Id"),
+]
+
+
+def _existing_index_names(table: str) -> set[str]:
+    return {
+        index["name"] for index in sa.inspect(op.get_bind()).get_indexes(table)
+    }
+
+
 def upgrade() -> None:
-    with op.batch_alter_table("edit_versions", schema=None) as batch_op:
-        batch_op.create_index(
-            batch_op.f("ix_edit_versions_Submission_Id"), ["Submission_Id"], unique=False
-        )
-
-    with op.batch_alter_table("newsletter_external_items", schema=None) as batch_op:
-        batch_op.create_index(
-            batch_op.f("ix_newsletter_external_items_Newsletter_Id"),
-            ["Newsletter_Id"], unique=False,
-        )
-        batch_op.create_index(
-            batch_op.f("ix_newsletter_external_items_Section_Id"),
-            ["Section_Id"], unique=False,
-        )
-
-    with op.batch_alter_table("newsletter_items", schema=None) as batch_op:
-        batch_op.create_index(
-            batch_op.f("ix_newsletter_items_Newsletter_Id"),
-            ["Newsletter_Id"], unique=False,
-        )
-        batch_op.create_index(
-            batch_op.f("ix_newsletter_items_Section_Id"),
-            ["Section_Id"], unique=False,
-        )
-        batch_op.create_index(
-            batch_op.f("ix_newsletter_items_Submission_Id"),
-            ["Submission_Id"], unique=False,
-        )
-
-    with op.batch_alter_table("recurring_message_issue_overrides", schema=None) as batch_op:
-        batch_op.create_index(
-            batch_op.f("ix_recurring_message_issue_overrides_Newsletter_Id"),
-            ["Newsletter_Id"], unique=False,
-        )
-        batch_op.create_index(
-            batch_op.f("ix_recurring_message_issue_overrides_Recurring_Message_Id"),
-            ["Recurring_Message_Id"], unique=False,
-        )
-
-    with op.batch_alter_table("recurring_messages", schema=None) as batch_op:
-        batch_op.create_index(
-            batch_op.f("ix_recurring_messages_Section_Id"),
-            ["Section_Id"], unique=False,
-        )
-
-    with op.batch_alter_table("submission_links", schema=None) as batch_op:
-        batch_op.create_index(
-            batch_op.f("ix_submission_links_Submission_Id"),
-            ["Submission_Id"], unique=False,
-        )
-
-    with op.batch_alter_table("submission_schedule_requests", schema=None) as batch_op:
-        batch_op.create_index(
-            batch_op.f("ix_submission_schedule_requests_Submission_Id"),
-            ["Submission_Id"], unique=False,
-        )
+    for table, index_name, column_name in TABLE_INDEXES:
+        if index_name in _existing_index_names(table):
+            continue
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.create_index(index_name, [column_name], unique=False)
 
 
 def downgrade() -> None:
-    with op.batch_alter_table("submission_schedule_requests", schema=None) as batch_op:
-        batch_op.drop_index(batch_op.f("ix_submission_schedule_requests_Submission_Id"))
-
-    with op.batch_alter_table("submission_links", schema=None) as batch_op:
-        batch_op.drop_index(batch_op.f("ix_submission_links_Submission_Id"))
-
-    with op.batch_alter_table("recurring_messages", schema=None) as batch_op:
-        batch_op.drop_index(batch_op.f("ix_recurring_messages_Section_Id"))
-
-    with op.batch_alter_table("recurring_message_issue_overrides", schema=None) as batch_op:
-        batch_op.drop_index(batch_op.f("ix_recurring_message_issue_overrides_Recurring_Message_Id"))
-        batch_op.drop_index(batch_op.f("ix_recurring_message_issue_overrides_Newsletter_Id"))
-
-    with op.batch_alter_table("newsletter_items", schema=None) as batch_op:
-        batch_op.drop_index(batch_op.f("ix_newsletter_items_Submission_Id"))
-        batch_op.drop_index(batch_op.f("ix_newsletter_items_Section_Id"))
-        batch_op.drop_index(batch_op.f("ix_newsletter_items_Newsletter_Id"))
-
-    with op.batch_alter_table("newsletter_external_items", schema=None) as batch_op:
-        batch_op.drop_index(batch_op.f("ix_newsletter_external_items_Section_Id"))
-        batch_op.drop_index(batch_op.f("ix_newsletter_external_items_Newsletter_Id"))
-
-    with op.batch_alter_table("edit_versions", schema=None) as batch_op:
-        batch_op.drop_index(batch_op.f("ix_edit_versions_Submission_Id"))
+    for table, index_name, _column_name in reversed(TABLE_INDEXES):
+        if index_name not in _existing_index_names(table):
+            continue
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.drop_index(index_name)

--- a/backend/alembic/versions/d2e3f4a5b6c7_add_holiday_shift_enabled_to_schedule_configs.py
+++ b/backend/alembic/versions/d2e3f4a5b6c7_add_holiday_shift_enabled_to_schedule_configs.py
@@ -20,11 +20,20 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "schedule_configs",
-        sa.Column("Holiday_Shift_Enabled", sa.Boolean(), nullable=True, server_default=sa.text("false")),
-    )
+    # Some long-running deployments already have this column from an earlier
+    # Base.metadata.create_all() bootstrap that predated this migration. Guard
+    # the ADD so replays against a drifted DB stamp forward without failing.
+    bind = op.get_bind()
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("schedule_configs")}
+    if "Holiday_Shift_Enabled" not in columns:
+        op.add_column(
+            "schedule_configs",
+            sa.Column("Holiday_Shift_Enabled", sa.Boolean(), nullable=True, server_default=sa.text("false")),
+        )
 
 
 def downgrade() -> None:
-    op.drop_column("schedule_configs", "Holiday_Shift_Enabled")
+    bind = op.get_bind()
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("schedule_configs")}
+    if "Holiday_Shift_Enabled" in columns:
+        op.drop_column("schedule_configs", "Holiday_Shift_Enabled")


### PR DESCRIPTION
## Summary

- Guard `d2e3f4a5b6c7` (Holiday_Shift_Enabled column add) with an existence check
- Guard every index create in `67a4bd17e12f` (FK-column indexes) with an existence check, and refactor the body to a single data-driven loop
- Guards apply symmetrically on `downgrade()` so dropping is safe too

## Why

Both production (`ucm_newsletter`) and dev (`ucm_newsletter_dev`) databases have `alembic_version = b8f9c2d4e6a1` but the schema has every column/table/index through `67a4bd17e12f` already — drift accumulated from an earlier bootstrap that used `Base.metadata.create_all()` without stamping alembic. The next `alembic upgrade head` on either DB crashes:

```
DuplicateColumnError: column "Holiday_Shift_Enabled" of relation "schedule_configs" already exists
[SQL: ALTER TABLE schedule_configs ADD COLUMN "Holiday_Shift_Enabled" BOOLEAN DEFAULT false]
```

`792c4cd01807` (one revision between these two) is already self-idempotent and calls this out in its own docstring. This PR brings its neighbors to the same bar.

Discovered while deploying a feature branch to `ucmnews-dev`. Dev was unblocked by stamping its `alembic_version` directly to `67a4bd17e12f`; **prod has the identical drift and will hit the same error on next redeploy** unless this merges first.

## Test plan

- [ ] Fresh DB (no tables): `alembic upgrade head` still creates the column and indexes as before — no behavior change on clean installs
- [ ] Drifted DB (simulating prod/dev): pre-add the column and pre-create the indexes, stamp alembic back to `b8f9c2d4e6a1`, then run `alembic upgrade head` — should no-op the existing objects and finish cleanly
- [ ] `alembic downgrade b8f9c2d4e6a1` then `alembic upgrade head` round-trips without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)