### PR TITLE
Add SLC leadership calendar exploration spike

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f7_add_slc_calendar_fields_to_submissions.py
+++ b/backend/alembic/versions/a1b2c3d4e5f7_add_slc_calendar_fields_to_submissions.py
@@ -1,0 +1,146 @@
+"""add_slc_calendar_fields_to_submissions
+
+Revision ID: a1b2c3d4e5f7
+Revises: 67a4bd17e12f
+Create Date: 2026-04-19 11:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f7"
+down_revision: Union[str, Sequence[str], None] = "67a4bd17e12f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {column["name"] for column in inspector.get_columns("submissions")}
+
+    with op.batch_alter_table("submissions", schema=None) as batch_op:
+        if "Show_In_SLC_Calendar" not in columns:
+            batch_op.add_column(
+                sa.Column(
+                    "Show_In_SLC_Calendar",
+                    sa.Boolean(),
+                    nullable=False,
+                    server_default=sa.false(),
+                )
+            )
+        if "Event_Classification" not in columns:
+            batch_op.add_column(
+                sa.Column(
+                    "Event_Classification",
+                    sa.String(length=50),
+                    nullable=True,
+                )
+            )
+
+    rows = [
+        {
+            "Value_Group": "Event_Classification",
+            "Code": "strategic",
+            "Label": "Strategic Event",
+            "Display_Order": 10,
+            "Is_Active": True,
+            "Visibility_Role": "staff",
+            "Description": (
+                "Advances university priorities, relationships, operations, "
+                "or institutional goals."
+            ),
+        },
+        {
+            "Value_Group": "Event_Classification",
+            "Code": "signature",
+            "Label": "Signature Event",
+            "Display_Order": 20,
+            "Is_Active": True,
+            "Visibility_Role": "staff",
+            "Description": (
+                "Highly visible, public-facing event that represents the "
+                "university and shapes campus or community perception."
+            ),
+        },
+        {
+            "Value_Group": "Submission_Category",
+            "Code": "slc_event",
+            "Label": "SLC Calendar Event",
+            "Display_Order": 50,
+            "Is_Active": True,
+            "Visibility_Role": "slc",
+            "Description": (
+                "Event intended for the Senior Leadership Council calendar, "
+                "submitted via Auxiliary Services' vetting workflow."
+            ),
+        },
+    ]
+
+    for row in rows:
+        existing = bind.execute(
+            sa.text(
+                'SELECT "Id" FROM allowed_values '
+                'WHERE "Value_Group" = :value_group AND "Code" = :code'
+            ),
+            {"value_group": row["Value_Group"], "code": row["Code"]},
+        ).scalar_one_or_none()
+        if existing:
+            bind.execute(
+                sa.text(
+                    'UPDATE allowed_values '
+                    'SET "Label" = :label, "Display_Order" = :display_order, '
+                    '"Is_Active" = :is_active, "Visibility_Role" = :visibility_role, '
+                    '"Description" = :description '
+                    'WHERE "Value_Group" = :value_group AND "Code" = :code'
+                ),
+                {
+                    "label": row["Label"],
+                    "display_order": row["Display_Order"],
+                    "is_active": row["Is_Active"],
+                    "visibility_role": row["Visibility_Role"],
+                    "description": row["Description"],
+                    "value_group": row["Value_Group"],
+                    "code": row["Code"],
+                },
+            )
+            continue
+
+        bind.execute(
+            sa.text(
+                'INSERT INTO allowed_values '
+                '("Id", "Value_Group", "Code", "Label", "Display_Order", "Is_Active", '
+                '"Visibility_Role", "Description") '
+                'VALUES (:Id, :Value_Group, :Code, :Label, :Display_Order, :Is_Active, '
+                ':Visibility_Role, :Description)'
+            ),
+            {"Id": str(uuid.uuid4()), **row},
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute(
+        sa.text(
+            "DELETE FROM allowed_values "
+            "WHERE \"Value_Group\" = 'Event_Classification' "
+            "AND \"Code\" IN ('strategic', 'signature')"
+        )
+    )
+    op.execute(
+        sa.text(
+            "DELETE FROM allowed_values "
+            "WHERE \"Value_Group\" = 'Submission_Category' "
+            "AND \"Code\" = 'slc_event'"
+        )
+    )
+    with op.batch_alter_table("submissions", schema=None) as batch_op:
+        batch_op.drop_column("Event_Classification")
+        batch_op.drop_column("Show_In_SLC_Calendar")

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.engine import async_session_factory
 
-SubmitterRole = Literal["public", "staff"]
+SubmitterRole = Literal["public", "staff", "slc"]
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
@@ -17,6 +17,10 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
 async def get_submitter_role(
     x_user_role: str | None = Header(None, alias="X-User-Role"),
 ) -> SubmitterRole:
-    if x_user_role and x_user_role.lower() == "staff":
-        return cast(SubmitterRole, "staff")
+    if x_user_role:
+        normalized = x_user_role.lower()
+        if normalized == "staff":
+            return cast(SubmitterRole, "staff")
+        if normalized == "slc":
+            return cast(SubmitterRole, "slc")
     return cast(SubmitterRole, "public")

--- a/backend/app/api/v1/submissions.py
+++ b/backend/app/api/v1/submissions.py
@@ -84,6 +84,9 @@ async def _validate_schedule_request(
     target_newsletter: str,
     schedule_request: ScheduleRequestCreate,
 ) -> None:
+    if target_newsletter == "none":
+        # SLC-only events do not publish into a newsletter; no pub-day validation.
+        return
     if target_newsletter == "both":
         # For "both": Requested_Date is for TDR, Second_Requested_Date is for My UI
         if schedule_request.Requested_Date:
@@ -134,15 +137,25 @@ async def list_submissions(
     search: str | None = None,
     date_from: date | None = None,
     date_to: date | None = None,
+    slc_calendar_only: bool = False,
     offset: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
     db: AsyncSession = Depends(get_db),
     submission_role: SubmitterRole = Depends(get_submitter_role),
 ):
+    if slc_calendar_only and submission_role not in ("staff", "slc"):
+        raise HTTPException(
+            status_code=403,
+            detail="SLC calendar events are only visible to authorized viewers.",
+        )
+    # Viewers without staff/slc access never see SLC-only submissions.
+    exclude_slc_only = submission_role not in ("staff", "slc")
     items, total = await submission_service.list_submissions(
         db, status=status, category=category, target_newsletter=target_newsletter,
         search=search, date_from=date_from, date_to=date_to,
         offset=offset, limit=limit,
+        slc_calendar_only=slc_calendar_only,
+        exclude_slc_only=exclude_slc_only,
     )
     return _to_submission_list_response(items, total, submission_role)
 
@@ -155,6 +168,11 @@ async def get_submission(
 ):
     submission = await submission_service.get_submission(db, submission_id)
     if not submission:
+        raise HTTPException(status_code=404, detail="Submission not found")
+    if (
+        submission.Target_Newsletter == "none"
+        and submission_role not in ("staff", "slc")
+    ):
         raise HTTPException(status_code=404, detail="Submission not found")
     return _to_submission_response(submission, submission_role)
 

--- a/backend/app/models/submission.py
+++ b/backend/app/models/submission.py
@@ -15,6 +15,12 @@ vocabulary without code changes.
 SubmissionLink stores hyperlinks that should be embedded in the published item.
 SubmissionScheduleRequest lets submitters indicate preferred publication dates
 and repeat-run preferences.
+
+Beyond the newsletter audiences, a Submission may also be flagged for inclusion
+in the Senior Leadership Council calendar (Show_In_SLC_Calendar) and optionally
+classified as a Strategic or Signature Event (Event_Classification). SLC-only
+events use Target_Newsletter = "none"; events that are both newsletter-facing
+and SLC-visible keep their newsletter target and carry the SLC flag alongside.
 """
 
 import uuid
