### PR TITLE
Harden submission image uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ MINDROUTER_MODEL=openai/gpt-oss-120b
 # File uploads
 ENVIRONMENT=development
 UPLOAD_DIR=./uploads
+IMAGE_UPLOAD_MAX_BYTES=10485760
+IMAGE_UPLOAD_MAX_PIXELS=36000000
 
 # Trusted auth boundary
 # Set this to the shared secret used by your reverse proxy or auth gateway when

--- a/backend/app/api/v1/submissions.py
+++ b/backend/app/api/v1/submissions.py
@@ -1,7 +1,7 @@
 import os
 from datetime import date
 
-from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
+from fastapi import APIRouter, Depends, File, Header, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -20,7 +20,12 @@ from app.schemas.submission import (
     SubmissionUpdate,
 )
 from app.services import allowed_value_service, schedule_service, submission_service
-from app.services.image_service import ImageProcessingError, save_upload, validate_image
+from app.services.image_service import (
+    ImageProcessingError,
+    ImageTooLargeError,
+    save_upload_file,
+    validate_image_filename,
+)
 
 router = APIRouter(prefix="/submissions", tags=["submissions"])
 
@@ -388,26 +393,42 @@ async def delete_schedule_request(
 async def upload_image(
     submission_id: str,
     file: UploadFile = File(...),
+    content_length: int | None = Header(None),
     db: AsyncSession = Depends(get_db),
-    submission_role: SubmitterRole = Depends(get_submitter_role),
+    _staff: SubmitterRole = Depends(require_staff),
 ):
-    content = await file.read()
-    error = validate_image(file.filename or "unknown", len(content))
+    if content_length and content_length > settings.image_upload_max_bytes + (2 * 1024 * 1024):
+        raise HTTPException(
+            status_code=413,
+            detail="Image upload request is too large.",
+        )
+
+    filename = file.filename or "unknown"
+    error = validate_image_filename(filename)
     if error:
         raise HTTPException(status_code=400, detail=error)
 
     try:
-        filename = await save_upload(file.filename or "image.png", content)
+        filename = await save_upload_file(file, filename)
+    except ImageTooLargeError as exc:
+        raise HTTPException(
+            status_code=413,
+            detail=str(exc),
+        ) from exc
     except ImageProcessingError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     submission = await submission_service.set_image(db, submission_id, filename)
     if not submission:
         raise HTTPException(status_code=404, detail="Submission not found")
-    return _to_submission_response(submission, submission_role)
+    return _to_submission_response(submission, "staff")
 
 
 @router.get("/{submission_id}/image")
-async def get_image(submission_id: str, db: AsyncSession = Depends(get_db)):
+async def get_image(
+    submission_id: str,
+    db: AsyncSession = Depends(get_db),
+    _staff: SubmitterRole = Depends(require_staff),
+):
     submission = await submission_service.get_submission(db, submission_id)
     if not submission or not submission.Image_Path:
         raise HTTPException(status_code=404, detail="Image not found")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -32,6 +32,8 @@ class Settings(BaseSettings):
     # App
     environment: str = "development"
     upload_dir: str = "./uploads"
+    image_upload_max_bytes: int = 10 * 1024 * 1024
+    image_upload_max_pixels: int = 36_000_000
     cors_origins: str | list[str] | None = None
     trusted_role_header_secret: str = ""
     calendar_source_url: str = (

--- a/backend/app/services/image_service.py
+++ b/backend/app/services/image_service.py
@@ -4,6 +4,7 @@ import uuid
 from pathlib import Path
 
 from PIL import Image
+from fastapi import UploadFile
 
 from app.config import settings
 
@@ -15,17 +16,25 @@ class ImageProcessingError(Exception):
     """Raised when an uploaded image cannot be processed safely (e.g., EXIF stripping failed)."""
 
 
-ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
-MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+class ImageTooLargeError(ImageProcessingError):
+    """Raised when an uploaded image exceeds the configured byte limit."""
 
 
-def validate_image(filename: str, file_size: int) -> str | None:
+ALLOWED_IMAGE_FORMATS = {
+    ".jpg": "JPEG",
+    ".jpeg": "JPEG",
+    ".png": "PNG",
+    ".gif": "GIF",
+    ".webp": "WEBP",
+}
+UPLOAD_CHUNK_SIZE = 1024 * 1024
+
+
+def validate_image_filename(filename: str) -> str | None:
     """Return an error message if invalid, None if valid."""
     ext = Path(filename).suffix.lower()
-    if ext not in ALLOWED_EXTENSIONS:
-        return f"File type '{ext}' not allowed. Use: {', '.join(ALLOWED_EXTENSIONS)}"
-    if file_size > MAX_FILE_SIZE:
-        return f"File too large ({file_size // 1024 // 1024}MB). Max is 10MB."
+    if ext not in ALLOWED_IMAGE_FORMATS:
+        return f"File type '{ext}' not allowed. Use: {', '.join(ALLOWED_IMAGE_FORMATS)}"
     return None
 
 
@@ -33,6 +42,38 @@ def check_image_dimensions(filepath: str) -> tuple[int, int]:
     """Return (width, height) of an image file."""
     with Image.open(filepath) as img:
         return img.size
+
+
+def _verify_image_file(filepath: str, filename: str) -> tuple[str, tuple[int, int]]:
+    """Validate actual image format and dimensions, returning format and size."""
+    ext = Path(filename).suffix.lower()
+    expected_format = ALLOWED_IMAGE_FORMATS[ext]
+
+    try:
+        with Image.open(filepath) as img:
+            actual_format = img.format
+            width, height = img.size
+            img.verify()
+    except Exception as exc:
+        raise ImageProcessingError(
+            "Unable to process image. The file may be corrupt or not a real image."
+        ) from exc
+
+    if actual_format != expected_format:
+        raise ImageProcessingError(
+            f"Image content is {actual_format or 'unknown'}, but the filename uses '{ext}'."
+        )
+
+    if width <= 0 or height <= 0:
+        raise ImageProcessingError("Image dimensions are invalid.")
+
+    pixel_count = width * height
+    if pixel_count > settings.image_upload_max_pixels:
+        raise ImageProcessingError(
+            f"Image dimensions are too large ({width}x{height})."
+        )
+
+    return actual_format, (width, height)
 
 
 def _strip_exif(filepath: str) -> None:
@@ -44,41 +85,50 @@ def _strip_exif(filepath: str) -> None:
     with Image.open(filepath) as img:
         if img.format == "GIF":
             return
-        cleaned = Image.new(img.mode, img.size)
-        cleaned.putdata(list(img.getdata()))
+        cleaned = img.copy()
         cleaned.save(filepath, format=img.format)
 
 
-async def save_upload(filename: str, content: bytes) -> str:
-    """Save uploaded file, strip EXIF metadata, and return the relative path.
-
-    Fails closed: if EXIF stripping fails (corrupt file, unsupported format,
-    or a file whose extension lies about its content), the saved file is
-    deleted and ImageProcessingError is raised. We would rather reject an
-    upload than silently store an image with metadata intact.
-    """
+async def save_upload_file(file: UploadFile, filename: str) -> str:
+    """Stream an uploaded image to disk, validate real content, strip EXIF, and return path."""
     os.makedirs(settings.upload_dir, exist_ok=True)
     ext = Path(filename).suffix.lower()
     unique_name = f"{uuid.uuid4()}{ext}"
-    filepath = os.path.join(settings.upload_dir, unique_name)
-    with open(filepath, "wb") as f:
-        f.write(content)
+    final_path = os.path.join(settings.upload_dir, unique_name)
+    temp_path = f"{final_path}.part"
+
+    total_size = 0
     try:
-        _strip_exif(filepath)
+        with open(temp_path, "wb") as f:
+            while chunk := await file.read(UPLOAD_CHUNK_SIZE):
+                total_size += len(chunk)
+                if total_size > settings.image_upload_max_bytes:
+                    raise ImageTooLargeError(
+                        f"File too large. Max is {settings.image_upload_max_bytes // 1024 // 1024}MB."
+                    )
+                f.write(chunk)
+
+        _verify_image_file(temp_path, filename)
+        os.replace(temp_path, final_path)
+        _strip_exif(final_path)
+    except ImageProcessingError:
+        for path in (temp_path, final_path):
+            try:
+                if os.path.exists(path):
+                    os.remove(path)
+            except OSError:
+                logger.warning("Failed to clean up rejected upload %s", path)
+        raise
     except Exception as exc:
-        logger.warning(
-            "Failed to strip EXIF from upload %s (stored as %s): %s",
-            filename,
-            unique_name,
-            exc,
-            exc_info=True,
-        )
-        try:
-            os.remove(filepath)
-        except OSError:
-            logger.warning("Failed to clean up unprocessable upload %s", filepath)
+        for path in (temp_path, final_path):
+            try:
+                if os.path.exists(path):
+                    os.remove(path)
+            except OSError:
+                logger.warning("Failed to clean up unprocessable upload %s", path)
         raise ImageProcessingError(
             "Unable to process image. The file may be corrupt, not a real image, "
             "or in an unsupported format."
         ) from exc
+
     return unique_name

--- a/backend/tests/test_images.py
+++ b/backend/tests/test_images.py
@@ -1,0 +1,173 @@
+"""Tests for submission image authorization and validation."""
+
+from io import BytesIO
+
+import pytest
+from httpx import AsyncClient
+from PIL import Image
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.submission import Submission
+from tests.conftest import make_submission_data
+
+
+def make_png_bytes(size: tuple[int, int] = (16, 16)) -> bytes:
+    buffer = BytesIO()
+    Image.new("RGB", size, color=(120, 80, 40)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+@pytest.fixture(autouse=True)
+def isolate_upload_dir(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("app.services.image_service.settings.upload_dir", str(tmp_path))
+    monkeypatch.setattr("app.api.v1.submissions.settings.upload_dir", str(tmp_path))
+
+
+@pytest.mark.asyncio
+class TestSubmissionImages:
+    async def test_public_cannot_upload_or_read_submission_images(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+    ):
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(),
+        )
+        assert submission_resp.status_code == 201
+        submission_id = submission_resp.json()["Id"]
+
+        upload_resp = await client.post(
+            f"/api/v1/submissions/{submission_id}/image",
+            files={"file": ("image.png", make_png_bytes(), "image/png")},
+        )
+        assert upload_resp.status_code == 403
+
+        staff_upload_resp = await client.post(
+            f"/api/v1/submissions/{submission_id}/image",
+            files={"file": ("image.png", make_png_bytes(), "image/png")},
+            headers=staff_headers,
+        )
+        assert staff_upload_resp.status_code == 200
+
+        read_resp = await client.get(f"/api/v1/submissions/{submission_id}/image")
+        assert read_resp.status_code == 403
+
+    async def test_staff_can_upload_and_read_valid_image(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+    ):
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(),
+        )
+        assert submission_resp.status_code == 201
+        submission_id = submission_resp.json()["Id"]
+
+        upload_resp = await client.post(
+            f"/api/v1/submissions/{submission_id}/image",
+            files={"file": ("image.png", make_png_bytes(), "image/png")},
+            headers=staff_headers,
+        )
+
+        assert upload_resp.status_code == 200
+        body = upload_resp.json()
+        assert body["Has_Image"] is True
+        assert body["Image_Path"].endswith(".png")
+
+        db.expire_all()
+        submission = await db.get(Submission, submission_id)
+        assert submission is not None
+        assert submission.Has_Image is True
+        assert submission.Image_Path == body["Image_Path"]
+
+        read_resp = await client.get(
+            f"/api/v1/submissions/{submission_id}/image",
+            headers=staff_headers,
+        )
+        assert read_resp.status_code == 200
+        assert read_resp.content.startswith(b"\x89PNG")
+
+    async def test_oversized_image_is_rejected_before_persisting(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr("app.services.image_service.settings.image_upload_max_bytes", 16)
+        monkeypatch.setattr("app.api.v1.submissions.settings.image_upload_max_bytes", 16)
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(),
+        )
+        assert submission_resp.status_code == 201
+        submission_id = submission_resp.json()["Id"]
+
+        upload_resp = await client.post(
+            f"/api/v1/submissions/{submission_id}/image",
+            files={"file": ("image.png", make_png_bytes(), "image/png")},
+            headers=staff_headers,
+        )
+
+        assert upload_resp.status_code == 413
+        submission = await db.get(Submission, submission_id)
+        assert submission is not None
+        assert submission.Has_Image is False
+        assert submission.Image_Path is None
+
+    async def test_corrupt_image_content_is_rejected(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+    ):
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(),
+        )
+        assert submission_resp.status_code == 201
+        submission_id = submission_resp.json()["Id"]
+
+        upload_resp = await client.post(
+            f"/api/v1/submissions/{submission_id}/image",
+            files={"file": ("image.png", b"not a real image", "image/png")},
+            headers=staff_headers,
+        )
+
+        assert upload_resp.status_code == 422
+        assert "not a real image" in upload_resp.json()["detail"]
+        submission = await db.get(Submission, submission_id)
+        assert submission is not None
+        assert submission.Has_Image is False
+        assert submission.Image_Path is None
+
+    async def test_image_dimensions_are_limited(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr("app.services.image_service.settings.image_upload_max_pixels", 4)
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(),
+        )
+        assert submission_resp.status_code == 201
+        submission_id = submission_resp.json()["Id"]
+
+        upload_resp = await client.post(
+            f"/api/v1/submissions/{submission_id}/image",
+            files={"file": ("image.png", make_png_bytes(size=(3, 3)), "image/png")},
+            headers=staff_headers,
+        )
+
+        assert upload_resp.status_code == 422
+        assert "dimensions are too large" in upload_resp.json()["detail"]
+        submission = await db.get(Submission, submission_id)
+        assert submission is not None
+        assert submission.Has_Image is False
+        assert submission.Image_Path is None

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,6 +1,7 @@
 server {
     listen 80;
     server_name _;
+    client_max_body_size 12m;
 
     root /usr/share/nginx/html;
     index index.html;


### PR DESCRIPTION
## Summary
- Require staff authorization for submission image upload and image reads
- Stream image uploads to bounded temporary storage instead of reading the whole file into memory
- Enforce configurable byte and pixel limits, plus nginx request size protection
- Validate real image format/dimensions with Pillow before persisting and strip EXIF only after validation
- Add regression tests for public denial, staff upload/read, oversized uploads, corrupt images, and oversized dimensions

## Tests
- cd backend && .venv/bin/pytest
- cd backend && .venv/bin/ruff check .
- cd frontend && npm run lint
- cd frontend && npm run build

Closes #117