### PR TITLE
Infer role from direct-entry routes

### DIFF
--- a/frontend/src/utils/submitterRole.ts
+++ b/frontend/src/utils/submitterRole.ts
@@ -1,6 +1,16 @@
 export type SubmitterRole = 'public' | 'staff' | 'slc';
 
 const STORAGE_KEY = 'ucm_submitter_role';
+const STAFF_ONLY_ROUTE_PREFIXES = [
+  '/dashboard',
+  '/builder',
+  '/recurring-messages',
+  '/style-rules',
+  '/settings',
+  '/edit',
+  '/home',
+];
+const SLC_ROUTE_PREFIXES = ['/slc-calendar', '/submit-slc-event'];
 
 function parseRole(value: string | null): SubmitterRole | null {
   if (!value) return null;
@@ -11,18 +21,41 @@ function parseRole(value: string | null): SubmitterRole | null {
   return null;
 }
 
+function matchesRoutePrefix(pathname: string, prefix: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+function inferRoleFromPath(
+  pathname: string,
+  preferredRole: SubmitterRole | null,
+): SubmitterRole | null {
+  const normalizedPath = pathname.toLowerCase();
+
+  if (STAFF_ONLY_ROUTE_PREFIXES.some((prefix) => matchesRoutePrefix(normalizedPath, prefix))) {
+    return 'staff';
+  }
+
+  if (SLC_ROUTE_PREFIXES.some((prefix) => matchesRoutePrefix(normalizedPath, prefix))) {
+    return preferredRole === 'staff' || preferredRole === 'slc' ? preferredRole : 'slc';
+  }
+
+  return preferredRole;
+}
+
 export function getSubmitterRole(): SubmitterRole {
   if (typeof window === 'undefined') {
     return 'public';
   }
 
   const queryRole = parseRole(new URLSearchParams(window.location.search).get('role'));
-  if (queryRole) {
-    window.localStorage.setItem(STORAGE_KEY, queryRole);
-    return queryRole;
+  const storedRole = parseRole(window.localStorage.getItem(STORAGE_KEY));
+  const resolvedRole = inferRoleFromPath(window.location.pathname, queryRole ?? storedRole);
+
+  if (resolvedRole && resolvedRole !== storedRole) {
+    window.localStorage.setItem(STORAGE_KEY, resolvedRole);
   }
 
-  return parseRole(window.localStorage.getItem(STORAGE_KEY)) ?? 'public';
+  return resolvedRole ?? 'public';
 }
 
 export function setSubmitterRole(role: SubmitterRole) {


### PR DESCRIPTION
## Summary
- infer the effective submitter role from direct-entry routes instead of relying only on saved local state
- force staff mode for staff-only routes and default SLC routes to SLC mode unless an active staff session should be preserved
- keep sidebar mode, nav visibility, and request headers aligned when users land directly on staff or SLC pages

## Verification
- npm run lint
- npm run build
- verified direct entry from a forced public session in the in-app browser for /settings and /builder
- verified direct entry from a forced public session in the in-app browser for /slc-calendar, /submit-slc-event, and /edit/04520bea-2759-4cf2-99f3-f0373d2f74f7