@@ -51,6 +57,10 @@ class Submission(Base):
     Image_Path: Mapped[str | None] = mapped_column(sa.String(512), nullable=True)
     Survey_End_Date: Mapped[date | None] = mapped_column(sa.Date, nullable=True)
     Status: Mapped[str] = mapped_column(sa.String(50), nullable=False, default="new")
+    Show_In_SLC_Calendar: Mapped[bool] = mapped_column(
+        sa.Boolean, nullable=False, default=False, server_default=sa.false()
+    )
+    Event_Classification: Mapped[str | None] = mapped_column(sa.String(50), nullable=True)
     Created_At: Mapped[datetime] = mapped_column(
         sa.DateTime, nullable=False, server_default=sa.func.now()
     )

--- a/backend/app/schemas/submission.py
+++ b/backend/app/schemas/submission.py
@@ -77,13 +77,15 @@ class ScheduleOccurrenceRescheduleRequest(BaseModel):
 
 class SubmissionCreate(BaseModel):
     Category: str = Field(..., min_length=1, max_length=100)
-    Target_Newsletter: str = Field(..., pattern=r"^(tdr|myui|both)$")
+    Target_Newsletter: str = Field(..., pattern=r"^(tdr|myui|both|none)$")
     Original_Headline: str = Field(..., min_length=1, max_length=500)
     Original_Body: str = Field(..., min_length=1)
     Submitter_Name: str = Field(..., min_length=1, max_length=255)
     Submitter_Email: str = Field(..., max_length=255)
     Submitter_Notes: str | None = None
     Survey_End_Date: date | None = None
+    Show_In_SLC_Calendar: bool = False
+    Event_Classification: str | None = Field(None, pattern=r"^(strategic|signature)$")
     Links: list[LinkCreate] = []
     Schedule_Requests: list[ScheduleRequestCreate] = Field(..., min_length=1)
 
@@ -97,7 +99,9 @@ class SubmissionUpdate(BaseModel):
     Assigned_Editor: str | None = Field(None, max_length=255)
     Editorial_Notes: str | None = None
     Category: str | None = Field(None, min_length=1, max_length=100)
-    Target_Newsletter: str | None = Field(None, pattern=r"^(tdr|myui|both)$")
+    Target_Newsletter: str | None = Field(None, pattern=r"^(tdr|myui|both|none)$")
+    Show_In_SLC_Calendar: bool | None = None
+    Event_Classification: str | None = Field(None, pattern=r"^(strategic|signature)$")
 
 
 class SubmissionResponse(BaseModel):
@@ -115,6 +119,8 @@ class SubmissionResponse(BaseModel):
     Has_Image: bool
     Image_Path: str | None
     Status: str
+    Show_In_SLC_Calendar: bool = False
+    Event_Classification: str | None = None
     Created_At: datetime
     Updated_At: datetime
     Links: list[LinkResponse]

--- a/backend/app/services/allowed_value_service.py
+++ b/backend/app/services/allowed_value_service.py
@@ -13,6 +13,7 @@ def _submission_category_visibility_filter(submission_role: SubmitterRole):
     return sa.or_(
         AllowedValue.Value_Group != "Submission_Category",
         AllowedValue.Visibility_Role == "public",
+        AllowedValue.Visibility_Role == submission_role,
     )
 
 
