### PR TITLE
Restrict public submission reads

### DIFF
--- a/backend/app/api/v1/submissions.py
+++ b/backend/app/api/v1/submissions.py
@@ -28,11 +28,16 @@ router = APIRouter(prefix="/submissions", tags=["submissions"])
 def _to_submission_response(
     submission,
     submission_role: SubmitterRole,
+    redact_pii: bool = False,
 ) -> SubmissionResponse:
     response = SubmissionResponse.model_validate(submission)
     if submission_role != "staff":
         response.Assigned_Editor = None
         response.Editorial_Notes = None
+    if redact_pii:
+        response.Submitter_Name = ""
+        response.Submitter_Email = ""
+        response.Submitter_Notes = None
     return response
 
 
@@ -40,10 +45,11 @@ def _to_submission_list_response(
     submissions: list,
     total: int,
     submission_role: SubmitterRole,
+    redact_pii: bool = False,
 ) -> SubmissionListResponse:
     return SubmissionListResponse(
         Items=[
-            _to_submission_response(submission, submission_role)
+            _to_submission_response(submission, submission_role, redact_pii=redact_pii)
             for submission in submissions
         ],
         Total=total,
@@ -143,6 +149,8 @@ async def list_submissions(
     db: AsyncSession = Depends(get_db),
     submission_role: SubmitterRole = Depends(get_submitter_role),
 ):
+    if not slc_calendar_only and submission_role != "staff":
+        raise HTTPException(status_code=403, detail="Submission listing is staff-only.")
     if slc_calendar_only and submission_role not in ("staff", "slc"):
         raise HTTPException(
             status_code=403,
@@ -157,22 +165,22 @@ async def list_submissions(
         slc_calendar_only=slc_calendar_only,
         exclude_slc_only=exclude_slc_only,
     )
-    return _to_submission_list_response(items, total, submission_role)
+    return _to_submission_list_response(
+        items,
+        total,
+        submission_role,
+        redact_pii=submission_role != "staff",
+    )
 
 
 @router.get("/{submission_id}", response_model=SubmissionResponse)
 async def get_submission(
     submission_id: str,
     db: AsyncSession = Depends(get_db),
-    submission_role: SubmitterRole = Depends(get_submitter_role),
+    submission_role: SubmitterRole = Depends(require_staff),
 ):
     submission = await submission_service.get_submission(db, submission_id)
     if not submission:
-        raise HTTPException(status_code=404, detail="Submission not found")
-    if (
-        submission.Target_Newsletter == "none"
-        and submission_role not in ("staff", "slc")
-    ):
         raise HTTPException(status_code=404, detail="Submission not found")
     return _to_submission_response(submission, submission_role)
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -62,6 +62,15 @@ def staff_headers() -> dict[str, str]:
 
 
 @pytest.fixture
+def slc_headers() -> dict[str, str]:
+    """Return headers that simulate the trusted auth boundary asserting SLC access."""
+    return {
+        "X-Trusted-User-Role": "slc",
+        "X-Trusted-Auth-Secret": TEST_TRUSTED_ROLE_SECRET,
+    }
+
+
+@pytest.fixture
 async def db() -> AsyncGenerator[AsyncSession, None]:
     """Provide an async DB session for direct model access in tests."""
     async with TestSession() as session:

--- a/backend/tests/postgres_smoke.py
+++ b/backend/tests/postgres_smoke.py
@@ -17,6 +17,7 @@ from datetime import date, timedelta
 import sqlalchemy as sa
 from httpx import ASGITransport, AsyncClient
 
+from app.config import settings
 from app.db.engine import async_session_factory
 from app.main import app as fastapi_app
 from app.models.edit_history import EditVersion
@@ -76,6 +77,11 @@ async def main() -> None:
         raise RuntimeError("DATABASE_URL must point to PostgreSQL for this smoke test.")
 
     submission_id = await seed_submission()
+    settings.trusted_role_header_secret = "postgres-smoke-secret"
+    staff_headers = {
+        "X-Trusted-User-Role": "staff",
+        "X-Trusted-Auth-Secret": "postgres-smoke-secret",
+    }
 
     transport = ASGITransport(app=fastapi_app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -87,7 +93,11 @@ async def main() -> None:
         assert settings_response.status_code == 200
         assert "active_provider" in settings_response.json()
 
-        submissions_response = await client.get("/api/v1/submissions/", params={"limit": 1})
+        submissions_response = await client.get(
+            "/api/v1/submissions/",
+            params={"limit": 1},
+            headers=staff_headers,
+        )
         assert submissions_response.status_code == 200
         payload = submissions_response.json()
         assert payload["Total"] >= 1
@@ -96,7 +106,10 @@ async def main() -> None:
         assert first_item["Schedule_Requests"][0]["Recurrence_Type"] == "weekly"
         assert "Occurrence_Dates" in first_item["Schedule_Requests"][0]
 
-        detail_response = await client.get(f"/api/v1/submissions/{submission_id}")
+        detail_response = await client.get(
+            f"/api/v1/submissions/{submission_id}",
+            headers=staff_headers,
+        )
         assert detail_response.status_code == 200
         detail_payload = detail_response.json()
         assert detail_payload["Schedule_Requests"][0]["Recurrence_Interval"] == 2

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -77,3 +77,62 @@ class TestTrustedRoleAuthorization:
         )
 
         assert resp.status_code == 403
+
+    async def test_public_cannot_list_or_read_submissions(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+    ):
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(),
+        )
+        assert submission_resp.status_code == 201
+        submission_id = submission_resp.json()["Id"]
+
+        list_resp = await client.get("/api/v1/submissions/")
+        assert list_resp.status_code == 403
+
+        detail_resp = await client.get(f"/api/v1/submissions/{submission_id}")
+        assert detail_resp.status_code == 403
+
+        staff_list_resp = await client.get("/api/v1/submissions/", headers=staff_headers)
+        assert staff_list_resp.status_code == 200
+        staff_item = staff_list_resp.json()["Items"][0]
+        assert staff_item["Submitter_Name"] == "Test User"
+        assert staff_item["Submitter_Email"] == "test@uidaho.edu"
+
+        staff_detail_resp = await client.get(
+            f"/api/v1/submissions/{submission_id}",
+            headers=staff_headers,
+        )
+        assert staff_detail_resp.status_code == 200
+        assert staff_detail_resp.json()["Submitter_Email"] == "test@uidaho.edu"
+
+    async def test_slc_calendar_feed_redacts_submitter_pii(
+        self,
+        client: AsyncClient,
+        slc_headers: dict[str, str],
+    ):
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Target_Newsletter="none",
+                Show_In_SLC_Calendar=True,
+                Submitter_Name="Sensitive Submitter",
+                Submitter_Email="sensitive@uidaho.edu",
+                Submitter_Notes="Private note",
+            ),
+        )
+        assert submission_resp.status_code == 201
+
+        resp = await client.get(
+            "/api/v1/submissions/?slc_calendar_only=true",
+            headers=slc_headers,
+        )
+
+        assert resp.status_code == 200
+        item = resp.json()["Items"][0]
+        assert item["Submitter_Name"] == ""
+        assert item["Submitter_Email"] == ""
+        assert item["Submitter_Notes"] is None

