### PR TITLE
Add AI edit task workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ CLAUDE_MODEL=claude-sonnet-4-20250514
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4o
 
+# AI edit task processing
+AI_EDIT_MAX_CONCURRENCY=2
+
 # MindRouter — University of Idaho on-prem AI (required when LLM_PROVIDER=mindrouter)
 MINDROUTER_API_KEY=
 MINDROUTER_ENDPOINT_URL=https://mindrouter.uidaho.edu/v1/chat/completions

--- a/backend/app/api/v1/ai_edits.py
+++ b/backend/app/api/v1/ai_edits.py
@@ -1,19 +1,27 @@
 """AI editing API endpoints."""
 
+import asyncio
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
 import sqlalchemy as sa
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.config import settings
 from app.api.deps import get_db, require_staff
+from app.db.engine import async_session_factory
 from app.models.submission import Submission
 from app.models.edit_history import EditVersion
 from app.services.ai.factory import get_llm_provider
-from app.services.ai.editor import AIEditor
+from app.services.ai.editor import AIEditor, AIEditError, EditResult
 from app.schemas.ai_edit import (
     AIEditRequest,
     AIEditResponse,
+    AIEditTaskResponse,
     AIEditFlag,
     AIEditLink,
     TextDiffResponse,
@@ -24,67 +32,51 @@ from app.schemas.ai_edit import (
 
 router = APIRouter(prefix="/ai-edits", tags=["ai-edits"])
 
+AIEditTaskStatus = Literal["queued", "running", "succeeded", "failed"]
 
-@router.post("/{submission_id}/edit", response_model=AIEditResponse)
-async def trigger_ai_edit(
+
+@dataclass
+class AIEditTaskState:
+    Task_Id: str
+    Submission_Id: str
+    Newsletter_Type: str
+    Status: AIEditTaskStatus
+    Created_At: datetime
+    Updated_At: datetime
+    Result: AIEditResponse | None = None
+    Error_Message: str | None = None
+
+
+_ai_edit_tasks: dict[str, AIEditTaskState] = {}
+_ai_edit_semaphore = asyncio.Semaphore(settings.ai_edit_max_concurrency)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _serialize_task(task: AIEditTaskState) -> AIEditTaskResponse:
+    return AIEditTaskResponse(
+        Task_Id=task.Task_Id,
+        Submission_Id=task.Submission_Id,
+        Newsletter_Type=task.Newsletter_Type,
+        Status=task.Status,
+        Result=task.Result,
+        Error_Message=task.Error_Message,
+        Created_At=task.Created_At,
+        Updated_At=task.Updated_At,
+    )
+
+
+def _build_ai_edit_response(
     submission_id: str,
-    request: AIEditRequest,
-    session: AsyncSession = Depends(get_db),
-    _staff: None = Depends(require_staff),
-):
-    """Trigger AI editing on a submission for a specific newsletter type.
-
-    This creates an 'original' EditVersion (if not exists) and an 'ai_suggested' EditVersion.
-    """
-    # Load submission with links
-    result = await session.execute(
-        sa.select(Submission)
-        .where(Submission.Id == submission_id)
-        .options(selectinload(Submission.Links))
-    )
-    submission = result.scalar_one_or_none()
-    if not submission:
-        raise HTTPException(status_code=404, detail="Submission not found")
-
-    # Validate newsletter type matches submission target
-    if submission.Target_Newsletter not in (request.Newsletter_Type, "both"):
-        raise HTTPException(
-            status_code=400,
-            detail=f"Submission targets '{submission.Target_Newsletter}', not '{request.Newsletter_Type}'",
-        )
-
-    # Get LLM provider
-    try:
-        llm = get_llm_provider(settings)
-    except ValueError as e:
-        raise HTTPException(status_code=503, detail=str(e))
-
-    # Run AI editing pipeline
-    editor = AIEditor(llm)
-    edit_result = await editor.edit_submission(
-        session=session,
-        submission=submission,
-        newsletter_type=request.Newsletter_Type,
-    )
-
-    # Save edit versions
-    _original_version, ai_version = await editor.save_edit_versions(
-        session=session,
-        submission_id=submission_id,
-        edit_result=edit_result,
-        original_headline=submission.Original_Headline,
-        original_body=submission.Original_Body,
-    )
-
-    # Update submission status
-    submission.Status = "ai_edited"
-    await session.commit()
-    await session.refresh(ai_version)
-
-    # Build response
+    newsletter_type: str,
+    edit_result: EditResult,
+    ai_version: EditVersion,
+) -> AIEditResponse:
     return AIEditResponse(
         Submission_Id=submission_id,
-        Newsletter_Type=request.Newsletter_Type,
+        Newsletter_Type=newsletter_type,
         Edited_Headline=edit_result.edited_headline,
         Edited_Body=edit_result.edited_body,
         Headline_Case=edit_result.headline_case,
@@ -106,6 +98,143 @@ async def trigger_ai_edit(
         ),
         Edit_Version_Id=ai_version.Id,
     )
+
+
+async def _run_ai_edit(
+    session: AsyncSession,
+    submission_id: str,
+    newsletter_type: str,
+) -> AIEditResponse:
+    result = await session.execute(
+        sa.select(Submission)
+        .where(Submission.Id == submission_id)
+        .options(selectinload(Submission.Links))
+    )
+    submission = result.scalar_one_or_none()
+    if not submission:
+        raise HTTPException(status_code=404, detail="Submission not found")
+
+    if submission.Target_Newsletter not in (newsletter_type, "both"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Submission targets '{submission.Target_Newsletter}', not '{newsletter_type}'",
+        )
+
+    try:
+        llm = get_llm_provider(settings)
+    except ValueError as e:
+        raise HTTPException(status_code=503, detail=str(e)) from e
+
+    editor = AIEditor(llm)
+    edit_result = await editor.edit_submission(
+        session=session,
+        submission=submission,
+        newsletter_type=newsletter_type,
+    )
+
+    _original_version, ai_version = await editor.save_edit_versions(
+        session=session,
+        submission_id=submission_id,
+        edit_result=edit_result,
+        original_headline=submission.Original_Headline,
+        original_body=submission.Original_Body,
+    )
+
+    submission.Status = "ai_edited"
+    await session.commit()
+    await session.refresh(ai_version)
+
+    return _build_ai_edit_response(
+        submission_id=submission_id,
+        newsletter_type=newsletter_type,
+        edit_result=edit_result,
+        ai_version=ai_version,
+    )
+
+
+async def _process_ai_edit_task(task_id: str) -> None:
+    task = _ai_edit_tasks[task_id]
+
+    try:
+        async with _ai_edit_semaphore:
+            task.Status = "running"
+            task.Updated_At = _utcnow()
+            async with async_session_factory() as session:
+                task.Result = await _run_ai_edit(
+                    session=session,
+                    submission_id=task.Submission_Id,
+                    newsletter_type=task.Newsletter_Type,
+                )
+        task.Status = "succeeded"
+        task.Error_Message = None
+    except AIEditError as e:
+        task.Status = "failed"
+        task.Error_Message = str(e)
+    except HTTPException as e:
+        task.Status = "failed"
+        task.Error_Message = str(e.detail)
+    except Exception:
+        task.Status = "failed"
+        task.Error_Message = "AI editing failed unexpectedly."
+    finally:
+        task.Updated_At = _utcnow()
+
+
+@router.post(
+    "/{submission_id}/edit",
+    response_model=AIEditTaskResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def trigger_ai_edit(
+    submission_id: str,
+    request: AIEditRequest,
+    background_tasks: BackgroundTasks,
+    session: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
+):
+    """Trigger AI editing on a submission for a specific newsletter type.
+
+    This queues an AI edit task. A successful task creates an 'original'
+    EditVersion (if not exists) and an 'ai_suggested' EditVersion.
+    """
+    result = await session.execute(
+        sa.select(Submission.Id, Submission.Target_Newsletter).where(Submission.Id == submission_id)
+    )
+    submission = result.one_or_none()
+    if not submission:
+        raise HTTPException(status_code=404, detail="Submission not found")
+
+    if submission.Target_Newsletter not in (request.Newsletter_Type, "both"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Submission targets '{submission.Target_Newsletter}', not '{request.Newsletter_Type}'",
+        )
+
+    now = _utcnow()
+    task = AIEditTaskState(
+        Task_Id=str(uuid.uuid4()),
+        Submission_Id=submission_id,
+        Newsletter_Type=request.Newsletter_Type,
+        Status="queued",
+        Created_At=now,
+        Updated_At=now,
+    )
+    _ai_edit_tasks[task.Task_Id] = task
+    background_tasks.add_task(_process_ai_edit_task, task.Task_Id)
+
+    return _serialize_task(task)
+
+
+@router.get("/tasks/{task_id}", response_model=AIEditTaskResponse)
+async def get_ai_edit_task(
+    task_id: str,
+    _staff: None = Depends(require_staff),
+):
+    """Get the status and result of an AI edit task."""
+    task = _ai_edit_tasks.get(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="AI edit task not found")
+    return _serialize_task(task)
 
 
 @router.get("/{submission_id}/versions", response_model=list[EditVersionResponse])

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -41,6 +41,7 @@ class Settings(BaseSettings):
     job_postings_source_url: str = "https://uidaho.peopleadmin.com/postings/search"
     job_postings_request_timeout_seconds: float = 10.0
     job_postings_max_pages: int = 5
+    ai_edit_max_concurrency: int = 2
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 

--- a/backend/app/schemas/ai_edit.py
+++ b/backend/app/schemas/ai_edit.py
@@ -51,6 +51,18 @@ class AIEditResponse(BaseModel):
     Edit_Version_Id: str
 
 
+class AIEditTaskResponse(BaseModel):
+    """Status response for an asynchronous AI edit task."""
+    Task_Id: str
+    Submission_Id: str
+    Newsletter_Type: str
+    Status: str = Field(..., pattern=r"^(queued|running|succeeded|failed)$")
+    Result: AIEditResponse | None = None
+    Error_Message: str | None = None
+    Created_At: datetime
+    Updated_At: datetime
+
+
 class EditVersionResponse(BaseModel):
     Id: str
     Submission_Id: str

--- a/backend/app/services/ai/editor.py
+++ b/backend/app/services/ai/editor.py
@@ -25,6 +25,10 @@ from app.utils.hyperlinks import parse_submitter_notes
 logger = logging.getLogger(__name__)
 
 
+class AIEditError(Exception):
+    """Raised when the LLM provider cannot produce an edit suggestion."""
+
+
 @dataclass
 class EditResult:
     """Result of an AI edit operation."""
@@ -160,22 +164,7 @@ class AIEditor:
             )
         except Exception as e:
             logger.error(f"LLM call failed for submission {submission.Id}: {e}")
-            return EditResult(
-                edited_headline=submission.Original_Headline,
-                edited_body=submission.Original_Body,
-                headline_case=headline_case,
-                flags=[
-                    *pre_flags,
-                    {
-                        "type": "error",
-                        "rule_key": "ai_error",
-                        "message": f"AI editing failed: {str(e)}",
-                    },
-                ],
-                confidence=0.0,
-                ai_provider="error",
-                ai_model="error",
-            )
+            raise AIEditError(f"AI editing failed: {str(e)}") from e
 
         edited_headline = ai_result.get("edited_headline", submission.Original_Headline)
         edited_body = ai_result.get("edited_body", submission.Original_Body)

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -1,0 +1,183 @@
+"""Tests for AI edit task handling and failure behavior."""
+
+import asyncio
+
+import pytest
+import sqlalchemy as sa
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.edit_history import EditVersion
+from app.models.submission import Submission
+from tests.conftest import TestSession, make_submission_data
+
+
+@pytest.fixture(autouse=True)
+def configure_ai_edit_tasks(monkeypatch: pytest.MonkeyPatch):
+    from app.api.v1 import ai_edits
+
+    ai_edits._ai_edit_tasks.clear()
+    monkeypatch.setattr(ai_edits, "async_session_factory", TestSession)
+    yield
+    ai_edits._ai_edit_tasks.clear()
+
+
+class SuccessfulProvider:
+    model = "test-model"
+
+    async def complete(self, *args, **kwargs):  # pragma: no cover - unused interface method
+        raise NotImplementedError
+
+    async def complete_json(self, *args, **kwargs):
+        return {
+            "edited_headline": "Edited headline",
+            "edited_body": "Edited body.",
+            "changes_made": ["Shortened headline"],
+            "flags": [],
+            "embedded_links": [],
+            "confidence": 0.95,
+        }
+
+
+class FailingProvider:
+    model = "test-model"
+
+    async def complete(self, *args, **kwargs):  # pragma: no cover - unused interface method
+        raise NotImplementedError
+
+    async def complete_json(self, *args, **kwargs):
+        raise RuntimeError("provider unavailable")
+
+
+async def wait_for_task(
+    client: AsyncClient,
+    task_id: str,
+    staff_headers: dict[str, str],
+) -> dict:
+    for _ in range(10):
+        resp = await client.get(f"/api/v1/ai-edits/tasks/{task_id}", headers=staff_headers)
+        assert resp.status_code == 200
+        task = resp.json()
+        if task["Status"] in {"succeeded", "failed"}:
+            return task
+        await asyncio.sleep(0)
+    raise AssertionError("AI edit task did not finish")
+
+
+@pytest.mark.asyncio
+class TestAIEditTasks:
+    async def test_staff_ai_edit_runs_as_task_and_saves_successful_result(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: SuccessfulProvider(),
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(),
+        )
+        assert submission_resp.status_code == 201
+        submission_id = submission_resp.json()["Id"]
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_id}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+
+        assert resp.status_code == 202
+        task = await wait_for_task(client, resp.json()["Task_Id"], staff_headers)
+        assert task["Status"] == "succeeded"
+        assert task["Result"]["Edited_Headline"] == "Edited headline"
+        assert task["Result"]["Edit_Version_Id"]
+
+        versions_resp = await client.get(
+            f"/api/v1/ai-edits/{submission_id}/versions",
+            headers=staff_headers,
+        )
+        assert versions_resp.status_code == 200
+        assert [version["Version_Type"] for version in versions_resp.json()] == [
+            "original",
+            "ai_suggested",
+        ]
+
+        submission_detail_resp = await client.get(
+            f"/api/v1/submissions/{submission_id}",
+            headers=staff_headers,
+        )
+        assert submission_detail_resp.status_code == 200
+        assert submission_detail_resp.json()["Status"] == "ai_edited"
+
+    async def test_provider_failure_does_not_save_ai_version_or_mark_ai_edited(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: FailingProvider(),
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(),
+        )
+        assert submission_resp.status_code == 201
+        submission_id = submission_resp.json()["Id"]
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_id}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+
+        assert resp.status_code == 202
+        task = await wait_for_task(client, resp.json()["Task_Id"], staff_headers)
+        assert task["Status"] == "failed"
+        assert task["Result"] is None
+        assert "provider unavailable" in task["Error_Message"]
+
+        versions = (
+            await db.execute(
+                sa.select(EditVersion).where(EditVersion.Submission_Id == submission_id)
+            )
+        ).scalars().all()
+        assert versions == []
+
+        submission = (
+            await db.execute(sa.select(Submission).where(Submission.Id == submission_id))
+        ).scalar_one()
+        assert submission.Status == "new"
+
+    async def test_public_cannot_access_ai_edit_task_or_version_endpoints(
+        self,
+        client: AsyncClient,
+    ):
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(),
+        )
+        assert submission_resp.status_code == 201
+        submission_id = submission_resp.json()["Id"]
+
+        task_resp = await client.get("/api/v1/ai-edits/tasks/not-a-task")
+        assert task_resp.status_code == 403
+
+        versions_resp = await client.get(f"/api/v1/ai-edits/{submission_id}/versions")
+        assert versions_resp.status_code == 403
+
+        version_resp = await client.get(
+            f"/api/v1/ai-edits/{submission_id}/versions/not-a-version"
+        )
+        assert version_resp.status_code == 403
+
+        finalize_resp = await client.post(
+            f"/api/v1/ai-edits/{submission_id}/finalize",
+            json={"Headline": "Final", "Body": "Final body."},
+        )
+        assert finalize_resp.status_code == 403

