### PR TITLE
Optimize submission occurrence filtering

### DIFF
--- a/backend/alembic/versions/c9d8e7f6a5b4_add_submission_listing_indexes.py
+++ b/backend/alembic/versions/c9d8e7f6a5b4_add_submission_listing_indexes.py
@@ -1,0 +1,76 @@
+"""add submission listing indexes
+
+Revision ID: c9d8e7f6a5b4
+Revises: a1b2c3d4e5f7
+Create Date: 2026-04-28 10:10:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c9d8e7f6a5b4"
+down_revision: Union[str, Sequence[str], None] = "a1b2c3d4e5f7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TABLE_INDEXES: list[tuple[str, str, list[str]]] = [
+    ("submissions", "ix_submissions_Status_Created_At", ["Status", "Created_At"]),
+    ("submissions", "ix_submissions_Category_Created_At", ["Category", "Created_At"]),
+    (
+        "submissions",
+        "ix_submissions_Target_Newsletter_Created_At",
+        ["Target_Newsletter", "Created_At"],
+    ),
+    (
+        "submissions",
+        "ix_submissions_Show_In_SLC_Calendar_Created_At",
+        ["Show_In_SLC_Calendar", "Created_At"],
+    ),
+    (
+        "submission_schedule_requests",
+        "ix_submission_schedule_requests_Requested_Date",
+        ["Requested_Date"],
+    ),
+    (
+        "submission_schedule_requests",
+        "ix_submission_schedule_requests_Second_Requested_Date",
+        ["Second_Requested_Date"],
+    ),
+    (
+        "submission_schedule_requests",
+        "ix_submission_schedule_requests_Recurrence_End_Date",
+        ["Recurrence_End_Date"],
+    ),
+    (
+        "submission_schedule_requests",
+        "ix_submission_schedule_requests_Recurrence_Type",
+        ["Recurrence_Type"],
+    ),
+]
+
+
+def _existing_index_names(table: str) -> set[str]:
+    return {
+        index["name"] for index in sa.inspect(op.get_bind()).get_indexes(table)
+    }
+
+
+def upgrade() -> None:
+    for table, index_name, column_names in TABLE_INDEXES:
+        if index_name in _existing_index_names(table):
+            continue
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.create_index(index_name, column_names, unique=False)
+
+
+def downgrade() -> None:
+    for table, index_name, _column_names in reversed(TABLE_INDEXES):
+        if index_name not in _existing_index_names(table):
+            continue
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.drop_index(index_name)

--- a/backend/app/models/submission.py
+++ b/backend/app/models/submission.py
@@ -40,6 +40,20 @@ class Submission(Base):
     """A content submission destined for one or both UCM newsletters."""
 
     __tablename__ = "submissions"
+    __table_args__ = (
+        sa.Index("ix_submissions_Status_Created_At", "Status", "Created_At"),
+        sa.Index("ix_submissions_Category_Created_At", "Category", "Created_At"),
+        sa.Index(
+            "ix_submissions_Target_Newsletter_Created_At",
+            "Target_Newsletter",
+            "Created_At",
+        ),
+        sa.Index(
+            "ix_submissions_Show_In_SLC_Calendar_Created_At",
+            "Show_In_SLC_Calendar",
+            "Created_At",
+        ),
+    )
 
     Id: Mapped[str] = mapped_column(
         sa.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
@@ -103,6 +117,21 @@ class SubmissionScheduleRequest(Base):
     """A submitter's preferred publication date and repeat-run preferences."""
 
     __tablename__ = "submission_schedule_requests"