--- a/backend/tests/test_submissions.py
+++ b/backend/tests/test_submissions.py
@@ -145,26 +145,31 @@ class TestSubmissionCRUD:
         assert resp.status_code == 201
         assert resp.json()["Category"] == "news_release"
 
-    async def test_list_submissions(self, client: AsyncClient):
+    async def test_list_submissions(self, client: AsyncClient, staff_headers: dict[str, str]):
         # Create two submissions
         await client.post("/api/v1/submissions/", json=make_submission_data())
         await client.post(
             "/api/v1/submissions/",
             json=make_submission_data(Original_Headline="Second one"),
         )
-        resp = await client.get("/api/v1/submissions/")
+        resp = await client.get("/api/v1/submissions/", headers=staff_headers)
         assert resp.status_code == 200
         body = resp.json()
         assert body["Total"] == 2
         assert len(body["Items"]) == 2
 
-    async def test_list_submissions_filter_status(self, client: AsyncClient):
+    async def test_list_submissions_filter_status(
+        self, client: AsyncClient, staff_headers: dict[str, str]
+    ):
         await client.post("/api/v1/submissions/", json=make_submission_data())
-        resp = await client.get("/api/v1/submissions/?status=new")
+        resp = await client.get("/api/v1/submissions/?status=new", headers=staff_headers)
         assert resp.status_code == 200
         assert resp.json()["Total"] == 1
 
