### PR TITLE
Harden CORS settings parsing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ MINDROUTER_ENDPOINT_URL=https://mindrouter.uidaho.edu/v1/chat/completions
 MINDROUTER_MODEL=openai/gpt-oss-120b
 
 # File uploads
+ENVIRONMENT=development
 UPLOAD_DIR=./uploads
 
 # University calendar source
@@ -31,5 +32,5 @@ JOB_POSTINGS_SOURCE_URL=https://uidaho.peopleadmin.com/postings/search
 JOB_POSTINGS_REQUEST_TIMEOUT_SECONDS=10.0
 JOB_POSTINGS_MAX_PAGES=5
 
-# CORS (comma-separated origins)
+# CORS (comma-separated origins; JSON arrays are also supported)
 CORS_ORIGINS=http://localhost:5173

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,12 @@
+import json
+from typing import Any, Self
+
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings
+
+
+LOCAL_DEV_CORS_ORIGINS = ["http://localhost:5173"]
+PRODUCTION_ENVIRONMENTS = {"prod", "production"}
 
 
 class Settings(BaseSettings):
@@ -22,8 +30,9 @@ class Settings(BaseSettings):
     mindrouter_model: str = "openai/gpt-oss-120b"
 
     # App
+    environment: str = "development"
     upload_dir: str = "./uploads"
-    cors_origins: list[str] = ["http://localhost:5173"]
+    cors_origins: str | list[str] | None = None
     calendar_source_url: str = (
         "https://www.qatrumba.com/events-calendar/ui/uidaho/vandals/vandal/event/events/calendar/moscow/idaho/id/university-of-idaho"
     )
@@ -33,6 +42,46 @@ class Settings(BaseSettings):
     job_postings_max_pages: int = 5
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+
+    @field_validator("cors_origins", mode="before")
+    @classmethod
+    def parse_cors_origins(cls, value: Any) -> list[str] | None:
+        """Accept comma-separated or JSON-array CORS origin values."""
+        if value is None:
+            return None
+
+        if isinstance(value, str):
+            raw_value = value.strip()
+            if not raw_value:
+                return None
+            if raw_value.startswith("["):
+                try:
+                    value = json.loads(raw_value)
+                except json.JSONDecodeError as exc:
+                    raise ValueError("CORS_ORIGINS must be comma-separated or a JSON array") from exc
+            else:
+                value = raw_value.split(",")
+
+        if isinstance(value, list):
+            origins = [str(origin).strip() for origin in value if str(origin).strip()]
+            return origins or None
+
+        raise ValueError("CORS_ORIGINS must be comma-separated or a JSON array")
+
+    @model_validator(mode="after")
+    def validate_cors_origins(self) -> Self:
+        is_production = self.environment.lower() in PRODUCTION_ENVIRONMENTS
+
+        if self.cors_origins is None:
+            if is_production:
+                raise ValueError("CORS_ORIGINS must be set when ENVIRONMENT=production")
+            self.cors_origins = LOCAL_DEV_CORS_ORIGINS.copy()
+            return self
+
+        if is_production and "*" in self.cors_origins:
+            raise ValueError("CORS_ORIGINS cannot include '*' when ENVIRONMENT=production")
+
+        return self
 
 
 settings = Settings()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,48 @@
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings
+
+
+def test_cors_origins_accept_comma_separated_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(
+        "CORS_ORIGINS",
+        "http://localhost:5173, https://ucmnews.insight.uidaho.edu",
+    )
+
+    settings = Settings(_env_file=None)
+
+    assert settings.cors_origins == [
+        "http://localhost:5173",
+        "https://ucmnews.insight.uidaho.edu",
+    ]
+
+
+def test_cors_origins_accept_json_array_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(
+        "CORS_ORIGINS",
+        '["http://localhost:5173", "https://ucmnews.insight.uidaho.edu"]',
+    )
+
+    settings = Settings(_env_file=None)
+
+    assert settings.cors_origins == [
+        "http://localhost:5173",
+        "https://ucmnews.insight.uidaho.edu",
+    ]
+
+
+def test_production_requires_explicit_cors_origins(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("CORS_ORIGINS", raising=False)
+
+    with pytest.raises(ValidationError, match="CORS_ORIGINS must be set"):
+        Settings(_env_file=None)
+
+
+def test_production_rejects_wildcard_cors_origin(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("CORS_ORIGINS", '["*"]')
+
+    with pytest.raises(ValidationError, match="cannot include"):
+        Settings(_env_file=None)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,9 @@ services:
       MINDROUTER_API_KEY: ${MINDROUTER_API_KEY:-}
       MINDROUTER_ENDPOINT_URL: ${MINDROUTER_ENDPOINT_URL:-https://mindrouter.uidaho.edu/v1/chat/completions}
       MINDROUTER_MODEL: ${MINDROUTER_MODEL:-Qwen/Qwen3-32B}
+      ENVIRONMENT: ${ENVIRONMENT:-production}
       UPLOAD_DIR: /app/uploads
-      CORS_ORIGINS: '${CORS_ORIGINS:-["*"]}'
+      CORS_ORIGINS: '${CORS_ORIGINS:?Set CORS_ORIGINS in .env}'
     volumes:
       - uploads:/app/uploads
     networks:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,6 +57,9 @@ Create a `.env` file in the project root (for Docker) or `backend/` directory (f
 # Database (SQLite for development)
 DATABASE_URL=sqlite+aiosqlite:///./ucm_newsletter.db
 
+# App environment
+ENVIRONMENT=development
+
 # LLM Provider ("claude", "openai", or "mindrouter")
 LLM_PROVIDER=claude
 
@@ -73,7 +76,7 @@ MINDROUTER_API_KEY=mr2_...
 MINDROUTER_ENDPOINT_URL=https://mindrouter.uidaho.edu/v1/chat/completions
 MINDROUTER_MODEL=openai/gpt-oss-120b
 
-# CORS (development)
+# CORS (development; comma-separated origins or a JSON array)
 CORS_ORIGINS=http://localhost:5173
 ```
 
@@ -226,6 +229,12 @@ MINDROUTER_MODEL=openai/gpt-oss-120b
 # Docker
 HOST_PORT=9280          # 9290 for dev
 DOCKER_SUBNET=10.20.9.0/24  # 10.20.10.0/24 for dev
+
+# App environment and CORS
+ENVIRONMENT=production
+CORS_ORIGINS=https://ucmnews.insight.uidaho.edu
+# For deployed dev:
+# CORS_ORIGINS=https://ucmnews-dev.insight.uidaho.edu
 ```
 
 ### Nginx Proxy Timeouts


### PR DESCRIPTION
## Summary
- parse CORS_ORIGINS from comma-separated values or JSON arrays
- require explicit CORS_ORIGINS in Docker deployments instead of defaulting to wildcard
- fail settings validation when production starts without CORS_ORIGINS or with wildcard origins
- document ENVIRONMENT/CORS deployment values

## Verification
- ./backend/.venv/bin/pytest backend/tests/test_config.py
- .venv/bin/ruff check . (from backend/)
- .venv/bin/pytest (from backend/)
- env DATABASE_URL=postgresql+asyncpg://ucm:example@insight-db:5432/ucm_newsletter CORS_ORIGINS=https://ucmnews.insight.uidaho.edu docker compose config
- env -u CORS_ORIGINS DATABASE_URL=postgresql+asyncpg://ucm:example@insight-db:5432/ucm_newsletter docker compose config (expected failure)

Closes #111