### PR TITLE
Add submission form tests

### DIFF
--- a/frontend/src/components/submission/CategorySelect.tsx
+++ b/frontend/src/components/submission/CategorySelect.tsx
@@ -16,10 +16,14 @@ export default function CategorySelect({
 }: Props) {
   return (
     <div>
-      <label className="block text-sm font-medium text-gray-700 mb-1">
+      <label
+        htmlFor="submission-category"
+        className="block text-sm font-medium text-gray-700 mb-1"
+      >
         Announcement Type
       </label>
       <select
+        id="submission-category"
         value={value}
         onChange={(e) => onChange(e.target.value as SubmissionCategory)}
         disabled={isLoading || categories.length === 0}

--- a/frontend/src/components/submission/LinkEditor.tsx
+++ b/frontend/src/components/submission/LinkEditor.tsx
@@ -73,11 +73,15 @@ export default function LinkEditor({ links, onChange }: Props) {
               </div>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <div>
-                  <label className="block text-xs text-gray-500 mb-1">
+                  <label
+                    htmlFor={`submission-link-${index}-url`}
+                    className="block text-xs text-gray-500 mb-1"
+                  >
                     {emailMode ? 'Email address' : 'URL'}
                   </label>
                   {emailMode ? (
                     <input
+                      id={`submission-link-${index}-url`}
                       type="email"
                       placeholder="name@uidaho.edu"
                       value={link.Url.replace(/^mailto:/, '')}
@@ -87,6 +91,7 @@ export default function LinkEditor({ links, onChange }: Props) {
                     />
                   ) : (
                     <input
+                      id={`submission-link-${index}-url`}
                       type="url"
                       placeholder="https://..."
                       value={link.Url}
@@ -97,12 +102,16 @@ export default function LinkEditor({ links, onChange }: Props) {
                   )}
                 </div>
                 <div>
-                  <label className="block text-xs text-gray-500 mb-1">
+                  <label
+                    htmlFor={`submission-link-${index}-anchor`}
+                    className="block text-xs text-gray-500 mb-1"
+                  >
                     {emailMode
                       ? "Link text (person's name or email address)"
                       : 'Words to link the URL to (e.g., Learn more.)'}
                   </label>
                   <input
+                    id={`submission-link-${index}-anchor`}
                     type="text"
                     placeholder={emailMode ? "e.g., Jane Smith" : "e.g., Learn more"}
                     value={link.Anchor_Text}

--- a/frontend/src/components/submission/SchedulePrefs.tsx
+++ b/frontend/src/components/submission/SchedulePrefs.tsx
@@ -107,10 +107,14 @@ export default function SchedulePrefs({
         <div className="space-y-3">
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-xs text-gray-500 mb-1">
+              <label
+                htmlFor="submission-tdr-run-date"
+                className="block text-xs text-gray-500 mb-1"
+              >
                 Daily Register run date (Mon–Fri)
               </label>
               <input
+                id="submission-tdr-run-date"
                 type="date"
                 value={schedule.Requested_Date}
                 onChange={(e) => update('Requested_Date', e.target.value)}
@@ -128,10 +132,14 @@ export default function SchedulePrefs({
               <p className="text-xs text-gray-400 mt-1">Weekdays only</p>
             </div>
             <div>
-              <label className="block text-xs text-gray-500 mb-1">
+              <label
+                htmlFor="submission-myui-run-date"
+                className="block text-xs text-gray-500 mb-1"
+              >
                 My UI run date (Mondays only)
               </label>
               <input
+                id="submission-myui-run-date"
                 type="date"
                 value={schedule.Second_Requested_Date}
                 onChange={(e) => update('Second_Requested_Date', e.target.value)}
@@ -158,10 +166,14 @@ export default function SchedulePrefs({
         <>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-xs text-gray-500 mb-1">
+              <label
+                htmlFor="submission-preferred-run-date"
+                className="block text-xs text-gray-500 mb-1"
+              >
                 Preferred run date
               </label>
               <input
+                id="submission-preferred-run-date"
                 type="date"
                 value={schedule.Requested_Date}
                 onChange={(e) => update('Requested_Date', e.target.value)}
@@ -185,10 +197,14 @@ export default function SchedulePrefs({
               </p>
             </div>
             <div>
-              <label className="block text-xs text-gray-500 mb-1">
+              <label
+                htmlFor="submission-repeat-count"
+                className="block text-xs text-gray-500 mb-1"
+              >
                 How many times to run
               </label>
               <select
+                id="submission-repeat-count"
                 value={schedule.Repeat_Count}
                 onChange={(e) => update('Repeat_Count', parseInt(e.target.value))}
                 className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
@@ -200,10 +216,14 @@ export default function SchedulePrefs({
           </div>
           {schedule.Repeat_Count >= 2 && (
             <div className="mt-3">
-              <label className="block text-xs text-gray-500 mb-1">
+              <label
+                htmlFor="submission-second-run-date"
+                className="block text-xs text-gray-500 mb-1"
+              >
                 Second run date
               </label>
               <input
+                id="submission-second-run-date"
                 type="date"
                 value={schedule.Second_Requested_Date}
                 onChange={(e) => update('Second_Requested_Date', e.target.value)}
@@ -228,10 +248,14 @@ export default function SchedulePrefs({
       {showRecurrenceControls ? (
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-3">
           <div>
-            <label className="block text-xs text-gray-500 mb-1">
+            <label
+              htmlFor="submission-recurrence-type"
+              className="block text-xs text-gray-500 mb-1"
+            >
               Repeat on a cadence
             </label>
             <select
+              id="submission-recurrence-type"
               value={schedule.Recurrence_Type}
               onChange={(e) => {
                 const recurrenceType = e.target.value as ScheduleEntry['Recurrence_Type'];
@@ -254,10 +278,14 @@ export default function SchedulePrefs({
             </p>
           </div>
           <div>
-            <label className="block text-xs text-gray-500 mb-1">
+            <label
+              htmlFor="submission-recurrence-interval"
+              className="block text-xs text-gray-500 mb-1"
+            >
               Interval
             </label>
             <input
+              id="submission-recurrence-interval"
               type="number"
               min={1}
               max={12}
@@ -275,10 +303,14 @@ export default function SchedulePrefs({
             </p>
           </div>
           <div>
-            <label className="block text-xs text-gray-500 mb-1">
+            <label
+              htmlFor="submission-recurrence-end-date"
+              className="block text-xs text-gray-500 mb-1"
+            >
               Stop after
             </label>
             <input
+              id="submission-recurrence-end-date"
               type="date"
               value={schedule.Recurrence_End_Date}
               onChange={(e) => update('Recurrence_End_Date', e.target.value)}
@@ -337,10 +369,14 @@ export default function SchedulePrefs({
         )}
       </div>
       <div className="mt-3">
-        <label className="block text-xs text-gray-500 mb-1">
+        <label
+          htmlFor="submission-scheduling-notes"
+          className="block text-xs text-gray-500 mb-1"
+        >
           Scheduling notes (optional)
         </label>
         <input
+          id="submission-scheduling-notes"
           type="text"
           placeholder="e.g., 'Please skip finals week if needed'"
           value={schedule.Repeat_Note}

--- a/frontend/src/components/submission/SubmissionForm.test.tsx
+++ b/frontend/src/components/submission/SubmissionForm.test.tsx
@@ -1,0 +1,254 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { listAllowedValues } from '../../api/allowedValues';
+import { getValidDates } from '../../api/schedule';
+import { createSubmission } from '../../api/submissions';
+import type { AllowedValue } from '../../types/allowedValue';
+import type { Submission } from '../../types/submission';
+import SubmissionForm from './SubmissionForm';
+
+const submitterRoleMock = vi.hoisted(() => ({
+  value: 'public',
+}));
+
+vi.mock('../../api/allowedValues', () => ({
+  listAllowedValues: vi.fn(),
+}));
+
+vi.mock('../../api/schedule', () => ({
+  getValidDates: vi.fn(),
+}));
+
+vi.mock('../../api/submissions', () => ({
+  createSubmission: vi.fn(),
+}));
+
+vi.mock('../../utils/submitterRole', () => ({
+  getSubmitterRole: () => submitterRoleMock.value,
+}));
+
+const listAllowedValuesMock = vi.mocked(listAllowedValues);
+const getValidDatesMock = vi.mocked(getValidDates);
+const createSubmissionMock = vi.mocked(createSubmission);
+
+const allowedCategories: AllowedValue[] = [
+  {
+    Id: 'faculty_staff',
+    Value_Group: 'Submission_Category',
+    Code: 'faculty_staff',
+    Label: 'Faculty or Staff Announcement',
+    Display_Order: 1,
+    Is_Active: true,
+    Visibility_Role: 'public',
+    Description: null,
+  },
+  {
+    Id: 'student',
+    Value_Group: 'Submission_Category',
+    Code: 'student',
+    Label: 'Student Announcement',
+    Display_Order: 2,
+    Is_Active: true,
+    Visibility_Role: 'public',
+    Description: null,
+  },
+  {
+    Id: 'survey',
+    Value_Group: 'Submission_Category',
+    Code: 'survey',
+    Label: 'Survey',
+    Display_Order: 3,
+    Is_Active: true,
+    Visibility_Role: 'public',
+    Description: null,
+  },
+  {
+    Id: 'job_opportunity',
+    Value_Group: 'Submission_Category',
+    Code: 'job_opportunity',
+    Label: 'Job Opportunity',
+    Display_Order: 4,
+    Is_Active: true,
+    Visibility_Role: 'public',
+    Description: null,
+  },
+];
+
+function makeSubmission(overrides: Partial<Submission> = {}): Submission {
+  return {
+    Id: 'submission-1',
+    Category: 'faculty_staff',
+    Target_Newsletter: 'tdr',
+    Original_Headline: 'Campus forum',
+    Original_Body: 'Forum details.',
+    Submitter_Name: 'Jane Submitter',
+    Submitter_Email: 'jane@example.edu',
+    Submitter_Notes: null,
+    Assigned_Editor: null,
+    Editorial_Notes: null,
+    Survey_End_Date: null,
+    Has_Image: false,
+    Image_Path: null,
+    Status: 'new',
+    Show_In_SLC_Calendar: false,
+    Event_Classification: null,
+    Created_At: '2026-04-28T12:00:00Z',
+    Updated_At: '2026-04-28T12:00:00Z',
+    Links: [],
+    Schedule_Requests: [],
+    Occurrence_Dates: [],
+    ...overrides,
+  };
+}
+
+async function fillStandardAnnouncement(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText('Headline'), 'Campus forum');
+  await user.type(screen.getByLabelText('Body Text'), 'Join us for a campus-wide forum.');
+  await user.type(screen.getAllByLabelText('URL')[0], 'https://www.uidaho.edu/forum');
+  await user.type(screen.getAllByLabelText(/words to link/i)[0], 'forum details');
+  await user.type(screen.getByLabelText('Preferred run date'), '2026-05-05');
+  await user.type(screen.getByLabelText('Additional Notes for Editors'), 'Please review timing.');
+  await user.type(screen.getByLabelText('Your Name'), 'Jane Submitter');
+  await user.type(screen.getByLabelText('Email Address'), 'jane@example.edu');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  submitterRoleMock.value = 'public';
+  listAllowedValuesMock.mockResolvedValue(allowedCategories);
+  getValidDatesMock.mockResolvedValue({
+    dates: [
+      { date: '2026-05-04', newsletters: ['myui'] },
+      { date: '2026-05-05', newsletters: ['tdr'] },
+      { date: '2026-05-06', newsletters: ['tdr'] },
+    ],
+    blackout_dates: [],
+  });
+  createSubmissionMock.mockResolvedValue(makeSubmission());
+});
+
+describe('SubmissionForm', () => {
+  it('submits a standard announcement with links and scheduling notes', async () => {
+    const user = userEvent.setup();
+    render(<SubmissionForm />);
+
+    await screen.findByRole('option', { name: 'Faculty or Staff Announcement' });
+    await fillStandardAnnouncement(user);
+    await user.click(screen.getByRole('button', { name: /submit announcement/i }));
+
+    await waitFor(() => {
+      expect(createSubmissionMock).toHaveBeenCalledWith({
+        Category: 'faculty_staff',
+        Target_Newsletter: 'tdr',
+        Original_Headline: 'Campus forum',
+        Original_Body: 'Join us for a campus-wide forum.',
+        Submitter_Name: 'Jane Submitter',
+        Submitter_Email: 'jane@example.edu',
+        Submitter_Notes: 'Please review timing.',
+        Survey_End_Date: undefined,
+        Links: [
+          {
+            Url: 'https://www.uidaho.edu/forum',
+            Anchor_Text: 'forum details',
+          },
+        ],
+        Schedule_Requests: [
+          {
+            Requested_Date: '2026-05-05',
+            Second_Requested_Date: undefined,
+            Repeat_Count: 1,
+            Repeat_Note: undefined,
+            Is_Flexible: undefined,
+            Flexible_Deadline: undefined,
+            Recurrence_Type: 'once',
+            Recurrence_Interval: 1,
+            Recurrence_End_Date: undefined,
+          },
+        ],
+      });
+    });
+    expect(await screen.findByText(/submission received/i)).toBeInTheDocument();
+  });
+
+  it('submits separate TDR and My UI run dates when both newsletters are selected', async () => {
+    const user = userEvent.setup();
+    render(<SubmissionForm />);
+
+    await screen.findByRole('option', { name: 'Faculty or Staff Announcement' });
+    await user.click(screen.getByRole('button', { name: /both newsletters/i }));
+    await user.type(screen.getByLabelText('Headline'), 'Campus forum');
+    await user.type(screen.getByLabelText('Body Text'), 'Join us for a campus-wide forum.');
+    await user.type(screen.getByLabelText(/daily register run date/i), '2026-05-05');
+    await user.type(screen.getByLabelText(/my ui run date/i), '2026-05-04');
+    await user.type(screen.getByLabelText('Your Name'), 'Jane Submitter');
+    await user.type(screen.getByLabelText('Email Address'), 'jane@example.edu');
+    await user.click(screen.getByRole('button', { name: /submit announcement/i }));
+
+    await waitFor(() => {
+      expect(createSubmissionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Target_Newsletter: 'both',
+          Schedule_Requests: [
+            expect.objectContaining({
+              Requested_Date: '2026-05-05',
+              Second_Requested_Date: '2026-05-04',
+              Repeat_Count: 2,
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
+  it('blocks submission when the selected run date is not valid', async () => {
+    const user = userEvent.setup();
+    render(<SubmissionForm />);
+
+    await screen.findByRole('option', { name: 'Faculty or Staff Announcement' });
+    await user.type(screen.getByLabelText('Headline'), 'Campus forum');
+    await user.type(screen.getByLabelText('Body Text'), 'Join us for a campus-wide forum.');
+    await user.type(screen.getByLabelText('Preferred run date'), '2026-05-03');
+    await user.type(screen.getByLabelText('Your Name'), 'Jane Submitter');
+    await user.type(screen.getByLabelText('Email Address'), 'jane@example.edu');
+    await user.click(screen.getByRole('button', { name: /submit announcement/i }));
+
+    expect(await screen.findByText('Please select a valid run date for the chosen newsletter.')).toBeInTheDocument();
+    expect(createSubmissionMock).not.toHaveBeenCalled();
+  });
+
+  it('builds the structured job posting payload and forces TDR', async () => {
+    const user = userEvent.setup();
+    render(<SubmissionForm />);
+
+    await screen.findByRole('option', { name: 'Job Opportunity' });
+    await user.selectOptions(screen.getByLabelText('Announcement Type'), 'job_opportunity');
+    expect(screen.getByRole('button', { name: /my ui/i })).toBeDisabled();
+
+    await user.type(screen.getByLabelText('Job Posting URL'), 'https://uidaho.peopleadmin.com/postings/123');
+    await user.type(screen.getByLabelText('Position Title'), 'Program Coordinator');
+    await user.type(screen.getByLabelText('Department'), 'Student Affairs');
+    await user.type(screen.getByLabelText('Location(s)'), 'Moscow');
+    await user.type(screen.getByLabelText('Preferred run date'), '2026-05-05');
+    await user.type(screen.getByLabelText('Your Name'), 'Jane Submitter');
+    await user.type(screen.getByLabelText('Email Address'), 'jane@example.edu');
+    await user.click(screen.getByRole('button', { name: /submit announcement/i }));
+
+    await waitFor(() => {
+      expect(createSubmissionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Category: 'job_opportunity',
+          Target_Newsletter: 'tdr',
+          Original_Headline: 'Program Coordinator',
+          Original_Body: 'Department: Student Affairs. Location: Moscow. Apply using the linked posting.',
+          Links: [
+            {
+              Url: 'https://uidaho.peopleadmin.com/postings/123',
+              Anchor_Text: 'Program Coordinator, Student Affairs, Moscow',
+            },
+          ],
+        }),
+      );
+    });
+  });
+});

--- a/frontend/src/components/submission/SubmissionForm.tsx
+++ b/frontend/src/components/submission/SubmissionForm.tsx
@@ -468,10 +468,11 @@ export default function SubmissionForm() {
         />
         {category === 'survey' && (
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="submission-survey-end-date" className="block text-sm font-medium text-gray-700 mb-1">
               Survey / Event End Date
             </label>
             <input
+              id="submission-survey-end-date"
               type="date"
               value={surveyEndDate}
               onChange={(e) => setSurveyEndDate(e.target.value)}
@@ -497,10 +498,11 @@ export default function SubmissionForm() {
               Job listings run in The Daily Register for two weeks. Provide the PeopleAdmin URL and position details below.
             </p>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="submission-job-url" className="block text-sm font-medium text-gray-700 mb-1">
                 Job Posting URL
               </label>
               <input
+                id="submission-job-url"
                 type="url"
                 value={jobUrl}
                 onChange={(e) => setJobUrl(e.target.value)}
@@ -514,10 +516,11 @@ export default function SubmissionForm() {
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="submission-job-title" className="block text-sm font-medium text-gray-700 mb-1">
                   Position Title
                 </label>
                 <input
+                  id="submission-job-title"
                   type="text"
                   value={jobTitle}
                   onChange={(e) => setJobTitle(e.target.value)}
@@ -527,10 +530,11 @@ export default function SubmissionForm() {
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="submission-job-department" className="block text-sm font-medium text-gray-700 mb-1">
                   Department
                 </label>
                 <input
+                  id="submission-job-department"
                   type="text"
                   value={jobDepartment}
                   onChange={(e) => setJobDepartment(e.target.value)}
@@ -540,10 +544,11 @@ export default function SubmissionForm() {
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="submission-job-location" className="block text-sm font-medium text-gray-700 mb-1">
                   Location(s)
                 </label>
                 <input
+                  id="submission-job-location"
                   type="text"
                   value={jobLocation}
                   onChange={(e) => setJobLocation(e.target.value)}
@@ -556,10 +561,11 @@ export default function SubmissionForm() {
               </div>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="submission-job-remove-date" className="block text-sm font-medium text-gray-700 mb-1">
                 Remove listing early? (optional)
               </label>
               <input
+                id="submission-job-remove-date"
                 type="date"
                 value={jobRemoveDate}
                 onChange={(e) => setJobRemoveDate(e.target.value)}
@@ -575,10 +581,11 @@ export default function SubmissionForm() {
           /* --- Standard announcement form --- */
           <>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="submission-headline" className="block text-sm font-medium text-gray-700 mb-1">
                 Headline
               </label>
               <input
+                id="submission-headline"
                 type="text"
                 value={headline}
                 onChange={(e) => setHeadline(e.target.value)}
@@ -590,13 +597,14 @@ export default function SubmissionForm() {
               <p className="text-xs text-gray-400 mt-1">{headline.length}/500</p>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="submission-body" className="block text-sm font-medium text-gray-700 mb-1">
                 Body Text
               </label>
               <p className="text-xs text-gray-500 mb-2">
                 Keep announcements concise — aim for 150–300 words. Include who, what, when, where, and cost if applicable.
               </p>
               <textarea
+                id="submission-body"
                 value={body}
                 onChange={(e) => setBody(e.target.value)}
                 required
@@ -633,10 +641,11 @@ export default function SubmissionForm() {
           showRecurrenceControls={isStaff}
         />
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label htmlFor="submission-editor-notes" className="block text-sm font-medium text-gray-700 mb-1">
             Additional Notes for Editors
           </label>
           <textarea
+            id="submission-editor-notes"
             value={notes}
             onChange={(e) => setNotes(e.target.value)}
             rows={3}
@@ -653,10 +662,11 @@ export default function SubmissionForm() {
         </h3>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="submission-submitter-name" className="block text-sm font-medium text-gray-700 mb-1">
               Your Name
             </label>
             <input
+              id="submission-submitter-name"
               type="text"
               value={submitterName}
               onChange={(e) => setSubmitterName(e.target.value)}
@@ -665,10 +675,11 @@ export default function SubmissionForm() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="submission-submitter-email" className="block text-sm font-medium text-gray-700 mb-1">
               Email Address
             </label>
             <input
+              id="submission-submitter-email"
               type="email"
               value={submitterEmail}
               onChange={(e) => setSubmitterEmail(e.target.value)}


### PR DESCRIPTION
## Summary
- add submission intake workflow tests for standard announcements, both-newsletter scheduling, invalid dates, and job posting payloads
- associate submission form labels with controls to improve accessibility and testability

## Verification
- npm test
- npm run lint
- npm run build