-        resp = await client.get("/api/v1/submissions/?status=approved")
+        resp = await client.get(
+            "/api/v1/submissions/?status=approved",
+            headers=staff_headers,
+        )
         assert resp.json()["Total"] == 0
 
     async def test_list_submissions_includes_recurring_occurrences_in_range(
@@ -194,7 +199,8 @@ class TestSubmissionCRUD:
         await client.post("/api/v1/submissions/", json=one_off)
 
         resp = await client.get(
-            "/api/v1/submissions/?date_from=2026-04-01&date_to=2026-04-30"
+            "/api/v1/submissions/?date_from=2026-04-01&date_to=2026-04-30",
+            headers=staff_headers,
         )
         assert resp.status_code == 200
         body = resp.json()
@@ -202,16 +208,16 @@ class TestSubmissionCRUD:
         assert body["Items"][0]["Original_Headline"] == "Recurring feature"
         assert body["Items"][0]["Occurrence_Dates"] == ["2026-04-06"]
 
-    async def test_get_submission(self, client: AsyncClient):
+    async def test_get_submission(self, client: AsyncClient, staff_headers: dict[str, str]):
         create_resp = await client.post("/api/v1/submissions/", json=make_submission_data())
         sub_id = create_resp.json()["Id"]
 
-        resp = await client.get(f"/api/v1/submissions/{sub_id}")
+        resp = await client.get(f"/api/v1/submissions/{sub_id}", headers=staff_headers)
         assert resp.status_code == 200
         assert resp.json()["Id"] == sub_id
 
-    async def test_get_submission_not_found(self, client: AsyncClient):
-        resp = await client.get("/api/v1/submissions/nonexistent")
+    async def test_get_submission_not_found(self, client: AsyncClient, staff_headers: dict[str, str]):
+        resp = await client.get("/api/v1/submissions/nonexistent", headers=staff_headers)
         assert resp.status_code == 404
 
     async def test_update_submission(self, client: AsyncClient):
@@ -270,7 +276,7 @@ class TestSubmissionCRUD:
         assert resp.status_code == 403
         assert "Only staff editors" in resp.json()["detail"]
 
-    async def test_public_list_redacts_editorial_workflow_fields(
+    async def test_staff_list_includes_editorial_workflow_fields(
         self, client: AsyncClient, staff_headers: dict[str, str]
     ):
         create_resp = await client.post("/api/v1/submissions/", json=make_submission_data())
@@ -285,10 +291,7 @@ class TestSubmissionCRUD:
         )
 
         public_resp = await client.get("/api/v1/submissions/")
-        assert public_resp.status_code == 200
-        item = public_resp.json()["Items"][0]
-        assert item["Assigned_Editor"] is None
-        assert item["Editorial_Notes"] is None
+        assert public_resp.status_code == 403
 
         staff_resp = await client.get(
             "/api/v1/submissions/",
@@ -306,7 +309,7 @@ class TestSubmissionCRUD:
         resp = await client.delete(f"/api/v1/submissions/{sub_id}", headers=staff_headers)
         assert resp.status_code == 204
 
-        resp = await client.get(f"/api/v1/submissions/{sub_id}")
+        resp = await client.get(f"/api/v1/submissions/{sub_id}", headers=staff_headers)
         assert resp.status_code == 404
 
 
@@ -361,7 +364,7 @@ class TestSubmissionLinks:
         )
         assert resp.status_code == 404
 
-        owner_detail = await client.get(f"/api/v1/submissions/{owner_id}")
+        owner_detail = await client.get(f"/api/v1/submissions/{owner_id}", headers=staff_headers)
         assert owner_detail.status_code == 200
         assert [link["Id"] for link in owner_detail.json()["Links"]] == [link_id]
 
@@ -436,7 +439,7 @@ class TestSubmissionSchedule:
         )
         assert resp.status_code == 404
 
-        owner_detail = await client.get(f"/api/v1/submissions/{owner_id}")
+        owner_detail = await client.get(f"/api/v1/submissions/{owner_id}", headers=staff_headers)
         assert owner_detail.status_code == 200
         assert [
             schedule["Id"] for schedule in owner_detail.json()["Schedule_Requests"]
@@ -473,7 +476,8 @@ class TestSubmissionSchedule:
         assert resp.json()["Occurrence_Dates"] == ["2026-05-04", "2026-06-01"]
 
         list_resp = await client.get(
-            "/api/v1/submissions/?date_from=2026-04-01&date_to=2026-04-30"
+            "/api/v1/submissions/?date_from=2026-04-01&date_to=2026-04-30",
+            headers=staff_headers,
         )
         assert list_resp.status_code == 200
         assert list_resp.json()["Total"] == 0
@@ -513,7 +517,8 @@ class TestSubmissionSchedule:
         assert resp.json()["Occurrence_Dates"] == ["2026-04-08"]
 
         list_resp = await client.get(
-            "/api/v1/submissions/?date_from=2026-04-01&date_to=2026-04-30"
+            "/api/v1/submissions/?date_from=2026-04-01&date_to=2026-04-30",
+            headers=staff_headers,
         )
         assert list_resp.status_code == 200
         body = list_resp.json()


### PR DESCRIPTION
## Summary
- Require staff authorization for normal submission listing and detail reads
- Preserve trusted SLC calendar-only listing while redacting submitter PII for non-staff viewers
- Add trusted SLC test headers and update the Postgres smoke test to use staff reads
- Add regression tests for public list/detail denial, staff read access, and SLC PII redaction

## Tests
- cd backend && .venv/bin/pytest
- cd backend && .venv/bin/ruff check .
- cd frontend && npm run lint
- cd frontend && npm run build

Closes #109