### PR TITLE
Remove production create_all paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ cd backend
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 cp ../.env.example ../.env  # Edit with your API keys
+alembic upgrade head
+python -m app.db.seed
 uvicorn app.main:app --port 8001 --reload
 ```
 

--- a/backend/app/db/seed.py
+++ b/backend/app/db/seed.py
@@ -13,9 +13,7 @@ from pathlib import Path
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.engine import async_session_factory, engine
-from app.db.base import Base
-import app.models  # noqa: F401 — ensure all models registered with Base
+from app.db.engine import async_session_factory
 from app.models.allowed_value import AllowedValue
 from app.models.section import NewsletterSection
 from app.models.style_rule import StyleRule
@@ -186,10 +184,7 @@ async def seed_blackout_dates(session: AsyncSession) -> None:
 
 
 async def seed_all() -> None:
-    """Create all tables and seed reference data."""
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
+    """Seed reference data into an already migrated database."""
     async with async_session_factory() as session:
         await seed_allowed_values(session)
         print("Seeded allowed values.")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,18 +6,12 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.v1.router import router as v1_router
 from app.config import settings
-from app.db.base import Base
-from app.db.engine import engine
-import app.models  # noqa: F401 — register all models with Base.metadata
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Create upload directory
     os.makedirs(settings.upload_dir, exist_ok=True)
-    # Create tables (dev convenience; production uses Alembic)
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
     yield
 
 

--- a/backend/tests/test_schema_management.py
+++ b/backend/tests/test_schema_management.py
@@ -1,0 +1,20 @@
+"""Tests for production schema management boundaries."""
+
+import inspect
+
+from app import main
+from app.db import seed
+
+
+def test_app_startup_does_not_create_database_schema():
+    """Production startup must not mutate schema outside Alembic migrations."""
+    source = inspect.getsource(main.lifespan)
+
+    assert "create_all" not in source
+
+
+def test_seed_all_does_not_create_database_schema():
+    """Reference seeding assumes an already migrated database."""
+    source = inspect.getsource(seed.seed_all)
+
+    assert "create_all" not in source

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,7 @@
 
 1. Clone the repository and follow the [Deployment guide](deployment.md) to set up backend and frontend environments.
 2. Install backend with `pip install -e ".[dev]"` (includes test and lint tools).
-3. Seed the database with `python -m app.db.seed`.
+3. Apply migrations with `alembic upgrade head`, then seed the database with `python -m app.db.seed`.
 4. Verify both servers start cleanly before making changes.
 
 ## Code Conventions

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,7 +28,8 @@ pip install -e ".[dev]"
 cp .env.example .env
 # Edit .env with your settings (see below)
 
-# Seed the database
+# Apply migrations and seed reference data
+alembic upgrade head
 python -m app.db.seed
 
 # Start the dev server
@@ -90,6 +91,10 @@ reference data: `AllowedValue` records, newsletter sections, style rules,
 schedule configs, and blackout dates. **These tables are load-bearing** —
 empty tables break dropdowns, validations, and FK lookups across the app.
 
+The seed script assumes the schema already exists. Run Alembic migrations
+before seeding; production schema changes must come only from checked-in
+migrations, not SQLAlchemy metadata creation at app startup.
+
 ### Docker deployments
 
 Seeding runs automatically on every backend container start via
@@ -102,11 +107,12 @@ skips rows that already exist.
 ### Local development
 
 For a local (non-Docker) dev server, run the seed script once after creating
-your venv:
+your venv and applying migrations:
 
 ```bash
 cd backend
 source .venv/bin/activate
+alembic upgrade head
 python -m app.db.seed
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ Submission Intake --> AI Editing --> Human Review --> Newsletter Assembly --> Wo
 cd backend
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
+alembic upgrade head
 python -m app.db.seed
 uvicorn app.main:app --port 8001 --reload
 


### PR DESCRIPTION
## Summary
- Remove SQLAlchemy `Base.metadata.create_all` from FastAPI startup
- Remove `create_all` from the reference seed script so seeding assumes an already migrated schema
- Update local setup docs to run `alembic upgrade head` before `python -m app.db.seed`
- Add regression tests guarding against schema mutation in startup and seed paths

## Verification
- cd backend && env DATABASE_URL=sqlite+aiosqlite:////tmp/ucm_issue_110_bootstrap.db .venv/bin/alembic upgrade head
- cd backend && env DATABASE_URL=sqlite+aiosqlite:////tmp/ucm_issue_110_bootstrap.db .venv/bin/python -m app.db.seed
- cd backend && .venv/bin/pytest
- cd backend && .venv/bin/ruff check .
- cd frontend && npm run lint
- cd frontend && npm run build

Closes #110