+    __table_args__ = (
+        sa.Index("ix_submission_schedule_requests_Requested_Date", "Requested_Date"),
+        sa.Index(
+            "ix_submission_schedule_requests_Second_Requested_Date",
+            "Second_Requested_Date",
+        ),
+        sa.Index(
+            "ix_submission_schedule_requests_Recurrence_End_Date",
+            "Recurrence_End_Date",
+        ),
+        sa.Index(
+            "ix_submission_schedule_requests_Recurrence_Type",
+            "Recurrence_Type",
+        ),
+    )
 
     Id: Mapped[str] = mapped_column(
         sa.String(36), primary_key=True, default=lambda: str(uuid.uuid4())

--- a/backend/app/services/newsletter_service.py
+++ b/backend/app/services/newsletter_service.py
@@ -325,6 +325,7 @@ async def assemble_newsletter(
     sections = list(sections_result.scalars().all())
     section_map = {s.Slug: s for s in sections}
     category_section_map = _get_category_section_map(newsletter_type)
+    occurrence_cache = submission_service.OccurrenceFilterCache()
 
     for sub in submissions:
         if sub.Id in existing_sub_ids:
@@ -335,6 +336,7 @@ async def assemble_newsletter(
             publish_date,
             publish_date,
             newsletter_type=newsletter_type,
+            occurrence_cache=occurrence_cache,
         )
         if publish_date not in occurrence_dates:
             continue

--- a/backend/app/services/submission_service.py
+++ b/backend/app/services/submission_service.py
@@ -1,5 +1,6 @@
 """Submission CRUD and related operations."""
 
+from dataclasses import dataclass, field as dataclass_field
 from datetime import date, timedelta
 
 import sqlalchemy as sa
@@ -10,6 +11,42 @@ from sqlalchemy.orm import selectinload
 from app.models.submission import Submission, SubmissionLink, SubmissionScheduleRequest
 from app.schemas.submission import SubmissionCreate, SubmissionUpdate
 from app.services import recurrence_service, schedule_service
+
+
+@dataclass
+class OccurrenceFilterCache:
+    """Request-scoped cache for publication-date filters used during listing."""
+
+    config_exists_by_newsletter: dict[str, bool] = dataclass_field(default_factory=dict)
+    valid_dates_by_range: dict[tuple[str, date, date], set[date]] = dataclass_field(
+        default_factory=dict
+    )
+
+    async def configs_exist(self, db: AsyncSession, newsletter_type: str) -> bool:
+        if newsletter_type not in self.config_exists_by_newsletter:
+            configs = await schedule_service.list_configs(db, newsletter_type)
+            self.config_exists_by_newsletter[newsletter_type] = bool(configs)
+        return self.config_exists_by_newsletter[newsletter_type]
+
+    async def valid_dates(
+        self,
+        db: AsyncSession,
+        newsletter_type: str,
+        from_date: date,
+        to_date: date,
+    ) -> set[date]:
+        key = (newsletter_type, from_date, to_date)
+        if key not in self.valid_dates_by_range:
+            valid_for_newsletter = await schedule_service.get_valid_publication_dates(
+                db,
+                from_date,
+                to_date,
+                newsletter_type,
+            )
+            self.valid_dates_by_range[key] = {
+                item["date"] for item in valid_for_newsletter
+            }
+        return self.valid_dates_by_range[key]
 
 
 async def create_submission(db: AsyncSession, data: SubmissionCreate) -> Submission:
@@ -124,33 +161,39 @@ async def list_submissions(
         effective_from = date_from or date.today()
         effective_to = date_to or effective_from
         recurrence_filter = Submission.Schedule_Requests.any(
-            sa.and_(
-                SubmissionScheduleRequest.Requested_Date <= effective_to,
-                sa.or_(
-                    SubmissionScheduleRequest.Recurrence_End_Date.is_(None),
-                    SubmissionScheduleRequest.Recurrence_End_Date >= effective_from,
+            sa.or_(
+                SubmissionScheduleRequest.Requested_Date.between(
+                    effective_from,
+                    effective_to,
+                ),
+                SubmissionScheduleRequest.Second_Requested_Date.between(
+                    effective_from,
+                    effective_to,
+                ),
+                sa.and_(
+                    SubmissionScheduleRequest.Requested_Date <= effective_to,
+                    SubmissionScheduleRequest.Recurrence_Type != "once",
+                    sa.or_(
+                        SubmissionScheduleRequest.Recurrence_End_Date.is_(None),
+                        SubmissionScheduleRequest.Recurrence_End_Date >= effective_from,
+                    ),
                 ),
             )
         )
         query = query.where(recurrence_filter)
         candidates = list((await db.execute(query)).scalars().all())
         filtered_items: list[Submission] = []
+        occurrence_cache = OccurrenceFilterCache()
         for submission in candidates:
-            occurrence_dates = await get_submission_occurrence_dates(
+            await hydrate_submission_occurrences(
                 db,
                 submission,
                 effective_from,
                 effective_to,
                 newsletter_type=target_newsletter,
+                occurrence_cache=occurrence_cache,
             )
-            if occurrence_dates:
-                await hydrate_submission_occurrences(
-                    db,
-                    submission,
-                    effective_from,
-                    effective_to,
-                    newsletter_type=target_newsletter,
-                )
+            if submission.Occurrence_Dates:
                 filtered_items.append(submission)
         total = len(filtered_items)
         return filtered_items[offset:offset + limit], total
@@ -160,6 +203,7 @@ async def list_submissions(
 
     preview_from = date.today()
     preview_to = preview_from + timedelta(days=180)
+    occurrence_cache = OccurrenceFilterCache()
     for submission in items:
         await hydrate_submission_occurrences(
             db,
@@ -168,6 +212,7 @@ async def list_submissions(
             preview_to,
             newsletter_type=target_newsletter,
             max_occurrences=3,
+            occurrence_cache=occurrence_cache,
         )
 
     return items, total
@@ -348,6 +393,7 @@ async def get_submission_occurrence_dates(
     from_date: date,
     to_date: date,
     newsletter_type: str | None = None,
+    occurrence_cache: OccurrenceFilterCache | None = None,
 ) -> list[date]:
     """Return valid occurrence dates for a submission within a range."""
     if from_date > to_date:
@@ -366,39 +412,15 @@ async def get_submission_occurrence_dates(
     if not candidate_dates:
         return []
 
-    relevant_newsletters = (
-        [newsletter_type]
-        if newsletter_type
-        else (
-            ["tdr", "myui"]
-            if submission.Target_Newsletter == "both"
-            else [submission.Target_Newsletter]
-        )
+    return await _filter_candidate_dates(
+        db,
+        submission,
+        candidate_dates,
+        from_date,
+        to_date,
+        newsletter_type,
+        occurrence_cache,
     )
-    relevant_newsletters = [nl for nl in relevant_newsletters if nl]
-
-    if not relevant_newsletters:
-        return sorted(candidate_dates)
-
-    has_configs = False
-    valid_dates: set[date] = set()
-    for nl_type in relevant_newsletters:
-        configs = await schedule_service.list_configs(db, nl_type)
-        if not configs:
-            continue
-        has_configs = True
-        valid_for_newsletter = await schedule_service.get_valid_publication_dates(
-            db,
-            from_date,
-            to_date,
-            nl_type,
-        )
-        valid_dates.update(item["date"] for item in valid_for_newsletter)
-
-    if not has_configs:
-        return sorted(candidate_dates)
-
-    return sorted(candidate_dates & valid_dates)
 
 
 async def hydrate_submission_occurrences(
@@ -408,6 +430,7 @@ async def hydrate_submission_occurrences(
     to_date: date,
     newsletter_type: str | None = None,
     max_occurrences: int | None = None,
+    occurrence_cache: OccurrenceFilterCache | None = None,
 ) -> Submission:
     """Attach occurrence previews to a submission and each schedule request."""
     all_occurrences: list[date] = []
@@ -425,6 +448,7 @@ async def hydrate_submission_occurrences(
             from_date,
             to_date,
             newsletter_type=newsletter_type,
+            occurrence_cache=occurrence_cache,
         )
         if max_occurrences is not None:
             valid_occurrences = valid_occurrences[:max_occurrences]
@@ -450,11 +474,27 @@ async def get_submission_occurrence_dates_for_request(
     from_date: date,
     to_date: date,
     newsletter_type: str | None = None,
+    occurrence_cache: OccurrenceFilterCache | None = None,
 ) -> list[date]:
     """Filter occurrence candidates to valid publication dates."""
     if not candidate_dates:
         return []
 
+    return await _filter_candidate_dates(
+        db,
+        submission,
+        set(candidate_dates),
+        from_date,
+        to_date,
+        newsletter_type,
+        occurrence_cache,
+    )
+
+
+def _get_relevant_newsletters(
+    submission: Submission,
+    newsletter_type: str | None = None,
+) -> list[str]:
     relevant_newsletters = (
         [newsletter_type]
         if newsletter_type
@@ -464,30 +504,43 @@ async def get_submission_occurrence_dates_for_request(
             else [submission.Target_Newsletter]
         )
     )
-    relevant_newsletters = [nl for nl in relevant_newsletters if nl]
+    return [
+        nl_type
+        for nl_type in relevant_newsletters
+        if nl_type and nl_type != "none"
+    ]
 
+
+async def _filter_candidate_dates(
+    db: AsyncSession,
+    submission: Submission,
+    candidate_dates: set[date],
+    from_date: date,
+    to_date: date,
+    newsletter_type: str | None = None,
+    occurrence_cache: OccurrenceFilterCache | None = None,
+) -> list[date]:
+    """Filter occurrence candidates to valid publication dates with request caching."""
+    if not candidate_dates:
+        return []
+
+    relevant_newsletters = _get_relevant_newsletters(submission, newsletter_type)
     if not relevant_newsletters:
         return sorted(candidate_dates)
 
+    cache = occurrence_cache or OccurrenceFilterCache()
     has_configs = False
     valid_dates: set[date] = set()
     for nl_type in relevant_newsletters:
-        configs = await schedule_service.list_configs(db, nl_type)
-        if not configs:
+        if not await cache.configs_exist(db, nl_type):
             continue
         has_configs = True
-        valid_for_newsletter = await schedule_service.get_valid_publication_dates(
-            db,
-            from_date,
-            to_date,
-            nl_type,
-        )
-        valid_dates.update(item["date"] for item in valid_for_newsletter)
+        valid_dates.update(await cache.valid_dates(db, nl_type, from_date, to_date))
 
     if not has_configs:
         return sorted(candidate_dates)
 
-    return sorted(date_value for date_value in candidate_dates if date_value in valid_dates)
+    return sorted(candidate_dates & valid_dates)
 
 
 # --- Image management ---

--- a/backend/tests/test_submission_service.py
+++ b/backend/tests/test_submission_service.py
@@ -1,5 +1,7 @@
 """Service-level submission tests."""
 
+from datetime import date
+
 import pytest
 
 from app.schemas.submission import SubmissionCreate
@@ -30,3 +32,94 @@ async def test_create_submission_persists_second_requested_date(db):
 
     assert submission is not None
     assert submission.Schedule_Requests[0].Second_Requested_Date.isoformat() == "2026-04-13"
+
+
+@pytest.mark.asyncio
+async def test_date_range_listing_caches_publication_dates_per_request(
+    db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    for index in range(3):
+        await submission_service.create_submission(
+            db,
+            SubmissionCreate(
+                Category="faculty_staff",
+                Target_Newsletter="tdr",
+                Original_Headline=f"Recurring announcement {index}",
+                Original_Body="Body text.",
+                Submitter_Name="Test User",
+                Submitter_Email="test@uidaho.edu",
+                Links=[],
+                Schedule_Requests=[
+                    {
+                        "Requested_Date": "2026-04-06",
+                        "Recurrence_Type": "monthly_nth_weekday",
+                        "Recurrence_End_Date": "2026-06-01",
+                    }
+                ],
+            ),
+        )
+
+    calls = {"configs": 0, "valid_dates": 0}
+
+    async def fake_list_configs(db, newsletter_type=None):
+        calls["configs"] += 1
+        return [object()]
+
+    async def fake_valid_dates(db, from_date, to_date, newsletter_type):
+        calls["valid_dates"] += 1
+        return [{"date": date(2026, 5, 4)}]
+
+    monkeypatch.setattr(
+        submission_service.schedule_service,
+        "list_configs",
+        fake_list_configs,
+    )
+    monkeypatch.setattr(
+        submission_service.schedule_service,
+        "get_valid_publication_dates",
+        fake_valid_dates,
+    )
+
+    items, total = await submission_service.list_submissions(
+        db,
+        target_newsletter="tdr",
+        date_from=date(2026, 5, 1),
+        date_to=date(2026, 5, 31),
+    )
+
+    assert total == 3
+    assert len(items) == 3
+    assert calls == {"configs": 1, "valid_dates": 1}
+
+
+@pytest.mark.asyncio
+async def test_date_range_listing_excludes_one_time_submissions_outside_range(db):
+    await submission_service.create_submission(
+        db,
+        SubmissionCreate(
+            Category="faculty_staff",
+            Target_Newsletter="tdr",
+            Original_Headline="Old one-time announcement",
+            Original_Body="Body text.",
+            Submitter_Name="Test User",
+            Submitter_Email="test@uidaho.edu",
+            Links=[],
+            Schedule_Requests=[
+                {
+                    "Requested_Date": "2026-04-06",
+                    "Recurrence_Type": "once",
+                }
+            ],
+        ),
+    )
+
+    items, total = await submission_service.list_submissions(
+        db,
+        target_newsletter="tdr",
+        date_from=date(2026, 5, 1),
+        date_to=date(2026, 5, 31),
+    )
+
+    assert total == 0
+    assert items == []


### PR DESCRIPTION
## Summary
- Add a request-scoped occurrence filter cache so schedule configs and valid publication dates are loaded once per newsletter/date range
- Avoid duplicate date expansion in date-range listing by hydrating each candidate once and filtering on the hydrated occurrence preview
- Push more date-range narrowing into SQL for one-time, second-date, and recurring schedule requests
- Reuse the occurrence cache during newsletter assembly date checks
- Add listing/date-filter indexes for submission and schedule request filters
- Add regression tests for request-level publication-date caching and one-time date filtering

## Verification
- cd backend && env DATABASE_URL=sqlite+aiosqlite:////tmp/ucm_issue_112_indexes.db .venv/bin/alembic upgrade head
- cd backend && .venv/bin/pytest
- cd backend && .venv/bin/ruff check .
- cd frontend && npm run lint
- cd frontend && npm run build

Closes #112