### PR TITLE
Harden staff authorization boundary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ MINDROUTER_MODEL=openai/gpt-oss-120b
 ENVIRONMENT=development
 UPLOAD_DIR=./uploads
 
+# Trusted auth boundary
+# Set this to the shared secret used by your reverse proxy or auth gateway when
+# it injects X-Trusted-User-Role and X-Trusted-Auth-Secret.
+TRUSTED_ROLE_HEADER_SECRET=
+
 # University calendar source
 CALENDAR_SOURCE_URL=https://www.qatrumba.com/events-calendar/ui/uidaho/vandals/vandal/event/events/calendar/moscow/idaho/id/university-of-idaho
 CALENDAR_REQUEST_TIMEOUT_SECONDS=10.0

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,9 +1,10 @@
 from collections.abc import AsyncGenerator
 from typing import Literal, cast
 
-from fastapi import Header
+from fastapi import Depends, Header, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.db.engine import async_session_factory
 
 SubmitterRole = Literal["public", "staff", "slc"]
@@ -16,11 +17,34 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
 
 async def get_submitter_role(
     x_user_role: str | None = Header(None, alias="X-User-Role"),
+    x_trusted_user_role: str | None = Header(None, alias="X-Trusted-User-Role"),
+    x_trusted_auth_secret: str | None = Header(None, alias="X-Trusted-Auth-Secret"),
 ) -> SubmitterRole:
     if x_user_role:
-        normalized = x_user_role.lower()
-        if normalized == "staff":
-            return cast(SubmitterRole, "staff")
-        if normalized == "slc":
-            return cast(SubmitterRole, "slc")
+        raise HTTPException(
+            status_code=400,
+            detail="X-User-Role is not accepted; user role must come from the trusted auth boundary.",
+        )
+
+    if x_trusted_user_role:
+        if not settings.trusted_role_header_secret:
+            raise HTTPException(status_code=403, detail="Trusted role headers are not configured.")
+        if x_trusted_auth_secret != settings.trusted_role_header_secret:
+            raise HTTPException(status_code=403, detail="Trusted role header verification failed.")
+
+        normalized = x_trusted_user_role.lower()
+        if normalized in ("staff", "slc"):
+            return cast(SubmitterRole, normalized)
+
     return cast(SubmitterRole, "public")
+
+
+async def require_staff(
+    submitter_role: SubmitterRole = Depends(get_submitter_role),
+) -> SubmitterRole:
+    if submitter_role != "staff":
+        raise HTTPException(
+            status_code=403,
+            detail="This action is available to staff editors only.",
+        )
+    return submitter_role

--- a/backend/app/api/v1/ai_edits.py
+++ b/backend/app/api/v1/ai_edits.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.config import settings
-from app.api.deps import get_db
+from app.api.deps import get_db, require_staff
 from app.models.submission import Submission
 from app.models.edit_history import EditVersion
 from app.services.ai.factory import get_llm_provider
