### PR TITLE
Fix nested resource mutation scoping

### DIFF
--- a/backend/app/api/v1/newsletters.py
+++ b/backend/app/api/v1/newsletters.py
@@ -381,7 +381,7 @@ async def update_item(
 ):
     """Update a newsletter item."""
     update_data = data.model_dump(exclude_unset=True)
-    item = await newsletter_service.update_item(db, item_id, **update_data)
+    item = await newsletter_service.update_item(db, newsletter_id, item_id, **update_data)
     if not item:
         raise HTTPException(status_code=404, detail="Item not found")
     return item
@@ -401,7 +401,9 @@ async def update_external_item(
     """Update an imported external item."""
     _require_staff(submission_role)
     update_data = data.model_dump(exclude_unset=True)
-    item = await newsletter_service.update_external_item(db, item_id, **update_data)
+    item = await newsletter_service.update_external_item(
+        db, newsletter_id, item_id, **update_data
+    )
     if not item:
         raise HTTPException(status_code=404, detail="External item not found")
     return item
@@ -414,7 +416,7 @@ async def remove_external_item(
     db: AsyncSession = Depends(get_db),
 ):
     """Remove an imported external item from a newsletter."""
-    if not await newsletter_service.remove_external_item(db, item_id):
+    if not await newsletter_service.remove_external_item(db, newsletter_id, item_id):
         raise HTTPException(status_code=404, detail="External item not found")
 
 
@@ -425,7 +427,7 @@ async def remove_item(
     db: AsyncSession = Depends(get_db),
 ):
     """Remove an item from a newsletter."""
-    if not await newsletter_service.remove_item(db, item_id):
+    if not await newsletter_service.remove_item(db, newsletter_id, item_id):
         raise HTTPException(status_code=404, detail="Item not found")
 
 

--- a/backend/app/api/v1/submissions.py
+++ b/backend/app/api/v1/submissions.py
@@ -222,7 +222,7 @@ async def add_link(
 
 @router.delete("/{submission_id}/links/{link_id}", status_code=204)
 async def delete_link(submission_id: str, link_id: str, db: AsyncSession = Depends(get_db)):
-    deleted = await submission_service.delete_link(db, link_id)
+    deleted = await submission_service.delete_link(db, submission_id, link_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Link not found")
 
@@ -356,7 +356,7 @@ async def reschedule_schedule_occurrence(
 async def delete_schedule_request(
     submission_id: str, schedule_id: str, db: AsyncSession = Depends(get_db)
 ):
-    deleted = await submission_service.delete_schedule_request(db, schedule_id)
+    deleted = await submission_service.delete_schedule_request(db, submission_id, schedule_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Schedule request not found")
 

--- a/backend/app/services/newsletter_service.py
+++ b/backend/app/services/newsletter_service.py
@@ -165,11 +165,15 @@ async def add_external_item(
 
 async def update_item(
     db: AsyncSession,
+    newsletter_id: str,
     item_id: str,
     **kwargs,
 ) -> NewsletterItem | None:
     result = await db.execute(
-        sa.select(NewsletterItem).where(NewsletterItem.Id == item_id)
+        sa.select(NewsletterItem).where(
+            NewsletterItem.Id == item_id,
+            NewsletterItem.Newsletter_Id == newsletter_id,
+        )
     )
     item = result.scalar_one_or_none()
     if not item:
@@ -184,11 +188,15 @@ async def update_item(
 
 async def update_external_item(
     db: AsyncSession,
+    newsletter_id: str,
     item_id: str,
     **kwargs,
 ) -> NewsletterExternalItem | None:
     result = await db.execute(
-        sa.select(NewsletterExternalItem).where(NewsletterExternalItem.Id == item_id)
+        sa.select(NewsletterExternalItem).where(
+            NewsletterExternalItem.Id == item_id,
+            NewsletterExternalItem.Newsletter_Id == newsletter_id,
+        )
     )
     item = result.scalar_one_or_none()
     if not item:
@@ -201,9 +209,12 @@ async def update_external_item(
     return item
 
 
-async def remove_item(db: AsyncSession, item_id: str) -> bool:
+async def remove_item(db: AsyncSession, newsletter_id: str, item_id: str) -> bool:
     result = await db.execute(
-        sa.select(NewsletterItem).where(NewsletterItem.Id == item_id)
+        sa.select(NewsletterItem).where(
+            NewsletterItem.Id == item_id,
+            NewsletterItem.Newsletter_Id == newsletter_id,
+        )
     )
     item = result.scalar_one_or_none()
     if not item:
@@ -213,9 +224,14 @@ async def remove_item(db: AsyncSession, item_id: str) -> bool:
     return True
 
 
-async def remove_external_item(db: AsyncSession, item_id: str) -> bool:
+async def remove_external_item(
+    db: AsyncSession, newsletter_id: str, item_id: str
+) -> bool:
     result = await db.execute(
-        sa.select(NewsletterExternalItem).where(NewsletterExternalItem.Id == item_id)
+        sa.select(NewsletterExternalItem).where(
+            NewsletterExternalItem.Id == item_id,
+            NewsletterExternalItem.Newsletter_Id == newsletter_id,
+        )
     )
     item = result.scalar_one_or_none()
     if not item:

--- a/backend/app/services/submission_service.py
+++ b/backend/app/services/submission_service.py
@@ -219,8 +219,13 @@ async def add_link(
     return link
 
 
-async def delete_link(db: AsyncSession, link_id: str) -> bool:
-    result = await db.execute(select(SubmissionLink).where(SubmissionLink.Id == link_id))
+async def delete_link(db: AsyncSession, submission_id: str, link_id: str) -> bool:
+    result = await db.execute(
+        select(SubmissionLink).where(
+            SubmissionLink.Id == link_id,
+            SubmissionLink.Submission_Id == submission_id,
+        )
+    )
     link = result.scalar_one_or_none()
     if not link:
         return False
@@ -268,9 +273,14 @@ async def add_schedule_request(
     return sched
 
 
-async def delete_schedule_request(db: AsyncSession, schedule_id: str) -> bool:
+async def delete_schedule_request(
+    db: AsyncSession, submission_id: str, schedule_id: str
+) -> bool:
     result = await db.execute(
-        select(SubmissionScheduleRequest).where(SubmissionScheduleRequest.Id == schedule_id)
+        select(SubmissionScheduleRequest).where(
+            SubmissionScheduleRequest.Id == schedule_id,
+            SubmissionScheduleRequest.Submission_Id == submission_id,
+        )
     )
     sched = result.scalar_one_or_none()
     if not sched:

--- a/backend/tests/test_newsletters.py
+++ b/backend/tests/test_newsletters.py
@@ -111,6 +111,137 @@ class TestNewsletterItems:
         resp = await client.delete(f"/api/v1/newsletters/{nl_id}/items/{item_id}")
         assert resp.status_code == 204
 
+    async def test_update_item_rejects_wrong_newsletter_parent(
+        self, client: AsyncClient
+    ):
+        owner_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(Publish_Date="2026-03-01"),
+        )
+        other_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(Publish_Date="2026-03-02"),
+        )
+        owner_id = owner_resp.json()["Id"]
+        other_id = other_resp.json()["Id"]
+        sub_resp = await client.post("/api/v1/submissions/", json=make_submission_data())
+
+        item_resp = await client.post(
+            f"/api/v1/newsletters/{owner_id}/items",
+            json={
+                "Submission_Id": sub_resp.json()["Id"],
+                "Section_Id": "sec-1",
+                "Position": 0,
+                "Final_Headline": "Original headline",
+                "Final_Body": "Body",
+            },
+        )
+        item_id = item_resp.json()["Id"]
+
+        resp = await client.patch(
+            f"/api/v1/newsletters/{other_id}/items/{item_id}",
+            json={"Final_Headline": "Wrong parent edit"},
+        )
+        assert resp.status_code == 404
+
+        detail_resp = await client.get(f"/api/v1/newsletters/{owner_id}")
+        assert detail_resp.status_code == 200
+        assert detail_resp.json()["Items"][0]["Final_Headline"] == "Original headline"
+
+    async def test_remove_item_rejects_wrong_newsletter_parent(
+        self, client: AsyncClient
+    ):
+        owner_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(Publish_Date="2026-03-01"),
+        )
+        other_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(Publish_Date="2026-03-02"),
+        )
+        owner_id = owner_resp.json()["Id"]
+        other_id = other_resp.json()["Id"]
+        sub_resp = await client.post("/api/v1/submissions/", json=make_submission_data())
+
+        item_resp = await client.post(
+            f"/api/v1/newsletters/{owner_id}/items",
+            json={
+                "Submission_Id": sub_resp.json()["Id"],
+                "Section_Id": "sec-1",
+                "Position": 0,
+                "Final_Headline": "Keep me",
+                "Final_Body": "Body",
+            },
+        )
+        item_id = item_resp.json()["Id"]
+
+        resp = await client.delete(f"/api/v1/newsletters/{other_id}/items/{item_id}")
+        assert resp.status_code == 404
+
+        detail_resp = await client.get(f"/api/v1/newsletters/{owner_id}")
+        assert detail_resp.status_code == 200
+        assert [item["Id"] for item in detail_resp.json()["Items"]] == [item_id]
+
+    async def test_external_item_mutations_reject_wrong_newsletter_parent(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+    ):
+        db.add(
+            NewsletterSection(
+                Newsletter_Type="tdr",
+                Name="Today's Events",
+                Slug="todays-events",
+                Display_Order=4,
+                Is_Active=True,
+            )
+        )
+        await db.commit()
+
+        owner_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(Publish_Date="2026-03-01"),
+        )
+        other_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(Publish_Date="2026-03-02"),
+        )
+        owner_id = owner_resp.json()["Id"]
+        other_id = other_resp.json()["Id"]
+
+        item_resp = await client.post(
+            f"/api/v1/newsletters/{owner_id}/calendar-events",
+            json={
+                "Source_Id": "event-1",
+                "Url": "https://example.com/event-1",
+                "Title": "Accessibility Workshop",
+                "Description": "Learn accessible PDF output.",
+                "Location": "IRIC 305",
+                "Event_Start": "2026-03-19T12:00:00",
+                "Event_End": "2026-03-19T13:00:00",
+            },
+        )
+        assert item_resp.status_code == 201
+        item_id = item_resp.json()["Id"]
+
+        update_resp = await client.patch(
+            f"/api/v1/newsletters/{other_id}/external-items/{item_id}",
+            json={"Final_Headline": "Wrong parent edit"},
+            headers={"X-User-Role": "staff"},
+        )
+        assert update_resp.status_code == 404
+
+        delete_resp = await client.delete(
+            f"/api/v1/newsletters/{other_id}/external-items/{item_id}"
+        )
+        assert delete_resp.status_code == 404
+
+        detail_resp = await client.get(f"/api/v1/newsletters/{owner_id}")
+        assert detail_resp.status_code == 200
+        external_items = detail_resp.json()["External_Items"]
+        assert [item["Id"] for item in external_items] == [item_id]
+        assert external_items[0]["Final_Headline"] == "Accessibility Workshop"
+
     async def test_assemble_newsletter_uses_matching_recurring_occurrence(
         self,
         client: AsyncClient,

--- a/backend/tests/test_submissions.py
+++ b/backend/tests/test_submissions.py
@@ -331,6 +331,28 @@ class TestSubmissionLinks:
         resp = await client.delete(f"/api/v1/submissions/{sub_id}/links/{link_id}")
         assert resp.status_code == 204
 
+    async def test_delete_link_rejects_wrong_submission_parent(self, client: AsyncClient):
+        owner_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Links=[{"Url": "https://owner.example", "Anchor_Text": "Owner"}]
+            ),
+        )
+        other_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(Original_Headline="Other submission"),
+        )
+        owner_id = owner_resp.json()["Id"]
+        other_id = other_resp.json()["Id"]
+        link_id = owner_resp.json()["Links"][0]["Id"]
+
+        resp = await client.delete(f"/api/v1/submissions/{other_id}/links/{link_id}")
+        assert resp.status_code == 404
+
+        owner_detail = await client.get(f"/api/v1/submissions/{owner_id}")
+        assert owner_detail.status_code == 200
+        assert [link["Id"] for link in owner_detail.json()["Links"]] == [link_id]
+
 
 @pytest.mark.asyncio
 @freeze_time(FROZEN_TODAY)
@@ -373,6 +395,34 @@ class TestSubmissionSchedule:
 
         resp = await client.delete(f"/api/v1/submissions/{sub_id}/schedule/{sched_id}")
         assert resp.status_code == 204
+
+    async def test_delete_schedule_request_rejects_wrong_submission_parent(
+        self, client: AsyncClient
+    ):
+        owner_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Schedule_Requests=[{"Requested_Date": "2026-05-01", "Repeat_Count": 1}]
+            ),
+        )
+        other_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(Original_Headline="Other submission"),
+        )
+        owner_id = owner_resp.json()["Id"]
+        other_id = other_resp.json()["Id"]
+        schedule_id = owner_resp.json()["Schedule_Requests"][0]["Id"]
+
+        resp = await client.delete(
+            f"/api/v1/submissions/{other_id}/schedule/{schedule_id}"
+        )
+        assert resp.status_code == 404
+
+        owner_detail = await client.get(f"/api/v1/submissions/{owner_id}")
+        assert owner_detail.status_code == 200
+        assert [
+            schedule["Id"] for schedule in owner_detail.json()["Schedule_Requests"]
+        ] == [schedule_id]
 
     async def test_skip_schedule_occurrence(self, client: AsyncClient):
         data = make_submission_data(


### PR DESCRIPTION
## Summary
- Scope nested submission link and schedule deletion by both parent submission ID and child ID
- Scope newsletter item and external item update/delete by both parent newsletter ID and child ID
- Add regression tests proving cross-parent mutations return 404 and preserve the original records

## Tests
- cd backend && .venv/bin/pytest
- cd backend && .venv/bin/ruff check .

Closes #113