### PR TITLE
Add prototype trusted role wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ IMAGE_UPLOAD_MAX_PIXELS=36000000
 # Set this to the shared secret used by your reverse proxy or auth gateway when
 # it injects X-Trusted-User-Role and X-Trusted-Auth-Secret.
 TRUSTED_ROLE_HEADER_SECRET=
+# Prototype deployments can assert one role for all proxied API traffic.
+# Leave blank for public-only behavior; set to "staff" to expose editor tools.
+TRUSTED_ROLE_HEADER_ROLE=
 
 # University calendar source
 CALENDAR_SOURCE_URL=https://www.qatrumba.com/events-calendar/ui/uidaho/vandals/vandal/event/events/calendar/moscow/idaho/id/university-of-idaho

--- a/deploy.sh
+++ b/deploy.sh
@@ -49,6 +49,21 @@ fi
 COMPOSE=(docker compose --env-file "$ENV_FILE" -p "$PROJECT_NAME")
 BASE_URL="http://127.0.0.1:${HOST_PORT}"
 
+env_file_value() {
+  local key="$1"
+  local line
+  line="$(grep -E "^${key}=" "$ENV_FILE" | tail -n 1 || true)"
+  if [[ -z "$line" ]]; then
+    return 0
+  fi
+  line="${line#*=}"
+  line="${line%\"}"
+  line="${line#\"}"
+  line="${line%\'}"
+  line="${line#\'}"
+  printf '%s' "$line"
+}
+
 retry() {
   local attempts="$1"
   shift
@@ -73,6 +88,27 @@ smoke_check() {
   retry 12 2 curl -fsS "$url" >/dev/null
 }
 
+smoke_check_trusted_role() {
+  local label="$1"
+  local url="$2"
+  local role
+  local secret
+
+  role="$(env_file_value TRUSTED_ROLE_HEADER_ROLE)"
+  secret="$(env_file_value TRUSTED_ROLE_HEADER_SECRET)"
+
+  echo "Checking ${label}: ${url}"
+  if [[ -n "$role" && -n "$secret" ]]; then
+    retry 12 2 curl -fsS \
+      -H "X-Trusted-User-Role: ${role}" \
+      -H "X-Trusted-Auth-Secret: ${secret}" \
+      "$url" >/dev/null
+    return
+  fi
+
+  echo "Skipping ${label}: TRUSTED_ROLE_HEADER_ROLE/SECRET not configured"
+}
+
 echo "Deploying ${ENVIRONMENT} with project ${PROJECT_NAME}"
 "${COMPOSE[@]}" up -d --build
 
@@ -87,7 +123,7 @@ smoke_check "frontend root" "${BASE_URL}/"
 smoke_check "SPA route" "${BASE_URL}/dashboard"
 smoke_check "health API" "${BASE_URL}/api/v1/health"
 smoke_check "settings API" "${BASE_URL}/api/v1/settings/ai"
-smoke_check "submissions API" "${BASE_URL}/api/v1/submissions/?limit=1"
+smoke_check_trusted_role "submissions API" "${BASE_URL}/api/v1/submissions/?limit=1"
 
 echo "Deployment checks passed for ${ENVIRONMENT}"
 echo "Public URL: ${PUBLIC_URL}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       ENVIRONMENT: ${ENVIRONMENT:-production}
       UPLOAD_DIR: /app/uploads
       CORS_ORIGINS: '${CORS_ORIGINS:?Set CORS_ORIGINS in .env}'
+      TRUSTED_ROLE_HEADER_SECRET: ${TRUSTED_ROLE_HEADER_SECRET:-}
     volumes:
       - uploads:/app/uploads
     networks:
@@ -29,6 +30,9 @@ services:
 
   frontend:
     build: ./frontend
+    environment:
+      TRUSTED_ROLE_HEADER_ROLE: ${TRUSTED_ROLE_HEADER_ROLE:-}
+      TRUSTED_ROLE_HEADER_SECRET: ${TRUSTED_ROLE_HEADER_SECRET:-}
     ports:
       - "${HOST_PORT:-9280}:80"
     depends_on:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -241,7 +241,34 @@ ENVIRONMENT=production
 CORS_ORIGINS=https://ucmnews.insight.uidaho.edu
 # For deployed dev:
 # CORS_ORIGINS=https://ucmnews-dev.insight.uidaho.edu
+
+# Trusted auth boundary
+TRUSTED_ROLE_HEADER_SECRET=
+# Prototype deployments can assert one role for all proxied API traffic.
+# Leave blank for public-only behavior; set to "staff" to expose editor tools.
+TRUSTED_ROLE_HEADER_ROLE=
 ```
+
+### Prototype Staff Access
+
+For advanced prototype testing, the frontend nginx container can assert a
+single trusted role for every proxied API request. Set both values in the
+environment file:
+
+```bash
+TRUSTED_ROLE_HEADER_SECRET=<random-long-secret>
+TRUSTED_ROLE_HEADER_ROLE=staff
+```
+
+`docker-compose.yml` passes the secret to both containers. The frontend proxy
+overwrites `X-Trusted-User-Role` and `X-Trusted-Auth-Secret` before forwarding
+requests to the backend, and FastAPI accepts staff-only routes only when the
+secret matches.
+
+For a non-prototype production deployment, leave `TRUSTED_ROLE_HEADER_ROLE`
+blank in the app container and have the campus auth gateway or reverse proxy
+decide the real user role, strip any client-supplied trusted headers, and then
+inject the trusted headers server-side.
 
 ### Nginx Proxy Timeouts
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,6 +11,6 @@ RUN npm run build
 FROM nginx:alpine
 
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/templates/default.conf.template
 
 EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -13,6 +13,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Trusted-User-Role "${TRUSTED_ROLE_HEADER_ROLE}";
+        proxy_set_header X-Trusted-Auth-Secret "${TRUSTED_ROLE_HEADER_SECRET}";
 
         # AI editing via MindRouter can take several minutes
         proxy_read_timeout 300s;


### PR DESCRIPTION
## Summary
- pass trusted role secret into backend and frontend containers
- let the frontend nginx proxy assert a configured prototype role for API requests
- update dev deploy smoke checks to use trusted role headers when configured
- document prototype staff access setup

## Verification
- bash -n deploy.sh
- docker compose --env-file .env.example config --quiet