@@ -45,6 +46,11 @@ async def is_submission_category_allowed(
         AllowedValue.Is_Active == True,  # noqa: E712
     )
     if submission_role != "staff":
-        query = query.where(AllowedValue.Visibility_Role == "public")
+        query = query.where(
+            sa.or_(
+                AllowedValue.Visibility_Role == "public",
+                AllowedValue.Visibility_Role == submission_role,
+            )
+        )
     result = await db.execute(query)
     return result.scalar_one_or_none() is not None

--- a/backend/app/services/submission_service.py
+++ b/backend/app/services/submission_service.py
@@ -22,6 +22,8 @@ async def create_submission(db: AsyncSession, data: SubmissionCreate) -> Submiss
         Submitter_Email=data.Submitter_Email,
         Submitter_Notes=data.Submitter_Notes,
         Survey_End_Date=data.Survey_End_Date,
+        Show_In_SLC_Calendar=data.Show_In_SLC_Calendar,
+        Event_Classification=data.Event_Classification,
     )
     db.add(submission)
     await db.flush()
@@ -86,6 +88,8 @@ async def list_submissions(
     date_to: date | None = None,
     offset: int = 0,
     limit: int = 50,
+    slc_calendar_only: bool = False,
+    exclude_slc_only: bool = False,
 ) -> tuple[list[Submission], int]:
     query = select(Submission).options(
         selectinload(Submission.Links),
@@ -102,6 +106,13 @@ async def list_submissions(
     if target_newsletter:
         query = query.where(Submission.Target_Newsletter == target_newsletter)
         count_query = count_query.where(Submission.Target_Newsletter == target_newsletter)
+    if slc_calendar_only:
+        query = query.where(Submission.Show_In_SLC_Calendar.is_(True))
+        count_query = count_query.where(Submission.Show_In_SLC_Calendar.is_(True))
+    if exclude_slc_only:
+        # Hide submissions whose only audience is the SLC calendar (Target_Newsletter="none").
+        query = query.where(Submission.Target_Newsletter != "none")
+        count_query = count_query.where(Submission.Target_Newsletter != "none")
     if search:
         pattern = f"%{search}%"
         search_filter = Submission.Original_Headline.ilike(pattern) | Submission.Original_Body.ilike(pattern) | Submission.Submitter_Name.ilike(pattern)

--- a/backend/scripts/seed_slc_events.py
+++ b/backend/scripts/seed_slc_events.py
@@ -1,0 +1,157 @@
+"""Seed SLC calendar submissions from the Auxiliary Services spreadsheet.
+
+Reads FY26 events (April + May 2026) from AuxServices/Calendar Spreadsheet1.xlsx
+and inserts them as Submissions with Target_Newsletter="none" and
+Show_In_SLC_Calendar=True. Idempotent: skips any submission where the
+Submitter_Email + Original_Headline + Requested_Date combo already exists.
+
+Exists as a one-off exploration seed for the feature/slc-calendar-exploration
+branch — not wired into production seed.py.
+"""
+
+import asyncio
+import re
+import sys
+import warnings
+from datetime import date, datetime
+from pathlib import Path
+
+from openpyxl import load_workbook
+from sqlalchemy import select
+
+from app.db.engine import async_session_factory
+from app.models.submission import Submission, SubmissionScheduleRequest
+
+warnings.filterwarnings("ignore", category=UserWarning, module="openpyxl")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SPREADSHEET = REPO_ROOT / "AuxServices" / "Calendar Spreadsheet1.xlsx"
+SEED_EMAIL = "auxservices-seed@example.edu"
+SEED_NAME = "Auxiliary Services (spreadsheet import)"
+
+
+def _parse_cell_date(value) -> date | None:
+    """Return a date for a cell that's either a datetime, date, or a m/d range string."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        # Strip trailing "?" and whitespace, keep only the start of a range.
+        cleaned = value.strip().rstrip("?").strip()
+        cleaned = cleaned.split("-")[0].strip()
+        m = re.match(r"^(\d{1,2})/(\d{1,2})$", cleaned)
+        if m:
+            month, day = int(m.group(1)), int(m.group(2))
+            # FY26 Apr–May data all falls in calendar-year 2026.
+            return date(2026, month, day)
+    return None
+
+
+def _build_body(event: str, location: str | None, sponsor: str | None,
+                start_time: str | None, ticketed: str | None) -> str:
+    parts = [f"Event: {event}"]
+    if location:
+        parts.append(f"Location: {location}")
+    if sponsor:
+        parts.append(f"Sponsor: {sponsor}")
+    if start_time:
+        parts.append(f"Start Time: {start_time}")
+    if ticketed:
+        parts.append(f"Ticketed: {ticketed}")
+    return "\n".join(parts)
+
+
+async def seed_from_spreadsheet(spreadsheet_path: Path) -> int:
+    if not spreadsheet_path.exists():
+        print(f"Spreadsheet not found: {spreadsheet_path}", file=sys.stderr)
+        return 0
+
+    wb = load_workbook(spreadsheet_path, data_only=True)
+    if "FY26" not in wb.sheetnames:
+        print("FY26 sheet not found in spreadsheet", file=sys.stderr)
+        return 0
+
+    ws = wb["FY26"]
+    rows = list(ws.iter_rows(min_row=2, values_only=True))
+
+    inserted = 0
+    async with async_session_factory() as session:
+        for row in rows:
+            if not row or len(row) < 3:
+                continue
+            date_cell, start_time, event, location, sponsor, ticketed = (row + (None,) * 6)[:6]
+            if not event or not str(event).strip():
+                continue
+            event_title = str(event).strip()
+            event_date = _parse_cell_date(date_cell)
+            if event_date is None:
+                # Skip rows without a resolvable date.
+                continue
+            if event_date.year != 2026:
+                # One known row has a 2024 typo for the Boise Commencement.
+                continue
+            if event_date.month not in (4, 5):
+                continue
+
+            # Idempotency check
+            existing = await session.execute(
+                select(Submission)
+                .join(Submission.Schedule_Requests)
+                .where(
+                    Submission.Submitter_Email == SEED_EMAIL,
+                    Submission.Original_Headline == event_title,
+                    SubmissionScheduleRequest.Requested_Date == event_date,
+                )
+            )
+            if existing.scalar_one_or_none():
+                continue
+
+            body = _build_body(
+                event_title,
+                str(location).strip() if location else None,
+                str(sponsor).strip() if sponsor else None,
+                str(start_time).strip() if start_time else None,
+                str(ticketed).strip() if ticketed else None,
+            )
+
+            submission = Submission(
+                Category="slc_event",
+                Target_Newsletter="none",
+                Original_Headline=event_title,
+                Original_Body=body,
+                Submitter_Name=SEED_NAME,
+                Submitter_Email=SEED_EMAIL,
+                Show_In_SLC_Calendar=True,
+                Event_Classification=None,
+                Status="approved",
+            )
+            session.add(submission)
+            await session.flush()
+
+            session.add(
+                SubmissionScheduleRequest(
+                    Submission_Id=submission.Id,
+                    Requested_Date=event_date,
+                    Repeat_Count=1,
+                    Recurrence_Type="once",
+                    Recurrence_Interval=1,
+                    Excluded_Dates=[],
+                )
+            )
+            inserted += 1
+
+        await session.commit()
+
+    return inserted
+
+
+async def main() -> None:
+    count = await seed_from_spreadsheet(SPREADSHEET)
+    print(f"Inserted {count} SLC events from {SPREADSHEET.name}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ import EditPage from './pages/EditPage';
 import SettingsPage from './pages/SettingsPage';
 import RecurringMessagesPage from './pages/RecurringMessagesPage';
 import LandingPage from './pages/LandingPage';
+import SLCCalendarPage from './pages/SLCCalendarPage';
+import SLCEventSubmitPage from './pages/SLCEventSubmitPage';
 
 export default function App() {
   return (
@@ -21,6 +23,8 @@ export default function App() {
           <Route path="/edit/:id" element={<EditPage />} />
           <Route path="/builder" element={<BuilderPage />} />
           <Route path="/recurring-messages" element={<RecurringMessagesPage />} />
+          <Route path="/slc-calendar" element={<SLCCalendarPage />} />
+          <Route path="/submit-slc-event" element={<SLCEventSubmitPage />} />
           <Route path="/style-rules" element={<StyleRulesPage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Route>

--- a/frontend/src/api/submissions.ts
+++ b/frontend/src/api/submissions.ts
@@ -23,6 +23,7 @@ export async function listSubmissions(params?: {
   date_to?: string;
   offset?: number;
   limit?: number;
+  slc_calendar_only?: boolean;
 }): Promise<SubmissionListResponse> {
   const searchParams = new URLSearchParams();
   if (params) {

--- a/frontend/src/components/editor/AIEditControls.tsx
+++ b/frontend/src/components/editor/AIEditControls.tsx
@@ -4,7 +4,9 @@ interface AIEditControlsProps {
   onRejectEdit: () => void;
   loading: boolean;
   hasAIEdit: boolean;
-  targetNewsletter: 'tdr' | 'myui' | 'both';
+  // Accepts "none" so SLC-only submissions type-check, though AI editing is never
+  // triggered for them — all button branches below gate on 'tdr'/'myui'/'both'.
+  targetNewsletter: 'tdr' | 'myui' | 'both' | 'none';
   confidence?: number;
 }
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,20 +1,33 @@
 import { NavLink } from 'react-router-dom';
 import { getSubmitterRole } from '../../utils/submitterRole';
 
-const navItems = [
-  { to: '/submit', label: 'Submit', icon: '+ ' },
-  { to: '/dashboard', label: 'Dashboard', icon: '' },
-  { to: '/builder', label: 'Builder', icon: '' },
-  { to: '/recurring-messages', label: 'Recurring', icon: '' },
-  { to: '/style-rules', label: 'Style Rules', icon: '' },
-  { to: '/settings', label: 'Settings', icon: '' },
+type NavItem = {
+  to: string;
+  label: string;
+  icon: string;
+  roles: ('public' | 'staff' | 'slc')[];
+};
+
+const navItems: NavItem[] = [
+  { to: '/submit', label: 'Submit', icon: '+ ', roles: ['public', 'staff', 'slc'] },
+  { to: '/dashboard', label: 'Dashboard', icon: '', roles: ['staff'] },
+  { to: '/builder', label: 'Builder', icon: '', roles: ['staff'] },
+  { to: '/recurring-messages', label: 'Recurring', icon: '', roles: ['staff'] },
+  { to: '/slc-calendar', label: 'SLC Calendar', icon: '', roles: ['staff', 'slc'] },
+  { to: '/submit-slc-event', label: 'Submit SLC Event', icon: '+ ', roles: ['staff', 'slc'] },
+  { to: '/style-rules', label: 'Style Rules', icon: '', roles: ['staff'] },
+  { to: '/settings', label: 'Settings', icon: '', roles: ['staff'] },
 ];
+
+const ROLE_LABEL: Record<'public' | 'staff' | 'slc', string> = {
+  public: 'Submitter View',
+  staff: 'Staff View',
+  slc: 'SLC Leadership View',
+};
 
 export default function Sidebar() {
   const role = getSubmitterRole();
-  const filteredNavItems = role === 'staff'
-    ? navItems
-    : navItems.filter((item) => item.to === '/submit');
+  const filteredNavItems = navItems.filter((item) => item.roles.includes(role));
 
   return (
     <aside className="w-64 bg-gray-900 text-white min-h-screen flex flex-col">
@@ -28,7 +41,7 @@ export default function Sidebar() {
         <div className="mt-4 rounded-lg border border-gray-700 bg-gray-800/80 px-3 py-2">
           <p className="text-[11px] uppercase tracking-wide text-gray-500">Current Mode</p>
           <p className="mt-1 text-sm font-medium text-white">
-            {role === 'staff' ? 'Staff View' : 'Submitter View'}
+            {ROLE_LABEL[role]}
           </p>
           <NavLink
             to="/"

--- a/frontend/src/components/submission/SubmissionForm.tsx
+++ b/frontend/src/components/submission/SubmissionForm.tsx
@@ -19,6 +19,8 @@ const NEWSLETTER_CATEGORY_CODES: Record<TargetNewsletter, Set<string>> = {
   myui: new Set(['student', 'survey']),
   tdr: new Set(['faculty_staff', 'job_opportunity', 'employee_announcement', 'kudos', 'in_memoriam', 'survey', 'news_release', 'ucm_feature_story']),
   both: new Set(['faculty_staff', 'survey']),
+  // SLC-only events route through the dedicated SLC submission form, not this one.
+  none: new Set<string>(),
 };
 
 interface LinkEntry {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -38,12 +38,14 @@ const CATEGORY_LABELS: Record<string, string> = {
   in_memoriam: 'In Memoriam',
   news_release: 'News Release',
   calendar_event: 'Calendar Event',
+  slc_event: 'SLC Event',
 };
 
 const NEWSLETTER_LABELS: Record<string, string> = {
   tdr: 'TDR',
   myui: 'My UI',
   both: 'Both',
+  none: 'SLC only',
 };
 
 function toISODate(d: Date): string {

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -39,7 +39,7 @@ function RoleCard({
 export default function LandingPage() {
   const navigate = useNavigate();
 
-  const handleSelect = (role: 'public' | 'staff', target: string) => {
+  const handleSelect = (role: 'public' | 'staff' | 'slc', target: string) => {
     setSubmitterRole(role);
     navigate(target);
   };
@@ -67,7 +67,7 @@ export default function LandingPage() {
             </p>
           </div>
 
-          <div className="mt-10 grid gap-6 md:grid-cols-2">
+          <div className="mt-10 grid gap-6 md:grid-cols-3">
             <RoleCard
               title="Submitter View"
               description="Use the public-style submission experience to send announcements, events, and news items into the workflow."
@@ -81,6 +81,13 @@ export default function LandingPage() {
               actionLabel="Open Staff Workspace"
               accentClass="hover:border-ui-gold-300"
               onSelect={() => handleSelect('staff', '/dashboard')}
+            />
+            <RoleCard
+              title="SLC Leadership View"
+              description="Private calendar of strategic and signature events for Senior Leadership Council members and their admins. Exploration preview."
+              actionLabel="Open SLC Calendar"
+              accentClass="hover:border-ui-clearwater-300"
+              onSelect={() => handleSelect('slc', '/slc-calendar')}
             />
           </div>
         </div>

--- a/frontend/src/pages/SLCCalendarPage.tsx
+++ b/frontend/src/pages/SLCCalendarPage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, useCallback, useMemo } from 'react';
 import { listSubmissions } from '../api/submissions';
 import type { Submission, EventClassification } from '../types/submission';
 import CalendarView from '../components/dashboard/CalendarView';
-import DayDetail from '../components/dashboard/DayDetail';
 import { getSubmitterRole } from '../utils/submitterRole';
 import { getOccurrenceDates } from '../utils/submissionOccurrences';
 

--- a/frontend/src/pages/SLCCalendarPage.tsx
+++ b/frontend/src/pages/SLCCalendarPage.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useState, useCallback, useMemo } from 'react';
+import { listSubmissions } from '../api/submissions';
+import type { Submission, EventClassification } from '../types/submission';
+import CalendarView from '../components/dashboard/CalendarView';
+import DayDetail from '../components/dashboard/DayDetail';
+import { getSubmitterRole } from '../utils/submitterRole';
+import { getOccurrenceDates } from '../utils/submissionOccurrences';
+
+const CLASSIFICATION_STYLES: Record<EventClassification, string> = {
+  strategic: 'bg-ui-clearwater-50 text-ui-clearwater-700 border-ui-clearwater-200',
+  signature: 'bg-ui-gold-50 text-ui-gold-700 border-ui-gold-200',
+};
+
+function toISODate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export default function SLCCalendarPage() {
+  const role = getSubmitterRole();
+  const allowed = role === 'slc' || role === 'staff';
+
+  const [submissions, setSubmissions] = useState<Submission[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentMonth, setCurrentMonth] = useState(() => new Date(2026, 3, 1));
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [classificationFilter, setClassificationFilter] = useState<'' | EventClassification>('');
+
+  const fetchData = useCallback(async () => {
+    if (!allowed) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const year = currentMonth.getFullYear();
+      const month = currentMonth.getMonth();
+      const data = await listSubmissions({
+        slc_calendar_only: true,
+        date_from: toISODate(new Date(year, month, 1)),
+        date_to: toISODate(new Date(year, month + 1, 0)),
+        limit: 200,
+      });
+      setSubmissions(data.Items);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load SLC events');
+    } finally {
+      setLoading(false);
+    }
+  }, [currentMonth, allowed]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const filteredSubmissions = useMemo(() => {
+    if (!classificationFilter) return submissions;
+    return submissions.filter((s) => s.Event_Classification === classificationFilter);
+  }, [submissions, classificationFilter]);
+
+  const eventsByDate = useMemo(() => {
+    const map = new Map<string, Submission[]>();
+    for (const sub of filteredSubmissions) {
+      for (const dateKey of getOccurrenceDates(sub)) {
+        if (!map.has(dateKey)) map.set(dateKey, []);
+        map.get(dateKey)!.push(sub);
+      }
+    }
+    return map;
+  }, [filteredSubmissions]);
+
+  if (!allowed) {
+    return (
+      <div className="max-w-2xl mx-auto mt-12 bg-white rounded-lg shadow p-8 text-center">
+        <h2 className="text-lg font-semibold text-gray-900">Restricted calendar</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          The Senior Leadership Council calendar is only available to authorized viewers.
+          Switch to an SLC or Staff role from the landing page to view it.
+        </p>
+      </div>
+    );
+  }
+
+  const totalsByClassification = filteredSubmissions.reduce(
+    (acc, s) => {
+      if (s.Event_Classification === 'signature') acc.signature += 1;
+      else if (s.Event_Classification === 'strategic') acc.strategic += 1;
+      else acc.unclassified += 1;
+      return acc;
+    },
+    { signature: 0, strategic: 0, unclassified: 0 },
+  );
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6 flex-wrap gap-4">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">
+            Senior Leadership Council Calendar
+          </h2>
+          <p className="text-sm text-gray-500 mt-1">
+            Strategic and signature events for leadership awareness.
+            Access is limited to SLC members, their admins, and UCM staff.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <span className="rounded px-2 py-1 bg-ui-gold-50 text-ui-gold-700 border border-ui-gold-200">
+            Signature: {totalsByClassification.signature}
+          </span>
+          <span className="rounded px-2 py-1 bg-ui-clearwater-50 text-ui-clearwater-700 border border-ui-clearwater-200">
+            Strategic: {totalsByClassification.strategic}
+          </span>
+          <span className="rounded px-2 py-1 bg-gray-50 text-gray-600 border border-gray-200">
+            Unclassified: {totalsByClassification.unclassified}
+          </span>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-lg shadow p-4 mb-6">
+        <div className="flex gap-4 items-end flex-wrap">
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">Classification</label>
+            <select
+              value={classificationFilter}
+              onChange={(e) =>
+                setClassificationFilter(e.target.value as '' | EventClassification)
+              }
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+            >
+              <option value="">All</option>
+              <option value="strategic">Strategic only</option>
+              <option value="signature">Signature only</option>
+            </select>
+          </div>
+          <div className="text-xs text-gray-500 self-center">
+            Showing {filteredSubmissions.length} event
+            {filteredSubmissions.length === 1 ? '' : 's'} in{' '}
+            {currentMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 text-sm p-3 rounded-lg mb-4">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-center py-12 text-gray-500">Loading...</div>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2">
+            <CalendarView
+              submissions={filteredSubmissions}
+              selectedDate={selectedDate}
+              onDateClick={setSelectedDate}
+              currentMonth={currentMonth}
+              onMonthChange={setCurrentMonth}
+            />
+          </div>
+          <div>
+            {selectedDate ? (
+              <SLCDayPanel
+                date={selectedDate}
+                events={eventsByDate.get(selectedDate) ?? []}
+              />
+            ) : (
+              <div className="bg-white rounded-lg shadow p-8 text-center">
+                <p className="text-sm text-gray-400">
+                  Click a date to see SLC events.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SLCDayPanel({ date, events }: { date: string; events: Submission[] }) {
+  const display = new Date(date + 'T12:00:00').toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  return (
+    <div className="bg-white rounded-lg shadow">
+      <div className="px-4 py-3 border-b border-gray-100">
+        <h3 className="text-sm font-semibold text-gray-900">{display}</h3>
+        <p className="text-xs text-gray-500 mt-0.5">
+          {events.length} event{events.length === 1 ? '' : 's'}
+        </p>
+      </div>
+      <div className="p-4 space-y-3">
+        {events.length === 0 && (
+          <p className="text-sm text-gray-400">No SLC events on this date.</p>
+        )}
+        {events.map((event) => (
+          <div
+            key={event.Id}
+            className="rounded-md border border-gray-200 p-3 text-sm"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <h4 className="font-medium text-gray-900">{event.Original_Headline}</h4>
+              {event.Event_Classification && (
+                <span
+                  className={`shrink-0 text-[10px] uppercase tracking-wide rounded border px-1.5 py-0.5 ${
+                    CLASSIFICATION_STYLES[event.Event_Classification]
+                  }`}
+                >
+                  {event.Event_Classification}
+                </span>
+              )}
+            </div>
+            <pre className="mt-2 text-xs text-gray-600 whitespace-pre-wrap font-sans">
+              {event.Original_Body}
+            </pre>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/SLCEventSubmitPage.tsx
+++ b/frontend/src/pages/SLCEventSubmitPage.tsx
@@ -1,0 +1,367 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { createSubmission } from '../api/submissions';
+import type { EventClassification } from '../types/submission';
+import { getSubmitterRole } from '../utils/submitterRole';
+
+type TicketedValue = '' | 'no' | 'yes' | 'eventbrite' | 'cvent';
+
+const TICKETED_OPTIONS: { value: TicketedValue; label: string }[] = [
+  { value: '', label: 'Not sure yet' },
+  { value: 'no', label: 'No — open/free' },
+  { value: 'yes', label: 'Yes — general ticketing' },
+  { value: 'eventbrite', label: 'Yes — Eventbrite' },
+  { value: 'cvent', label: 'Yes — CVENT' },
+];
+
+type ClassificationChoice = '' | EventClassification;
+
+const CLASSIFICATION_OPTIONS: { value: ClassificationChoice; label: string; hint: string }[] = [
+  { value: '', label: 'Not sure — let Aux Services decide', hint: '' },
+  {
+    value: 'strategic',
+    label: 'Strategic',
+    hint: 'Advances university priorities, relationships, operations, or institutional goals.',
+  },
+  {
+    value: 'signature',
+    label: 'Signature',
+    hint: 'Highly visible, public-facing event that shapes campus or community perception.',
+  },
+];
+
+function buildBody(fields: {
+  eventName: string;
+  location: string;
+  sponsor: string;
+  startTime: string;
+  ticketedLabel: string;
+  notes: string;
+}): string {
+  const parts = [`Event: ${fields.eventName}`];
+  if (fields.location) parts.push(`Location: ${fields.location}`);
+  if (fields.sponsor) parts.push(`Sponsor: ${fields.sponsor}`);
+  if (fields.startTime) parts.push(`Start Time: ${fields.startTime}`);
+  if (fields.ticketedLabel) parts.push(`Ticketed: ${fields.ticketedLabel}`);
+  if (fields.notes) parts.push(`Notes: ${fields.notes}`);
+  return parts.join('\n');
+}
+
+export default function SLCEventSubmitPage() {
+  const navigate = useNavigate();
+  const role = getSubmitterRole();
+  const allowed = role === 'slc' || role === 'staff';
+
+  const [submitterName, setSubmitterName] = useState('');
+  const [submitterEmail, setSubmitterEmail] = useState('');
+  const [eventName, setEventName] = useState('');
+  const [eventDate, setEventDate] = useState('');
+  const [startTime, setStartTime] = useState('');
+  const [location, setLocation] = useState('');
+  const [sponsor, setSponsor] = useState('');
+  const [ticketed, setTicketed] = useState<TicketedValue>('');
+  const [classification, setClassification] = useState<ClassificationChoice>('');
+  const [notes, setNotes] = useState('');
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successId, setSuccessId] = useState<string | null>(null);
+
+  if (!allowed) {
+    return (
+      <div className="max-w-2xl mx-auto mt-12 bg-white rounded-lg shadow p-8 text-center">
+        <h2 className="text-lg font-semibold text-gray-900">Restricted</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          SLC event submission is only available to SLC members, their admins,
+          and UCM staff.
+        </p>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!submitterName || !submitterEmail || !eventName || !eventDate) {
+      setError('Submitter name, email, event name, and event date are required.');
+      return;
+    }
+
+    const ticketedLabel =
+      TICKETED_OPTIONS.find((opt) => opt.value === ticketed)?.label ?? '';
+
+    const body = buildBody({
+      eventName,
+      location,
+      sponsor,
+      startTime,
+      ticketedLabel: ticketed ? ticketedLabel : '',
+      notes,
+    });
+
+    setSubmitting(true);
+    try {
+      const created = await createSubmission({
+        Category: 'slc_event',
+        Target_Newsletter: 'none',
+        Original_Headline: eventName,
+        Original_Body: body,
+        Submitter_Name: submitterName,
+        Submitter_Email: submitterEmail,
+        Submitter_Notes: notes || undefined,
+        Show_In_SLC_Calendar: true,
+        Event_Classification: classification || undefined,
+        Schedule_Requests: [
+          {
+            Requested_Date: eventDate,
+            Recurrence_Type: 'once',
+            Repeat_Count: 1,
+          },
+        ],
+      });
+      setSuccessId(created.Id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to submit event.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (successId) {
+    return (
+      <div className="max-w-2xl mx-auto mt-12 bg-white rounded-lg shadow p-8">
+        <h2 className="text-lg font-semibold text-gray-900">Event submitted</h2>
+        <p className="mt-3 text-sm text-gray-700">
+          Thanks — your event has been sent to Auxiliary Services for review.
+          You'll see it on the SLC calendar once it's approved.
+        </p>
+        <div className="mt-6 flex gap-3">
+          <button
+            type="button"
+            onClick={() => navigate('/slc-calendar')}
+            className="px-4 py-2 text-sm font-medium rounded-md bg-ui-gold-500 text-ui-black hover:bg-ui-gold-400"
+          >
+            View SLC Calendar
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setSuccessId(null);
+              setEventName('');
+              setEventDate('');
+              setStartTime('');
+              setLocation('');
+              setSponsor('');
+              setTicketed('');
+              setClassification('');
+              setNotes('');
+            }}
+            className="px-4 py-2 text-sm font-medium rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200"
+          >
+            Submit Another
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <div className="mb-6">
+        <h2 className="text-2xl font-bold text-gray-900">Submit an SLC Calendar Event</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          For Senior Leadership Council awareness. Submissions are reviewed by
+          Auxiliary Services before appearing on the calendar.
+        </p>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 text-sm p-3 rounded-lg mb-4">
+          {error}
+        </div>
+      )}
+
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white rounded-lg shadow p-6 space-y-5"
+      >
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              Submitter Name <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={submitterName}
+              onChange={(e) => setSubmitterName(e.target.value)}
+              required
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              Submitter Email <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="email"
+              value={submitterEmail}
+              onChange={(e) => setSubmitterEmail(e.target.value)}
+              required
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Event Name <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            value={eventName}
+            onChange={(e) => setEventName(e.target.value)}
+            required
+            maxLength={500}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              Event Date <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="date"
+              value={eventDate}
+              onChange={(e) => setEventDate(e.target.value)}
+              required
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            />
+            <p className="text-[11px] text-gray-400 mt-1">
+              For multi-day events, use the start date and note the range in Notes.
+            </p>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              Start Time
+            </label>
+            <input
+              type="text"
+              value={startTime}
+              onChange={(e) => setStartTime(e.target.value)}
+              placeholder="e.g. 5:30 PM"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              Location
+            </label>
+            <input
+              type="text"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder="e.g. ICCU Arena"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              Sponsor / Hosting Unit
+            </label>
+            <input
+              type="text"
+              value={sponsor}
+              onChange={(e) => setSponsor(e.target.value)}
+              placeholder="e.g. Alumni Relations"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Ticketed?
+          </label>
+          <select
+            value={ticketed}
+            onChange={(e) => setTicketed(e.target.value as TicketedValue)}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+          >
+            {TICKETED_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Suggested Classification
+          </label>
+          <div className="space-y-2">
+            {CLASSIFICATION_OPTIONS.map((opt) => (
+              <label
+                key={opt.value}
+                className="flex items-start gap-3 rounded-md border border-gray-200 p-3 text-sm hover:bg-gray-50 cursor-pointer"
+              >
+                <input
+                  type="radio"
+                  name="classification"
+                  value={opt.value}
+                  checked={classification === opt.value}
+                  onChange={(e) =>
+                    setClassification(e.target.value as ClassificationChoice)
+                  }
+                  className="mt-0.5"
+                />
+                <div>
+                  <div className="font-medium text-gray-900">{opt.label}</div>
+                  {opt.hint && (
+                    <div className="text-xs text-gray-500 mt-0.5">{opt.hint}</div>
+                  )}
+                </div>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Notes
+          </label>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={3}
+            placeholder="Anything else SLC should know — date ranges, VIP guests, attendance expectations, etc."
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+          />
+        </div>
+
+        <div className="flex items-center justify-end gap-3 pt-2">
+          <button
+            type="button"
+            onClick={() => navigate('/slc-calendar')}
+            className="px-4 py-2 text-sm font-medium rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="px-4 py-2 text-sm font-medium rounded-md bg-ui-gold-500 text-ui-black hover:bg-ui-gold-400 disabled:opacity-50"
+          >
+            {submitting ? 'Submitting…' : 'Submit Event'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/types/submission.ts
+++ b/frontend/src/types/submission.ts
@@ -83,6 +83,8 @@ export interface SubmissionCreate {
   Submitter_Email: string;
   Submitter_Notes?: string;
   Survey_End_Date?: string;
+  Show_In_SLC_Calendar?: boolean;
+  Event_Classification?: EventClassification;
   Links?: { Url: string; Anchor_Text?: string }[];
   Schedule_Requests?: {
     Requested_Date?: string;

--- a/frontend/src/types/submission.ts
+++ b/frontend/src/types/submission.ts
@@ -7,12 +7,16 @@ export type SubmissionCategory =
   | 'employee_announcement'
   | 'survey'
   | 'news_release'
-  | 'ucm_feature_story';
+  | 'ucm_feature_story'
+  | 'slc_event';
 
 /** Legacy categories that may exist on old submissions but are no longer submittable. */
 export type LegacyCategory = 'calendar_event';
 
-export type TargetNewsletter = 'tdr' | 'myui' | 'both';
+/** "none" = SLC calendar only, no newsletter publication. */
+export type TargetNewsletter = 'tdr' | 'myui' | 'both' | 'none';
+
+export type EventClassification = 'strategic' | 'signature';
 
 export type SubmissionStatus =
   | 'new'
@@ -61,6 +65,8 @@ export interface Submission {
   Has_Image: boolean;
   Image_Path: string | null;
   Status: SubmissionStatus;
+  Show_In_SLC_Calendar: boolean;
+  Event_Classification: EventClassification | null;
   Created_At: string;
   Updated_At: string;
   Links: SubmissionLink[];

--- a/frontend/src/utils/submitterRole.ts
+++ b/frontend/src/utils/submitterRole.ts
@@ -1,11 +1,14 @@
-export type SubmitterRole = 'public' | 'staff';
+export type SubmitterRole = 'public' | 'staff' | 'slc';
 
 const STORAGE_KEY = 'ucm_submitter_role';
 
 function parseRole(value: string | null): SubmitterRole | null {
   if (!value) return null;
   const normalized = value.toLowerCase();
-  return normalized === 'staff' ? 'staff' : normalized === 'public' ? 'public' : null;
+  if (normalized === 'staff') return 'staff';
+  if (normalized === 'slc') return 'slc';
+  if (normalized === 'public') return 'public';
+  return null;
 }
 
 export function getSubmitterRole(): SubmitterRole {
@@ -32,5 +35,5 @@ export function setSubmitterRole(role: SubmitterRole) {
 
 export function getSubmitterRoleHeaders(): HeadersInit {
   const role = getSubmitterRole();
-  return role === 'staff' ? { 'X-User-Role': role } : {};
+  return role === 'public' ? {} : { 'X-User-Role': role };
 }


### PR DESCRIPTION
## Summary
- add the SLC leadership calendar exploration pages, routes, and navigation updates
- add backend submission fields, schema/API changes, and the migration needed to support SLC calendar data
- add SLC event seeding support and the TypeScript build fixes included on the branch

## Testing
- Not run in this PR workflow

## Notes
- Dev is currently running this branch