@@ -30,6 +30,7 @@ async def trigger_ai_edit(
     submission_id: str,
     request: AIEditRequest,
     session: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Trigger AI editing on a submission for a specific newsletter type.
 
@@ -111,6 +112,7 @@ async def trigger_ai_edit(
 async def list_edit_versions(
     submission_id: str,
     session: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """List all edit versions for a submission."""
     result = await session.execute(
@@ -129,6 +131,7 @@ async def get_edit_version(
     submission_id: str,
     version_id: str,
     session: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Get a specific edit version."""
     result = await session.execute(
@@ -148,6 +151,7 @@ async def save_editor_final(
     submission_id: str,
     data: EditorFinalCreate,
     session: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Save the editor's final version of a submission.
 

--- a/backend/app/api/v1/newsletters.py
+++ b/backend/app/api/v1/newsletters.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import SubmitterRole, get_db, get_submitter_role
+from app.api.deps import get_db, require_staff
 from app.models.section import NewsletterSection
 from app.services import (
     calendar_event_service,
@@ -35,16 +35,12 @@ from app.utils.export import export_newsletter_docx
 router = APIRouter(prefix="/newsletters", tags=["newsletters"])
 
 
-def _require_staff(submission_role: SubmitterRole) -> None:
-    if submission_role != "staff":
-        raise HTTPException(
-            status_code=403,
-            detail="This action is available to staff editors only.",
-        )
-
-
 @router.post("", response_model=NewsletterResponse, status_code=201)
-async def create_newsletter(data: NewsletterCreate, db: AsyncSession = Depends(get_db)):
+async def create_newsletter(
+    data: NewsletterCreate,
+    db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
+):
     """Create a new newsletter draft."""
     newsletter = await newsletter_service.create_newsletter(
         db, data.Newsletter_Type, data.Publish_Date
@@ -77,6 +73,7 @@ async def update_status(
     newsletter_id: str,
     status: str,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Update newsletter status."""
     newsletter = await newsletter_service.update_newsletter_status(db, newsletter_id, status)
@@ -86,7 +83,11 @@ async def update_status(
 
 
 @router.delete("/{newsletter_id}", status_code=204)
-async def delete_newsletter(newsletter_id: str, db: AsyncSession = Depends(get_db)):
+async def delete_newsletter(
+    newsletter_id: str,
+    db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
+):
     """Delete a newsletter."""
     if not await newsletter_service.delete_newsletter(db, newsletter_id):
         raise HTTPException(status_code=404, detail="Newsletter not found")
@@ -100,6 +101,7 @@ async def add_item(
     newsletter_id: str,
     data: NewsletterItemCreate,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Add an item to a newsletter."""
     newsletter = await newsletter_service.get_newsletter(db, newsletter_id)
@@ -125,10 +127,9 @@ async def add_item(
 async def list_recurring_message_candidates(
     newsletter_id: str,
     db: AsyncSession = Depends(get_db),
-    submission_role: SubmitterRole = Depends(get_submitter_role),
+    _staff: None = Depends(require_staff),
 ):
     """Fetch recurring message candidates for a newsletter issue."""
-    _require_staff(submission_role)
     newsletter = await newsletter_service.get_newsletter(db, newsletter_id)
     if not newsletter:
         raise HTTPException(status_code=404, detail="Newsletter not found")
@@ -144,10 +145,9 @@ async def add_recurring_message(
     newsletter_id: str,
     recurring_message_id: str,
     db: AsyncSession = Depends(get_db),
-    submission_role: SubmitterRole = Depends(get_submitter_role),
+    _staff: None = Depends(require_staff),
 ):
     """Add a recurring message to a newsletter issue."""
-    _require_staff(submission_role)
     newsletter = await newsletter_service.get_newsletter(db, newsletter_id)
     if not newsletter:
         raise HTTPException(status_code=404, detail="Newsletter not found")
@@ -166,10 +166,9 @@ async def skip_recurring_message(
     newsletter_id: str,
     recurring_message_id: str,
     db: AsyncSession = Depends(get_db),
-    submission_role: SubmitterRole = Depends(get_submitter_role),
+    _staff: None = Depends(require_staff),
 ):
     """Skip a recurring message for a specific newsletter issue."""
-    _require_staff(submission_role)
     newsletter = await newsletter_service.get_newsletter(db, newsletter_id)
     if not newsletter:
         raise HTTPException(status_code=404, detail="Newsletter not found")
@@ -189,6 +188,7 @@ async def list_calendar_events(
     newsletter_id: str,
     extra_days: int = 0,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Fetch candidate calendar events for a newsletter issue.
 
@@ -231,6 +231,7 @@ async def list_calendar_events(
 async def list_job_postings(
     newsletter_id: str,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Fetch candidate job postings for a newsletter issue."""
     newsletter = await newsletter_service.get_newsletter(db, newsletter_id)
@@ -256,6 +257,7 @@ async def add_calendar_event(
     newsletter_id: str,
     data: CalendarEventImportRequest,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Import a calendar event into a newsletter section."""
     newsletter = await newsletter_service.get_newsletter(db, newsletter_id)
@@ -318,6 +320,7 @@ async def add_job_posting(
     newsletter_id: str,
     data: JobPostingImportRequest,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Import a job posting into a newsletter section."""
     newsletter = await newsletter_service.get_newsletter(db, newsletter_id)
@@ -378,6 +381,7 @@ async def update_item(
     item_id: str,
     data: NewsletterItemUpdate,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Update a newsletter item."""
     update_data = data.model_dump(exclude_unset=True)
@@ -396,10 +400,9 @@ async def update_external_item(
     item_id: str,
     data: NewsletterExternalItemUpdate,
     db: AsyncSession = Depends(get_db),
-    submission_role: SubmitterRole = Depends(get_submitter_role),
+    _staff: None = Depends(require_staff),
 ):
     """Update an imported external item."""
-    _require_staff(submission_role)
     update_data = data.model_dump(exclude_unset=True)
     item = await newsletter_service.update_external_item(
         db, newsletter_id, item_id, **update_data
@@ -414,6 +417,7 @@ async def remove_external_item(
     newsletter_id: str,
     item_id: str,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Remove an imported external item from a newsletter."""
     if not await newsletter_service.remove_external_item(db, newsletter_id, item_id):
@@ -425,6 +429,7 @@ async def remove_item(
     newsletter_id: str,
     item_id: str,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Remove an item from a newsletter."""
     if not await newsletter_service.remove_item(db, newsletter_id, item_id):
@@ -436,6 +441,7 @@ async def reorder_items(
     newsletter_id: str,
     positions: list[dict],
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Reorder items in a newsletter. Body: [{"id": "...", "position": 0, "section_id": "..."}]"""
     await newsletter_service.reorder_items(db, newsletter_id, positions)
@@ -446,7 +452,11 @@ async def reorder_items(
 
 
 @router.post("/assemble", response_model=NewsletterDetailResponse)
-async def assemble_newsletter(data: AssembleRequest, db: AsyncSession = Depends(get_db)):
+async def assemble_newsletter(
+    data: AssembleRequest,
+    db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
+):
     """Auto-populate a newsletter from approved submissions."""
     newsletter = await newsletter_service.assemble_newsletter(
         db, data.Newsletter_Type, data.Publish_Date
@@ -458,7 +468,11 @@ async def assemble_newsletter(data: AssembleRequest, db: AsyncSession = Depends(
 
 
 @router.get("/{newsletter_id}/export")
-async def export_newsletter(newsletter_id: str, db: AsyncSession = Depends(get_db)):
+async def export_newsletter(
+    newsletter_id: str,
+    db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
+):
     """Export a newsletter as a Word document."""
     newsletter = await newsletter_service.get_newsletter(db, newsletter_id)
     if not newsletter:

--- a/backend/app/api/v1/recurring_messages.py
+++ b/backend/app/api/v1/recurring_messages.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import SubmitterRole, get_db, get_submitter_role
+from app.api.deps import get_db, require_staff
 from app.schemas.recurring_message import (
     RecurringMessageCreate,
     RecurringMessageResponse,
@@ -14,23 +14,14 @@ from app.services import recurring_message_service
 router = APIRouter(prefix="/recurring-messages", tags=["recurring-messages"])
 
 
-def _require_staff(submission_role: SubmitterRole) -> None:
-    if submission_role != "staff":
-        raise HTTPException(
-            status_code=403,
-            detail="Recurring message management is available to staff editors only.",
-        )
-
-
 @router.get("", response_model=list[RecurringMessageResponse])
 async def list_recurring_messages(
     newsletter_type: str | None = None,
     active_only: bool = False,
     db: AsyncSession = Depends(get_db),
-    submission_role: SubmitterRole = Depends(get_submitter_role),
+    _staff: None = Depends(require_staff),
 ):
     """List recurring messages."""
-    _require_staff(submission_role)
     return await recurring_message_service.list_recurring_messages(
         db,
         newsletter_type=newsletter_type,
@@ -42,10 +33,9 @@ async def list_recurring_messages(
 async def create_recurring_message(
     data: RecurringMessageCreate,
     db: AsyncSession = Depends(get_db),
-    submission_role: SubmitterRole = Depends(get_submitter_role),
+    _staff: None = Depends(require_staff),
 ):
     """Create a recurring message."""
-    _require_staff(submission_role)
     try:
         return await recurring_message_service.create_recurring_message(
             db,
@@ -68,10 +58,9 @@ async def create_recurring_message(
 async def get_recurring_message(
     recurring_message_id: str,
     db: AsyncSession = Depends(get_db),
-    submission_role: SubmitterRole = Depends(get_submitter_role),
+    _staff: None = Depends(require_staff),
 ):
     """Get a recurring message."""
-    _require_staff(submission_role)
     message = await recurring_message_service.get_recurring_message(db, recurring_message_id)
     if not message:
         raise HTTPException(status_code=404, detail="Recurring message not found")
@@ -83,10 +72,9 @@ async def update_recurring_message(
     recurring_message_id: str,
     data: RecurringMessageUpdate,
     db: AsyncSession = Depends(get_db),
-    submission_role: SubmitterRole = Depends(get_submitter_role),
+    _staff: None = Depends(require_staff),
 ):
     """Update a recurring message."""
-    _require_staff(submission_role)
     try:
         message = await recurring_message_service.update_recurring_message(
             db,
@@ -104,9 +92,8 @@ async def update_recurring_message(
 async def delete_recurring_message(
     recurring_message_id: str,
     db: AsyncSession = Depends(get_db),
-    submission_role: SubmitterRole = Depends(get_submitter_role),
+    _staff: None = Depends(require_staff),
 ):
     """Delete a recurring message."""
-    _require_staff(submission_role)
     if not await recurring_message_service.delete_recurring_message(db, recurring_message_id):
         raise HTTPException(status_code=404, detail="Recurring message not found")

--- a/backend/app/api/v1/schedule.py
+++ b/backend/app/api/v1/schedule.py
@@ -5,7 +5,7 @@ from datetime import date
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_db
+from app.api.deps import get_db, require_staff
 from app.services import schedule_service
 from app.schemas.newsletter import (
     BlackoutDateCreate,
@@ -101,6 +101,7 @@ async def list_blackout_dates(
 async def create_blackout_date(
     data: BlackoutDateCreate,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Create a new blackout date."""
     return await schedule_service.create_blackout_date(db, data)
@@ -110,6 +111,7 @@ async def create_blackout_date(
 async def delete_blackout_date(
     blackout_id: str,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Delete a blackout date."""
     deleted = await schedule_service.delete_blackout_date(db, blackout_id)
@@ -135,6 +137,7 @@ async def list_mode_overrides(
 async def create_mode_override(
     data: ScheduleModeOverrideCreate,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Create a schedule mode override (e.g., activate winter break for a date range)."""
     if data.End_Date < data.Start_Date:
@@ -153,6 +156,7 @@ async def create_mode_override(
 async def delete_mode_override(
     override_id: str,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Delete a schedule mode override."""
     deleted = await schedule_service.delete_mode_override(db, override_id)
@@ -178,6 +182,7 @@ async def list_custom_dates(
 async def create_custom_date(
     data: CustomPublishDateCreate,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Add a custom publish date (e.g., for winter break editions)."""
     return await schedule_service.create_custom_publish_date(
@@ -192,6 +197,7 @@ async def create_custom_date(
 async def delete_custom_date(
     custom_date_id: str,
     db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Delete a custom publish date."""
     deleted = await schedule_service.delete_custom_publish_date(db, custom_date_id)

--- a/backend/app/api/v1/style_rules.py
+++ b/backend/app/api/v1/style_rules.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_db
+from app.api.deps import get_db, require_staff
 from app.models.style_rule import StyleRule
 from app.schemas.ai_edit import StyleRuleCreate, StyleRuleUpdate, StyleRuleResponse
 
@@ -34,6 +34,7 @@ async def list_style_rules(
 async def create_style_rule(
     data: StyleRuleCreate,
     session: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Create a new style rule."""
     rule = StyleRule(
@@ -70,6 +71,7 @@ async def update_style_rule(
     rule_id: str,
     data: StyleRuleUpdate,
     session: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Update a style rule."""
     result = await session.execute(
@@ -92,6 +94,7 @@ async def update_style_rule(
 async def delete_style_rule(
     rule_id: str,
     session: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     """Delete a style rule."""
     result = await session.execute(

--- a/backend/app/api/v1/submissions.py
+++ b/backend/app/api/v1/submissions.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import SubmitterRole, get_db, get_submitter_role
+from app.api.deps import SubmitterRole, get_db, get_submitter_role, require_staff
 from app.config import settings
 from app.schemas.submission import (
     LinkCreate,
@@ -199,7 +199,11 @@ async def update_submission(
 
 
 @router.delete("/{submission_id}", status_code=204)
-async def delete_submission(submission_id: str, db: AsyncSession = Depends(get_db)):
+async def delete_submission(
+    submission_id: str,
+    db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
+):
     deleted = await submission_service.delete_submission(db, submission_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Submission not found")
@@ -221,7 +225,12 @@ async def add_link(
 
 
 @router.delete("/{submission_id}/links/{link_id}", status_code=204)
-async def delete_link(submission_id: str, link_id: str, db: AsyncSession = Depends(get_db)):
+async def delete_link(
+    submission_id: str,
+    link_id: str,
+    db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
+):
     deleted = await submission_service.delete_link(db, submission_id, link_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Link not found")
@@ -354,7 +363,10 @@ async def reschedule_schedule_occurrence(
 
 @router.delete("/{submission_id}/schedule/{schedule_id}", status_code=204)
 async def delete_schedule_request(
-    submission_id: str, schedule_id: str, db: AsyncSession = Depends(get_db)
+    submission_id: str,
+    schedule_id: str,
+    db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     deleted = await submission_service.delete_schedule_request(db, submission_id, schedule_id)
     if not deleted:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -33,6 +33,7 @@ class Settings(BaseSettings):
     environment: str = "development"
     upload_dir: str = "./uploads"
     cors_origins: str | list[str] | None = None
+    trusted_role_header_secret: str = ""
     calendar_source_url: str = (
         "https://www.qatrumba.com/events-calendar/ui/uidaho/vandals/vandal/event/events/calendar/moscow/idaho/id/university-of-idaho"
     )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from app.api import deps as auth_deps
 from app.db.base import Base
 from app.api.deps import get_db
 from app.main import app as fastapi_app
@@ -17,6 +18,7 @@ from app.models.allowed_value import AllowedValue
 
 # In-memory SQLite for tests
 TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+TEST_TRUSTED_ROLE_SECRET = "test-trusted-role-secret"
 
 engine = create_async_engine(TEST_DATABASE_URL, connect_args={"check_same_thread": False})
 TestSession = async_sessionmaker(engine, expire_on_commit=False)
@@ -38,6 +40,25 @@ async def setup_db():
     yield
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.fixture(autouse=True)
+def configure_trusted_role_secret(monkeypatch: pytest.MonkeyPatch):
+    """Enable trusted role headers for tests that exercise staff-only flows."""
+    monkeypatch.setattr(
+        auth_deps.settings,
+        "trusted_role_header_secret",
+        TEST_TRUSTED_ROLE_SECRET,
+    )
+
+
+@pytest.fixture
+def staff_headers() -> dict[str, str]:
+    """Return headers that simulate the trusted auth boundary asserting staff."""
+    return {
+        "X-Trusted-User-Role": "staff",
+        "X-Trusted-Auth-Secret": TEST_TRUSTED_ROLE_SECRET,
+    }
 
 
 @pytest.fixture

--- a/backend/tests/test_allowed_values.py
+++ b/backend/tests/test_allowed_values.py
@@ -70,13 +70,13 @@ class TestAllowedValues:
         assert all(v["Visibility_Role"] == "public" for v in items)
 
     async def test_list_submission_categories_for_staff(
-        self, client: AsyncClient, db: AsyncSession
+        self, client: AsyncClient, db: AsyncSession, staff_headers: dict[str, str]
     ):
         await self._seed_values(db)
 
         resp = await client.get(
             "/api/v1/allowed-values?group=Submission_Category",
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert resp.status_code == 200
         items = resp.json()

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -1,0 +1,79 @@
+"""Tests for API authorization boundaries."""
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import make_newsletter_data, make_submission_data
+
+
+@pytest.mark.asyncio
+class TestTrustedRoleAuthorization:
+    async def test_rejects_client_controlled_user_role_header(self, client: AsyncClient):
+        resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(),
+            headers={"X-User-Role": "staff"},
+        )
+
+        assert resp.status_code == 400
+        assert "not accepted" in resp.json()["detail"]
+
+    async def test_rejects_trusted_role_without_valid_secret(self, client: AsyncClient):
+        resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(),
+            headers={
+                "X-Trusted-User-Role": "staff",
+                "X-Trusted-Auth-Secret": "wrong-secret",
+            },
+        )
+
+        assert resp.status_code == 403
+        assert "verification failed" in resp.json()["detail"]
+
+    async def test_public_cannot_create_update_delete_assemble_or_export_newsletters(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+    ):
+        create_resp = await client.post("/api/v1/newsletters", json=make_newsletter_data())
+        assert create_resp.status_code == 403
+
+        staff_create_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(),
+            headers=staff_headers,
+        )
+        assert staff_create_resp.status_code == 201
+        newsletter_id = staff_create_resp.json()["Id"]
+
+        update_resp = await client.patch(
+            f"/api/v1/newsletters/{newsletter_id}/status?status=in_progress"
+        )
+        assert update_resp.status_code == 403
+
+        assemble_resp = await client.post(
+            "/api/v1/newsletters/assemble",
+            json={"Newsletter_Type": "tdr", "Publish_Date": "2026-03-02"},
+        )
+        assert assemble_resp.status_code == 403
+
+        export_resp = await client.get(f"/api/v1/newsletters/{newsletter_id}/export")
+        assert export_resp.status_code == 403
+
+        delete_resp = await client.delete(f"/api/v1/newsletters/{newsletter_id}")
+        assert delete_resp.status_code == 403
+
+    async def test_public_cannot_trigger_ai_edit(self, client: AsyncClient):
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(),
+        )
+        assert submission_resp.status_code == 201
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_resp.json()['Id']}/edit",
+            json={"Newsletter_Type": "tdr"},
+        )
+
+        assert resp.status_code == 403

--- a/backend/tests/test_newsletters.py
+++ b/backend/tests/test_newsletters.py
@@ -13,25 +13,47 @@ from tests.conftest import make_newsletter_data, make_submission_data
 
 @pytest.mark.asyncio
 class TestNewsletterCRUD:
-    async def test_create_newsletter(self, client: AsyncClient):
-        resp = await client.post("/api/v1/newsletters", json=make_newsletter_data())
+    async def test_create_newsletter(self, client: AsyncClient, staff_headers: dict[str, str]):
+        resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(),
+            headers=staff_headers,
+        )
         assert resp.status_code == 201
         body = resp.json()
         assert body["Newsletter_Type"] == "tdr"
         assert body["Status"] == "draft"
         assert body["Id"]
 
-    async def test_list_newsletters(self, client: AsyncClient):
-        await client.post("/api/v1/newsletters", json=make_newsletter_data(Publish_Date="2026-03-01"))
-        await client.post("/api/v1/newsletters", json=make_newsletter_data(Publish_Date="2026-03-02"))
+    async def test_list_newsletters(self, client: AsyncClient, staff_headers: dict[str, str]):
+        await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(Publish_Date="2026-03-01"),
+            headers=staff_headers,
+        )
+        await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(Publish_Date="2026-03-02"),
+            headers=staff_headers,
+        )
 
         resp = await client.get("/api/v1/newsletters")
         assert resp.status_code == 200
         assert len(resp.json()) == 2
 
-    async def test_list_newsletters_filter_type(self, client: AsyncClient):
-        await client.post("/api/v1/newsletters", json=make_newsletter_data(Newsletter_Type="tdr"))
-        await client.post("/api/v1/newsletters", json=make_newsletter_data(Newsletter_Type="myui"))
+    async def test_list_newsletters_filter_type(
+        self, client: AsyncClient, staff_headers: dict[str, str]
+    ):
+        await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(Newsletter_Type="tdr"),
+            headers=staff_headers,
+        )
+        await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(Newsletter_Type="myui"),
+            headers=staff_headers,
+        )
 
         resp = await client.get("/api/v1/newsletters?newsletter_type=myui")
         assert resp.status_code == 200
@@ -39,8 +61,12 @@ class TestNewsletterCRUD:
         assert len(nls) == 1
         assert nls[0]["Newsletter_Type"] == "myui"
 
-    async def test_get_newsletter(self, client: AsyncClient):
-        create_resp = await client.post("/api/v1/newsletters", json=make_newsletter_data())
+    async def test_get_newsletter(self, client: AsyncClient, staff_headers: dict[str, str]):
+        create_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(),
+            headers=staff_headers,
+        )
         nl_id = create_resp.json()["Id"]
 
         resp = await client.get(f"/api/v1/newsletters/{nl_id}")
@@ -49,19 +75,32 @@ class TestNewsletterCRUD:
         assert body["Id"] == nl_id
         assert "Items" in body
 
-    async def test_update_newsletter_status(self, client: AsyncClient):
-        create_resp = await client.post("/api/v1/newsletters", json=make_newsletter_data())
+    async def test_update_newsletter_status(
+        self, client: AsyncClient, staff_headers: dict[str, str]
+    ):
+        create_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(),
+            headers=staff_headers,
+        )
         nl_id = create_resp.json()["Id"]
 
-        resp = await client.patch(f"/api/v1/newsletters/{nl_id}/status?status=in_progress")
+        resp = await client.patch(
+            f"/api/v1/newsletters/{nl_id}/status?status=in_progress",
+            headers=staff_headers,
+        )
         assert resp.status_code == 200
         assert resp.json()["Status"] == "in_progress"
 
-    async def test_delete_newsletter(self, client: AsyncClient):
-        create_resp = await client.post("/api/v1/newsletters", json=make_newsletter_data())
+    async def test_delete_newsletter(self, client: AsyncClient, staff_headers: dict[str, str]):
+        create_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(),
+            headers=staff_headers,
+        )
         nl_id = create_resp.json()["Id"]
 
-        resp = await client.delete(f"/api/v1/newsletters/{nl_id}")
+        resp = await client.delete(f"/api/v1/newsletters/{nl_id}", headers=staff_headers)
         assert resp.status_code == 204
 
         resp = await client.get(f"/api/v1/newsletters/{nl_id}")
@@ -70,9 +109,13 @@ class TestNewsletterCRUD:
 
 @pytest.mark.asyncio
 class TestNewsletterItems:
-    async def test_add_item(self, client: AsyncClient):
+    async def test_add_item(self, client: AsyncClient, staff_headers: dict[str, str]):
         # Create newsletter and submission
-        nl_resp = await client.post("/api/v1/newsletters", json=make_newsletter_data())
+        nl_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(),
+            headers=staff_headers,
+        )
         nl_id = nl_resp.json()["Id"]
         sub_resp = await client.post("/api/v1/submissions/", json=make_submission_data())
         sub_id = sub_resp.json()["Id"]
@@ -86,12 +129,17 @@ class TestNewsletterItems:
                 "Final_Headline": "Test headline",
                 "Final_Body": "Test body",
             },
+            headers=staff_headers,
         )
         assert resp.status_code == 201
         assert resp.json()["Final_Headline"] == "Test headline"
 
-    async def test_remove_item(self, client: AsyncClient):
-        nl_resp = await client.post("/api/v1/newsletters", json=make_newsletter_data())
+    async def test_remove_item(self, client: AsyncClient, staff_headers: dict[str, str]):
+        nl_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(),
+            headers=staff_headers,
+        )
         nl_id = nl_resp.json()["Id"]
         sub_resp = await client.post("/api/v1/submissions/", json=make_submission_data())
         sub_id = sub_resp.json()["Id"]
@@ -105,22 +153,28 @@ class TestNewsletterItems:
                 "Final_Headline": "Remove me",
                 "Final_Body": "Body",
             },
+            headers=staff_headers,
         )
         item_id = item_resp.json()["Id"]
 
-        resp = await client.delete(f"/api/v1/newsletters/{nl_id}/items/{item_id}")
+        resp = await client.delete(
+            f"/api/v1/newsletters/{nl_id}/items/{item_id}",
+            headers=staff_headers,
+        )
         assert resp.status_code == 204
 
     async def test_update_item_rejects_wrong_newsletter_parent(
-        self, client: AsyncClient
+        self, client: AsyncClient, staff_headers: dict[str, str]
     ):
         owner_resp = await client.post(
             "/api/v1/newsletters",
             json=make_newsletter_data(Publish_Date="2026-03-01"),
+            headers=staff_headers,
         )
         other_resp = await client.post(
             "/api/v1/newsletters",
             json=make_newsletter_data(Publish_Date="2026-03-02"),
+            headers=staff_headers,
         )
         owner_id = owner_resp.json()["Id"]
         other_id = other_resp.json()["Id"]
@@ -135,12 +189,14 @@ class TestNewsletterItems:
                 "Final_Headline": "Original headline",
                 "Final_Body": "Body",
             },
+            headers=staff_headers,
         )
         item_id = item_resp.json()["Id"]
 
         resp = await client.patch(
             f"/api/v1/newsletters/{other_id}/items/{item_id}",
             json={"Final_Headline": "Wrong parent edit"},
+            headers=staff_headers,
         )
         assert resp.status_code == 404
 
@@ -149,15 +205,17 @@ class TestNewsletterItems:
         assert detail_resp.json()["Items"][0]["Final_Headline"] == "Original headline"
 
     async def test_remove_item_rejects_wrong_newsletter_parent(
-        self, client: AsyncClient
+        self, client: AsyncClient, staff_headers: dict[str, str]
     ):
         owner_resp = await client.post(
             "/api/v1/newsletters",
             json=make_newsletter_data(Publish_Date="2026-03-01"),
+            headers=staff_headers,
         )
         other_resp = await client.post(
             "/api/v1/newsletters",
             json=make_newsletter_data(Publish_Date="2026-03-02"),
+            headers=staff_headers,
         )
         owner_id = owner_resp.json()["Id"]
         other_id = other_resp.json()["Id"]
@@ -172,10 +230,14 @@ class TestNewsletterItems:
                 "Final_Headline": "Keep me",
                 "Final_Body": "Body",
             },
+            headers=staff_headers,
         )
         item_id = item_resp.json()["Id"]
 
-        resp = await client.delete(f"/api/v1/newsletters/{other_id}/items/{item_id}")
+        resp = await client.delete(
+            f"/api/v1/newsletters/{other_id}/items/{item_id}",
+            headers=staff_headers,
+        )
         assert resp.status_code == 404
 
         detail_resp = await client.get(f"/api/v1/newsletters/{owner_id}")
@@ -186,6 +248,7 @@ class TestNewsletterItems:
         self,
         client: AsyncClient,
         db: AsyncSession,
+        staff_headers: dict[str, str],
     ):
         db.add(
             NewsletterSection(
@@ -201,10 +264,12 @@ class TestNewsletterItems:
         owner_resp = await client.post(
             "/api/v1/newsletters",
             json=make_newsletter_data(Publish_Date="2026-03-01"),
+            headers=staff_headers,
         )
         other_resp = await client.post(
             "/api/v1/newsletters",
             json=make_newsletter_data(Publish_Date="2026-03-02"),
+            headers=staff_headers,
         )
         owner_id = owner_resp.json()["Id"]
         other_id = other_resp.json()["Id"]
@@ -220,6 +285,7 @@ class TestNewsletterItems:
                 "Event_Start": "2026-03-19T12:00:00",
                 "Event_End": "2026-03-19T13:00:00",
             },
+            headers=staff_headers,
         )
         assert item_resp.status_code == 201
         item_id = item_resp.json()["Id"]
@@ -227,12 +293,13 @@ class TestNewsletterItems:
         update_resp = await client.patch(
             f"/api/v1/newsletters/{other_id}/external-items/{item_id}",
             json={"Final_Headline": "Wrong parent edit"},
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert update_resp.status_code == 404
 
         delete_resp = await client.delete(
-            f"/api/v1/newsletters/{other_id}/external-items/{item_id}"
+            f"/api/v1/newsletters/{other_id}/external-items/{item_id}",
+            headers=staff_headers,
         )
         assert delete_resp.status_code == 404
 
@@ -246,6 +313,7 @@ class TestNewsletterItems:
         self,
         client: AsyncClient,
         db: AsyncSession,
+        staff_headers: dict[str, str],
     ):
         db.add(
             NewsletterSection(
@@ -271,7 +339,7 @@ class TestNewsletterItems:
                     }
                 ],
             ),
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         recurring_id = recurring_resp.json()["Id"]
         await client.patch(
@@ -295,6 +363,7 @@ class TestNewsletterItems:
         assemble_resp = await client.post(
             "/api/v1/newsletters/assemble",
             json={"Newsletter_Type": "tdr", "Publish_Date": "2026-04-06"},
+            headers=staff_headers,
         )
         assert assemble_resp.status_code == 200
         items = assemble_resp.json()["Items"]
@@ -305,6 +374,7 @@ class TestNewsletterItems:
         self,
         client: AsyncClient,
         db: AsyncSession,
+        staff_headers: dict[str, str],
     ):
         db.add_all([
             NewsletterSection(
@@ -343,6 +413,7 @@ class TestNewsletterItems:
         assemble_resp = await client.post(
             "/api/v1/newsletters/assemble",
             json={"Newsletter_Type": "myui", "Publish_Date": "2026-04-06"},
+            headers=staff_headers,
         )
         assert assemble_resp.status_code == 200
         items = assemble_resp.json()["Items"]
@@ -474,8 +545,13 @@ class TestCalendarEventEndpoints:
         self,
         client: AsyncClient,
         monkeypatch: pytest.MonkeyPatch,
+        staff_headers: dict[str, str],
     ):
-        create_resp = await client.post("/api/v1/newsletters", json=make_newsletter_data())
+        create_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(),
+            headers=staff_headers,
+        )
         nl_id = create_resp.json()["Id"]
 
         async def fake_fetch_calendar_events(*args, **kwargs):
@@ -497,7 +573,10 @@ class TestCalendarEventEndpoints:
             fake_fetch_calendar_events,
         )
 
-        resp = await client.get(f"/api/v1/newsletters/{nl_id}/calendar-events")
+        resp = await client.get(
+            f"/api/v1/newsletters/{nl_id}/calendar-events",
+            headers=staff_headers,
+        )
         assert resp.status_code == 200
         body = resp.json()
         assert len(body) == 1
@@ -507,6 +586,7 @@ class TestCalendarEventEndpoints:
         self,
         client: AsyncClient,
         db: AsyncSession,
+        staff_headers: dict[str, str],
     ):
         db.add(
             NewsletterSection(
@@ -519,7 +599,11 @@ class TestCalendarEventEndpoints:
         )
         await db.commit()
 
-        create_resp = await client.post("/api/v1/newsletters", json=make_newsletter_data())
+        create_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(),
+            headers=staff_headers,
+        )
         nl_id = create_resp.json()["Id"]
 
         resp = await client.post(
@@ -533,6 +617,7 @@ class TestCalendarEventEndpoints:
                 "Event_Start": "2026-03-19T12:00:00",
                 "Event_End": "2026-03-19T13:00:00",
             },
+            headers=staff_headers,
         )
         assert resp.status_code == 201
         body = resp.json()
@@ -551,8 +636,13 @@ class TestJobPostingEndpoints:
         self,
         client: AsyncClient,
         monkeypatch: pytest.MonkeyPatch,
+        staff_headers: dict[str, str],
     ):
-        create_resp = await client.post("/api/v1/newsletters", json=make_newsletter_data())
+        create_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(),
+            headers=staff_headers,
+        )
         nl_id = create_resp.json()["Id"]
 
         async def fake_fetch_job_postings(*args, **kwargs):
@@ -575,7 +665,10 @@ class TestJobPostingEndpoints:
             fake_fetch_job_postings,
         )
 
-        resp = await client.get(f"/api/v1/newsletters/{nl_id}/job-postings")
+        resp = await client.get(
+            f"/api/v1/newsletters/{nl_id}/job-postings",
+            headers=staff_headers,
+        )
         assert resp.status_code == 200
         body = resp.json()
         assert len(body) == 1
@@ -585,6 +678,7 @@ class TestJobPostingEndpoints:
         self,
         client: AsyncClient,
         db: AsyncSession,
+        staff_headers: dict[str, str],
     ):
         db.add(
             NewsletterSection(
@@ -597,7 +691,11 @@ class TestJobPostingEndpoints:
         )
         await db.commit()
 
-        create_resp = await client.post("/api/v1/newsletters", json=make_newsletter_data())
+        create_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(),
+            headers=staff_headers,
+        )
         nl_id = create_resp.json()["Id"]
 
         resp = await client.post(
@@ -612,6 +710,7 @@ class TestJobPostingEndpoints:
                 "Closing_Date": "04/05/2026",
                 "Summary": "Responsible for providing complex technical support.",
             },
+            headers=staff_headers,
         )
         assert resp.status_code == 201
         body = resp.json()

--- a/backend/tests/test_recurring_messages.py
+++ b/backend/tests/test_recurring_messages.py
@@ -34,6 +34,7 @@ class TestRecurringMessageCRUD:
         self,
         client: AsyncClient,
         db: AsyncSession,
+        staff_headers: dict[str, str],
     ):
         await _seed_section(
             db,
@@ -55,14 +56,14 @@ class TestRecurringMessageCRUD:
                 "Recurrence_Interval": 1,
                 "End_Date": "2026-07-06",
             },
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert create_resp.status_code == 201
         message_id = create_resp.json()["Id"]
 
         list_resp = await client.get(
             "/api/v1/recurring-messages?newsletter_type=myui",
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert list_resp.status_code == 200
         assert len(list_resp.json()) == 1
@@ -70,14 +71,14 @@ class TestRecurringMessageCRUD:
         update_resp = await client.patch(
             f"/api/v1/recurring-messages/{message_id}",
             json={"Is_Active": False},
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert update_resp.status_code == 200
         assert update_resp.json()["Is_Active"] is False
 
         delete_resp = await client.delete(
             f"/api/v1/recurring-messages/{message_id}",
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert delete_resp.status_code == 204
 
@@ -115,6 +116,7 @@ class TestRecurringMessageIssueFlow:
         self,
         client: AsyncClient,
         db: AsyncSession,
+        staff_headers: dict[str, str],
     ):
         await _seed_section(
             db,
@@ -135,13 +137,14 @@ class TestRecurringMessageIssueFlow:
                 "Recurrence_Type": "weekly",
                 "Recurrence_Interval": 1,
             },
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         message_id = create_resp.json()["Id"]
 
         assemble_resp = await client.post(
             "/api/v1/newsletters/assemble",
             json={"Newsletter_Type": "tdr", "Publish_Date": "2026-04-03"},
+            headers=staff_headers,
         )
         assert assemble_resp.status_code == 200
         external_items = assemble_resp.json()["External_Items"]
@@ -153,6 +156,7 @@ class TestRecurringMessageIssueFlow:
         self,
         client: AsyncClient,
         db: AsyncSession,
+        staff_headers: dict[str, str],
     ):
         await _seed_section(
             db,
@@ -174,26 +178,27 @@ class TestRecurringMessageIssueFlow:
                 "Recurrence_Interval": 1,
                 "End_Date": "2026-04-07",
             },
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         message_id = create_resp.json()["Id"]
 
         assemble_resp = await client.post(
             "/api/v1/newsletters/assemble",
             json={"Newsletter_Type": "tdr", "Publish_Date": "2026-04-03"},
+            headers=staff_headers,
         )
         newsletter_id = assemble_resp.json()["Id"]
         assert len(assemble_resp.json()["External_Items"]) == 1
 
         skip_resp = await client.post(
             f"/api/v1/newsletters/{newsletter_id}/recurring-messages/{message_id}/skip",
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert skip_resp.status_code == 204
 
         candidates_after_skip = await client.get(
             f"/api/v1/newsletters/{newsletter_id}/recurring-messages",
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert candidates_after_skip.status_code == 200
         assert candidates_after_skip.json()[0]["Skipped"] is True
@@ -202,20 +207,21 @@ class TestRecurringMessageIssueFlow:
         reassemble_resp = await client.post(
             "/api/v1/newsletters/assemble",
             json={"Newsletter_Type": "tdr", "Publish_Date": "2026-04-03"},
+            headers=staff_headers,
         )
         assert reassemble_resp.status_code == 200
         assert reassemble_resp.json()["External_Items"] == []
 
         add_resp = await client.post(
             f"/api/v1/newsletters/{newsletter_id}/recurring-messages/{message_id}",
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert add_resp.status_code == 201
         assert add_resp.json()["Source_Type"] == "recurring_message"
 
         candidates_after_add = await client.get(
             f"/api/v1/newsletters/{newsletter_id}/recurring-messages",
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert candidates_after_add.status_code == 200
         assert candidates_after_add.json()[0]["Selected"] is True

--- a/backend/tests/test_style_rules.py
+++ b/backend/tests/test_style_rules.py
@@ -8,26 +8,44 @@ from tests.conftest import make_style_rule_data
 
 @pytest.mark.asyncio
 class TestStyleRuleCRUD:
-    async def test_create_style_rule(self, client: AsyncClient):
+    async def test_create_style_rule(self, client: AsyncClient, staff_headers: dict[str, str]):
         data = make_style_rule_data()
-        resp = await client.post("/api/v1/style-rules", json=data)
+        resp = await client.post("/api/v1/style-rules", json=data, headers=staff_headers)
         assert resp.status_code == 201
         body = resp.json()
         assert body["Rule_Key"] == "test_rule"
         assert body["Is_Active"] is True
         assert body["Id"]
 
-    async def test_list_style_rules(self, client: AsyncClient):
-        await client.post("/api/v1/style-rules", json=make_style_rule_data(Rule_Key="r1"))
-        await client.post("/api/v1/style-rules", json=make_style_rule_data(Rule_Key="r2"))
+    async def test_list_style_rules(self, client: AsyncClient, staff_headers: dict[str, str]):
+        await client.post(
+            "/api/v1/style-rules",
+            json=make_style_rule_data(Rule_Key="r1"),
+            headers=staff_headers,
+        )
+        await client.post(
+            "/api/v1/style-rules",
+            json=make_style_rule_data(Rule_Key="r2"),
+            headers=staff_headers,
+        )
 
         resp = await client.get("/api/v1/style-rules")
         assert resp.status_code == 200
         assert len(resp.json()) == 2
 
-    async def test_list_style_rules_filter_rule_set(self, client: AsyncClient):
-        await client.post("/api/v1/style-rules", json=make_style_rule_data(Rule_Set="shared", Rule_Key="s1"))
-        await client.post("/api/v1/style-rules", json=make_style_rule_data(Rule_Set="tdr", Rule_Key="t1"))
+    async def test_list_style_rules_filter_rule_set(
+        self, client: AsyncClient, staff_headers: dict[str, str]
+    ):
+        await client.post(
+            "/api/v1/style-rules",
+            json=make_style_rule_data(Rule_Set="shared", Rule_Key="s1"),
+            headers=staff_headers,
+        )
+        await client.post(
+            "/api/v1/style-rules",
+            json=make_style_rule_data(Rule_Set="tdr", Rule_Key="t1"),
+            headers=staff_headers,
+        )
 
         resp = await client.get("/api/v1/style-rules?rule_set=tdr")
         assert resp.status_code == 200
@@ -35,8 +53,12 @@ class TestStyleRuleCRUD:
         assert len(rules) == 1
         assert rules[0]["Rule_Set"] == "tdr"
 
-    async def test_get_style_rule(self, client: AsyncClient):
-        create_resp = await client.post("/api/v1/style-rules", json=make_style_rule_data())
+    async def test_get_style_rule(self, client: AsyncClient, staff_headers: dict[str, str]):
+        create_resp = await client.post(
+            "/api/v1/style-rules",
+            json=make_style_rule_data(),
+            headers=staff_headers,
+        )
         rule_id = create_resp.json()["Id"]
 
         resp = await client.get(f"/api/v1/style-rules/{rule_id}")
@@ -47,34 +69,50 @@ class TestStyleRuleCRUD:
         resp = await client.get("/api/v1/style-rules/nonexistent")
         assert resp.status_code == 404
 
-    async def test_update_style_rule(self, client: AsyncClient):
-        create_resp = await client.post("/api/v1/style-rules", json=make_style_rule_data())
+    async def test_update_style_rule(self, client: AsyncClient, staff_headers: dict[str, str]):
+        create_resp = await client.post(
+            "/api/v1/style-rules",
+            json=make_style_rule_data(),
+            headers=staff_headers,
+        )
         rule_id = create_resp.json()["Id"]
 
         resp = await client.patch(
             f"/api/v1/style-rules/{rule_id}",
             json={"Rule_Text": "Updated rule text", "Severity": "error"},
+            headers=staff_headers,
         )
         assert resp.status_code == 200
         assert resp.json()["Rule_Text"] == "Updated rule text"
         assert resp.json()["Severity"] == "error"
 
-    async def test_deactivate_style_rule(self, client: AsyncClient):
-        create_resp = await client.post("/api/v1/style-rules", json=make_style_rule_data())
+    async def test_deactivate_style_rule(
+        self, client: AsyncClient, staff_headers: dict[str, str]
+    ):
+        create_resp = await client.post(
+            "/api/v1/style-rules",
+            json=make_style_rule_data(),
+            headers=staff_headers,
+        )
         rule_id = create_resp.json()["Id"]
 
         resp = await client.patch(
             f"/api/v1/style-rules/{rule_id}",
             json={"Is_Active": False},
+            headers=staff_headers,
         )
         assert resp.status_code == 200
         assert resp.json()["Is_Active"] is False
 
-    async def test_delete_style_rule(self, client: AsyncClient):
-        create_resp = await client.post("/api/v1/style-rules", json=make_style_rule_data())
+    async def test_delete_style_rule(self, client: AsyncClient, staff_headers: dict[str, str]):
+        create_resp = await client.post(
+            "/api/v1/style-rules",
+            json=make_style_rule_data(),
+            headers=staff_headers,
+        )
         rule_id = create_resp.json()["Id"]
 
-        resp = await client.delete(f"/api/v1/style-rules/{rule_id}")
+        resp = await client.delete(f"/api/v1/style-rules/{rule_id}", headers=staff_headers)
         assert resp.status_code == 204
 
         resp = await client.get(f"/api/v1/style-rules/{rule_id}")

--- a/backend/tests/test_submissions.py
+++ b/backend/tests/test_submissions.py
@@ -77,7 +77,7 @@ class TestSubmissionCRUD:
         assert resp.json()["Survey_End_Date"] == "2026-04-15"
 
     async def test_create_submission_with_recurring_schedule(
-        self, client: AsyncClient, freeze_today
+        self, client: AsyncClient, freeze_today, staff_headers: dict[str, str]
     ):
         freeze_today(date(2026, 3, 10))
         data = make_submission_data(
@@ -93,7 +93,7 @@ class TestSubmissionCRUD:
         resp = await client.post(
             "/api/v1/submissions/",
             json=data,
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert resp.status_code == 201
         schedule = resp.json()["Schedule_Requests"][0]
@@ -133,12 +133,14 @@ class TestSubmissionCRUD:
         assert resp.status_code == 422
         assert "not available" in resp.json()["detail"]
 
-    async def test_staff_submitter_can_use_staff_only_category(self, client: AsyncClient):
+    async def test_staff_submitter_can_use_staff_only_category(
+        self, client: AsyncClient, staff_headers: dict[str, str]
+    ):
         data = make_submission_data(Category="news_release")
         resp = await client.post(
             "/api/v1/submissions/",
             json=data,
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert resp.status_code == 201
         assert resp.json()["Category"] == "news_release"
@@ -166,7 +168,7 @@ class TestSubmissionCRUD:
         assert resp.json()["Total"] == 0
 
     async def test_list_submissions_includes_recurring_occurrences_in_range(
-        self, client: AsyncClient
+        self, client: AsyncClient, staff_headers: dict[str, str]
     ):
         recurring = make_submission_data(
             Original_Headline="Recurring feature",
@@ -187,7 +189,7 @@ class TestSubmissionCRUD:
         await client.post(
             "/api/v1/submissions/",
             json=recurring,
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         await client.post("/api/v1/submissions/", json=one_off)
 
@@ -237,7 +239,9 @@ class TestSubmissionCRUD:
         assert resp.status_code == 200
         assert resp.json()["Survey_End_Date"] == "2026-05-01"
 
-    async def test_staff_can_update_editorial_workflow_fields(self, client: AsyncClient):
+    async def test_staff_can_update_editorial_workflow_fields(
+        self, client: AsyncClient, staff_headers: dict[str, str]
+    ):
         create_resp = await client.post("/api/v1/submissions/", json=make_submission_data())
         sub_id = create_resp.json()["Id"]
 
@@ -247,7 +251,7 @@ class TestSubmissionCRUD:
                 "Assigned_Editor": "Jane Editor",
                 "Editorial_Notes": "Waiting on quote confirmation.",
             },
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert resp.status_code == 200
         assert resp.json()["Assigned_Editor"] == "Jane Editor"
@@ -267,7 +271,7 @@ class TestSubmissionCRUD:
         assert "Only staff editors" in resp.json()["detail"]
 
     async def test_public_list_redacts_editorial_workflow_fields(
-        self, client: AsyncClient
+        self, client: AsyncClient, staff_headers: dict[str, str]
     ):
         create_resp = await client.post("/api/v1/submissions/", json=make_submission_data())
         sub_id = create_resp.json()["Id"]
@@ -277,7 +281,7 @@ class TestSubmissionCRUD:
                 "Assigned_Editor": "Jane Editor",
                 "Editorial_Notes": "Internal note.",
             },
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
 
         public_resp = await client.get("/api/v1/submissions/")
@@ -288,18 +292,18 @@ class TestSubmissionCRUD:
 
         staff_resp = await client.get(
             "/api/v1/submissions/",
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert staff_resp.status_code == 200
         staff_item = staff_resp.json()["Items"][0]
         assert staff_item["Assigned_Editor"] == "Jane Editor"
         assert staff_item["Editorial_Notes"] == "Internal note."
 
-    async def test_delete_submission(self, client: AsyncClient):
+    async def test_delete_submission(self, client: AsyncClient, staff_headers: dict[str, str]):
         create_resp = await client.post("/api/v1/submissions/", json=make_submission_data())
         sub_id = create_resp.json()["Id"]
 
-        resp = await client.delete(f"/api/v1/submissions/{sub_id}")
+        resp = await client.delete(f"/api/v1/submissions/{sub_id}", headers=staff_headers)
         assert resp.status_code == 204
 
         resp = await client.get(f"/api/v1/submissions/{sub_id}")
@@ -320,7 +324,7 @@ class TestSubmissionLinks:
         assert resp.status_code == 201
         assert resp.json()["Url"] == "https://test.com"
 
-    async def test_delete_link(self, client: AsyncClient):
+    async def test_delete_link(self, client: AsyncClient, staff_headers: dict[str, str]):
         data = make_submission_data(
             Links=[{"Url": "https://delete-me.com", "Anchor_Text": "Delete"}]
         )
@@ -328,10 +332,15 @@ class TestSubmissionLinks:
         link_id = create_resp.json()["Links"][0]["Id"]
         sub_id = create_resp.json()["Id"]
 
-        resp = await client.delete(f"/api/v1/submissions/{sub_id}/links/{link_id}")
+        resp = await client.delete(
+            f"/api/v1/submissions/{sub_id}/links/{link_id}",
+            headers=staff_headers,
+        )
         assert resp.status_code == 204
 
-    async def test_delete_link_rejects_wrong_submission_parent(self, client: AsyncClient):
+    async def test_delete_link_rejects_wrong_submission_parent(
+        self, client: AsyncClient, staff_headers: dict[str, str]
+    ):
         owner_resp = await client.post(
             "/api/v1/submissions/",
             json=make_submission_data(
@@ -346,7 +355,10 @@ class TestSubmissionLinks:
         other_id = other_resp.json()["Id"]
         link_id = owner_resp.json()["Links"][0]["Id"]
 
-        resp = await client.delete(f"/api/v1/submissions/{other_id}/links/{link_id}")
+        resp = await client.delete(
+            f"/api/v1/submissions/{other_id}/links/{link_id}",
+            headers=staff_headers,
+        )
         assert resp.status_code == 404
 
         owner_detail = await client.get(f"/api/v1/submissions/{owner_id}")
@@ -385,7 +397,9 @@ class TestSubmissionSchedule:
         assert resp.status_code == 403
         assert "staff editors only" in resp.json()["detail"]
 
-    async def test_delete_schedule_request(self, client: AsyncClient):
+    async def test_delete_schedule_request(
+        self, client: AsyncClient, staff_headers: dict[str, str]
+    ):
         data = make_submission_data(
             Schedule_Requests=[{"Requested_Date": "2026-05-01", "Repeat_Count": 1}]
         )
@@ -393,11 +407,14 @@ class TestSubmissionSchedule:
         sched_id = create_resp.json()["Schedule_Requests"][0]["Id"]
         sub_id = create_resp.json()["Id"]
 
-        resp = await client.delete(f"/api/v1/submissions/{sub_id}/schedule/{sched_id}")
+        resp = await client.delete(
+            f"/api/v1/submissions/{sub_id}/schedule/{sched_id}",
+            headers=staff_headers,
+        )
         assert resp.status_code == 204
 
     async def test_delete_schedule_request_rejects_wrong_submission_parent(
-        self, client: AsyncClient
+        self, client: AsyncClient, staff_headers: dict[str, str]
     ):
         owner_resp = await client.post(
             "/api/v1/submissions/",
@@ -414,7 +431,8 @@ class TestSubmissionSchedule:
         schedule_id = owner_resp.json()["Schedule_Requests"][0]["Id"]
 
         resp = await client.delete(
-            f"/api/v1/submissions/{other_id}/schedule/{schedule_id}"
+            f"/api/v1/submissions/{other_id}/schedule/{schedule_id}",
+            headers=staff_headers,
         )
         assert resp.status_code == 404
 
@@ -424,7 +442,9 @@ class TestSubmissionSchedule:
             schedule["Id"] for schedule in owner_detail.json()["Schedule_Requests"]
         ] == [schedule_id]
 
-    async def test_skip_schedule_occurrence(self, client: AsyncClient):
+    async def test_skip_schedule_occurrence(
+        self, client: AsyncClient, staff_headers: dict[str, str]
+    ):
         data = make_submission_data(
             Schedule_Requests=[
                 {
@@ -438,7 +458,7 @@ class TestSubmissionSchedule:
         create_resp = await client.post(
             "/api/v1/submissions/",
             json=data,
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         sched_id = create_resp.json()["Schedule_Requests"][0]["Id"]
         sub_id = create_resp.json()["Id"]
@@ -446,7 +466,7 @@ class TestSubmissionSchedule:
         resp = await client.post(
             f"/api/v1/submissions/{sub_id}/schedule/{sched_id}/skip",
             json={"Occurrence_Date": "2026-04-06"},
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert resp.status_code == 200
         assert resp.json()["Excluded_Dates"] == ["2026-04-06"]
@@ -459,7 +479,7 @@ class TestSubmissionSchedule:
         assert list_resp.json()["Total"] == 0
 
     async def test_reschedule_schedule_occurrence(
-        self, client: AsyncClient, freeze_today
+        self, client: AsyncClient, freeze_today, staff_headers: dict[str, str]
     ):
         freeze_today(date(2026, 3, 10))
         data = make_submission_data(
@@ -475,7 +495,7 @@ class TestSubmissionSchedule:
         create_resp = await client.post(
             "/api/v1/submissions/",
             json=data,
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         sched_id = create_resp.json()["Schedule_Requests"][0]["Id"]
         sub_id = create_resp.json()["Id"]
@@ -486,7 +506,7 @@ class TestSubmissionSchedule:
                 "Occurrence_Date": "2026-04-06",
                 "New_Date": "2026-04-08",
             },
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         assert resp.status_code == 201
         assert resp.json()["Requested_Date"] == "2026-04-08"
@@ -500,7 +520,9 @@ class TestSubmissionSchedule:
         assert body["Total"] == 1
         assert body["Items"][0]["Occurrence_Dates"] == ["2026-04-08"]
 
-    async def test_public_submitter_cannot_skip_occurrence(self, client: AsyncClient):
+    async def test_public_submitter_cannot_skip_occurrence(
+        self, client: AsyncClient, staff_headers: dict[str, str]
+    ):
         data = make_submission_data(
             Schedule_Requests=[
                 {
@@ -514,7 +536,7 @@ class TestSubmissionSchedule:
         create_resp = await client.post(
             "/api/v1/submissions/",
             json=data,
-            headers={"X-User-Role": "staff"},
+            headers=staff_headers,
         )
         sched_id = create_resp.json()["Schedule_Requests"][0]["Id"]
         sub_id = create_resp.json()["Id"]

--- a/frontend/src/components/submission/SubmissionForm.tsx
+++ b/frontend/src/components/submission/SubmissionForm.tsx
@@ -13,7 +13,7 @@ import SchedulePrefs from './SchedulePrefs';
 /**
  * Public categories filtered by target newsletter. Staff-visibility
  * categories (e.g., news_release, ucm_feature_story) bypass this
- * filter — the backend already gates them via the X-User-Role header.
+ * filter — the backend authorizes staff-only fields via the trusted auth boundary.
  */
 const NEWSLETTER_CATEGORY_CODES: Record<TargetNewsletter, Set<string>> = {
   myui: new Set(['student', 'survey']),

--- a/frontend/src/utils/submitterRole.ts
+++ b/frontend/src/utils/submitterRole.ts
@@ -67,6 +67,5 @@ export function setSubmitterRole(role: SubmitterRole) {
 }
 
 export function getSubmitterRoleHeaders(): HeadersInit {
-  const role = getSubmitterRole();
-  return role === 'public' ? {} : { 'X-User-Role': role };
+  return {};
 }


### PR DESCRIPTION
## Summary
- Reject client-supplied X-User-Role and accept role assertions only from a trusted auth boundary with X-Trusted-User-Role plus X-Trusted-Auth-Secret
- Add centralized require_staff dependency and apply it to staff-only newsletter, schedule, style rule, recurring message, AI edit, and destructive submission workflows
- Stop the frontend API client from sending role headers chosen in browser-local state
- Add authorization regression tests for rejected client role headers, invalid trusted secrets, public newsletter mutation/export/assembly denial, and public AI edit denial

## Tests
- cd backend && .venv/bin/pytest
- cd backend && .venv/bin/ruff check .
- cd frontend && npm run lint
- cd frontend && npm run build

Closes #108