--- a/frontend/src/api/aiEdits.ts
+++ b/frontend/src/api/aiEdits.ts
@@ -1,14 +1,42 @@
 import { apiFetch } from './client';
-import type { AIEditResponse, EditVersion } from '../types/aiEdit';
+import type { AIEditResponse, AIEditTaskResponse, EditVersion } from '../types/aiEdit';
+
+const AI_EDIT_POLL_INTERVAL_MS = 1500;
+const AI_EDIT_MAX_POLLS = 120;
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
 
 export async function triggerAIEdit(
   submissionId: string,
   newsletterType: 'tdr' | 'myui',
 ): Promise<AIEditResponse> {
-  return apiFetch<AIEditResponse>(`/ai-edits/${submissionId}/edit`, {
+  const task = await apiFetch<AIEditTaskResponse>(`/ai-edits/${submissionId}/edit`, {
     method: 'POST',
     body: JSON.stringify({ Newsletter_Type: newsletterType }),
   });
+
+  return pollAIEditTask(task.Task_Id);
+}
+
+export async function getAIEditTask(taskId: string): Promise<AIEditTaskResponse> {
+  return apiFetch<AIEditTaskResponse>(`/ai-edits/tasks/${taskId}`);
+}
+
+async function pollAIEditTask(taskId: string): Promise<AIEditResponse> {
+  for (let attempt = 0; attempt < AI_EDIT_MAX_POLLS; attempt += 1) {
+    const task = await getAIEditTask(taskId);
+    if (task.Status === 'succeeded' && task.Result) {
+      return task.Result;
+    }
+    if (task.Status === 'failed') {
+      throw new Error(task.Error_Message || 'AI edit failed');
+    }
+    await wait(AI_EDIT_POLL_INTERVAL_MS);
+  }
+
+  throw new Error('AI edit is still running. Try again in a moment.');
 }
 
 export async function listEditVersions(submissionId: string): Promise<EditVersion[]> {

--- a/frontend/src/types/aiEdit.ts
+++ b/frontend/src/types/aiEdit.ts
@@ -38,6 +38,17 @@ export interface AIEditResponse {
   Edit_Version_Id: string;
 }
 
+export interface AIEditTaskResponse {
+  Task_Id: string;
+  Submission_Id: string;
+  Newsletter_Type: 'tdr' | 'myui';
+  Status: 'queued' | 'running' | 'succeeded' | 'failed';
+  Result: AIEditResponse | null;
+  Error_Message: string | null;
+  Created_At: string;
+  Updated_At: string;
+}
+
 export interface EditVersion {
   Id: string;
   Submission_Id: string;


### PR DESCRIPTION
## Summary
- Move AI edit triggering to an explicit task workflow with staff-only task status polling
- Add bounded AI edit concurrency via `AI_EDIT_MAX_CONCURRENCY`
- Stop saving failed provider responses as `ai_suggested` versions or marking submissions `ai_edited`
- Update the frontend AI edit client to poll task status and surface task failures
- Add regression tests for successful tasks, provider failures, and staff-only AI edit endpoints

## Tests
- cd backend && .venv/bin/pytest
- cd backend && .venv/bin/ruff check .
- cd frontend && npm run lint
- cd frontend && npm run build

Closes #118