### PR TITLE
Distill Dashboard list rows (closes #147)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,49 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Three audiences, all internal to the University of Idaho:
+
+- **Submitters (faculty & staff)** — occasional users sending announcements, events, and news items into the newsletter pipeline. Working in browser tabs between other tasks; need a guided, low-friction path that prevents bad submissions.
+- **UCM editors** — the daily power users. They triage incoming submissions, apply AI-assisted style edits, manage controlled vocabularies (sections, allowed values, schedule), assemble newsletters, and publish. They live in this tool.
+- **SLC Leadership Council and their admins** — preview audience for a private strategic-events calendar. Read-mostly, occasional input.
+
+The two newsletters produced are *The Daily Register* (faculty/staff) and *My UI* (students).
+
+## Product Purpose
+
+An AI-assisted newsletter production pipeline. It absorbs unstructured submissions, applies institutional style rules through an LLM editor, and produces two newsletters on a recurring schedule. Success looks like: editors ship daily without copy-paste fatigue, style consistency is enforced without nagging humans, and submitters get useful constraints up front rather than rejection rounds.
+
+## Brand Personality
+
+**Confident, modern, helpful.** Linear / Notion / Stripe-grade product polish wearing University of Idaho brand colors. The voice is institutional but not stuffy, like a well-run newsroom desk: clear, efficient, mildly opinionated about good prose.
+
+Three words: confident, modern, helpful.
+
+## Anti-references
+
+What this should explicitly NOT look like:
+
+- **Generic SaaS dashboards.** Gradient hero metrics, identical 3-column card grids, "Welcome back, [name] 👋", animated counters. This is a workspace, not a portfolio piece.
+- **Old-school university CMS.** Cascade Server / SiteImprove era, tabular layouts, dated chrome, six-deep nested admin menus. The audience is institutional, the interface should not be.
+- **Consumer marketing flash.** Bold gradients, animated heroes, scroll-driven sections, motion-heavy compositions. Editors will use this for hours a day; spectacle becomes irritation.
+- **AI-tool slop.** Neon-on-black, glassmorphism cards, gradient text, dark glows, the "AI made this" reflex aesthetic. The product *uses* AI; it should not *advertise* AI.
+
+## Design Principles
+
+1. **Editorial calm over product flash.** This is a newsroom workspace, not a SaaS dashboard. Density, restraint, and clear information are the job, never decorative motion or hero-metric vanity.
+
+2. **The interface earns the brand, not the other way around.** UI Pride Gold and Clearwater are powerful colors; they should appear as deliberate accents on a quiet canvas. The UI should feel unmistakably University of Idaho without ever shouting it.
+
+3. **Trust the editor.** Submitters are guided; editors are not. Power-user surfaces (builder, dashboard, style rules) should reward speed and keyboard fluency, not hand-hold.
+
+## Accessibility & Inclusion
+
+- **WCAG 2.1 AA** baseline (US public university standard).
+- Editors use this product as a daily tool. Assume long sessions; fatigue tolerance matters more than first-impression dazzle.
+- Reduced motion: respect `prefers-reduced-motion`; any motion must be functional, never decorative.
+- Color-contrast caution: UI Pride Gold (#F1B300) on white fails AA for body text. Use Gold for accents and decoration only, never for text, links, or critical UI affordances. Clearwater 700+ on white is the safe text accent.

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -315,36 +315,24 @@ export default function DashboardPage() {
         </div>
       ) : (
         <div className="space-y-3">
-          {submissions.map((sub) => (
-            <div
-              key={sub.Id}
-              className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow cursor-pointer"
-              onClick={() => navigate(`/edit/${sub.Id}`)}
-            >
-              <div className="flex items-start justify-between">
+          {submissions.map((sub) => {
+            const occurrenceDate = getPrimaryOccurrenceDate(sub);
+            return (
+              <div
+                key={sub.Id}
+                className="bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow cursor-pointer p-4 flex items-center gap-4"
+                onClick={() => navigate(`/edit/${sub.Id}`)}
+              >
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1 flex-wrap">
+                  <div className="flex items-center gap-2 mb-1.5">
                     <span
                       className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_COLORS[sub.Status] || 'bg-gray-100'}`}
                     >
                       {STATUS_LABELS[sub.Status] || sub.Status}
                     </span>
-                    <span className="text-xs bg-gray-50 text-gray-600 px-2 py-0.5 rounded">
-                      {CATEGORY_LABELS[sub.Category] || sub.Category}
-                    </span>
                     <span className="text-xs bg-ui-gold-50 text-ui-gold-700 px-2 py-0.5 rounded font-medium">
                       {NEWSLETTER_LABELS[sub.Target_Newsletter]}
                     </span>
-                    {sub.Assigned_Editor && (
-                      <span className="text-xs bg-ui-clearwater-50 text-ui-clearwater-700 px-2 py-0.5 rounded font-medium">
-                        {sub.Assigned_Editor}
-                      </span>
-                    )}
-                    {sub.Editorial_Notes && (
-                      <span className="text-xs bg-amber-50 text-amber-700 px-2 py-0.5 rounded font-medium">
-                        Has notes
-                      </span>
-                    )}
                   </div>
                   <h3 className="text-sm font-semibold text-gray-900 truncate">
                     {sub.Original_Headline}
@@ -352,27 +340,56 @@ export default function DashboardPage() {
                   <p className="text-sm text-gray-600 mt-1 line-clamp-2">
                     {sub.Original_Body}
                   </p>
-                  <div className="flex items-center gap-4 mt-2 text-xs text-gray-400">
+                  <div className="mt-2 text-xs text-gray-500 flex items-center gap-x-2 gap-y-0.5 flex-wrap">
+                    <span>{CATEGORY_LABELS[sub.Category] || sub.Category}</span>
+                    <span aria-hidden="true" className="text-gray-300">·</span>
                     <span>{sub.Submitter_Name}</span>
-                    <span>{new Date(sub.Created_At.endsWith('Z') ? sub.Created_At : sub.Created_At + 'Z').toLocaleDateString()}</span>
-                    {sub.Links.length > 0 && (
-                      <span>{sub.Links.length} link{sub.Links.length > 1 ? 's' : ''}</span>
-                    )}
-                    {sub.Has_Image && <span>Has image</span>}
+                    <span aria-hidden="true" className="text-gray-300">·</span>
+                    <span>
+                      {new Date(
+                        sub.Created_At.endsWith('Z') ? sub.Created_At : sub.Created_At + 'Z',
+                      ).toLocaleDateString()}
+                    </span>
                     {sub.Schedule_Requests.length > 0 && (
-                      <span>
-                        {getPrimaryOccurrenceDate(sub)
-                          ? `Run: ${new Date(getPrimaryOccurrenceDate(sub)! + 'T12:00:00').toLocaleDateString()}`
-                          : 'Schedule prefs'}
-                      </span>
+                      <>
+                        <span aria-hidden="true" className="text-gray-300">·</span>
+                        <span>
+                          {occurrenceDate
+                            ? `Run: ${new Date(occurrenceDate + 'T12:00:00').toLocaleDateString()}`
+                            : 'Schedule prefs'}
+                        </span>
+                      </>
+                    )}
+                    {sub.Links.length > 0 && (
+                      <>
+                        <span aria-hidden="true" className="text-gray-300">·</span>
+                        <span>
+                          {sub.Links.length} link{sub.Links.length > 1 ? 's' : ''}
+                        </span>
+                      </>
+                    )}
+                    {sub.Has_Image && (
+                      <>
+                        <span aria-hidden="true" className="text-gray-300">·</span>
+                        <span>Has image</span>
+                      </>
                     )}
                     {sub.Assigned_Editor && (
-                      <span>Assigned: {sub.Assigned_Editor}</span>
+                      <>
+                        <span aria-hidden="true" className="text-gray-300">·</span>
+                        <span>Assigned: {sub.Assigned_Editor}</span>
+                      </>
+                    )}
+                    {sub.Editorial_Notes && (
+                      <>
+                        <span aria-hidden="true" className="text-gray-300">·</span>
+                        <span>Has notes</span>
+                      </>
                     )}
                   </div>
                 </div>
                 <button
-                  className="ml-4 px-3 py-1.5 text-xs font-medium rounded-md bg-ui-gold-50 text-ui-gold-700 hover:bg-ui-gold-100 whitespace-nowrap"
+                  className="shrink-0 px-3 py-1.5 text-xs font-medium rounded-md bg-ui-gold-50 text-ui-gold-700 hover:bg-ui-gold-100 whitespace-nowrap"
                   onClick={(e) => {
                     e.stopPropagation();
                     navigate(`/edit/${sub.Id}`);
@@ -381,8 +398,8 @@ export default function DashboardPage() {
                   {getStatusAction(sub.Status)}
                 </button>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Reduces Dashboard row chips from up to 5 → 2 (status + newsletter target only)
- Moves category, assigned editor, and "Has notes" into a muted secondary metadata line
- Centers the action button vertically; removes duplicate `Assigned_Editor` rendering (was both pill and footer text)
- Adds `PRODUCT.md` capturing register, users, brand personality, anti-references, and strategic design principles for future `$impeccable` runs

Resolves #147 — the editor's most-visited screen, where chip density made "scan for what needs my attention" harder than it should be.

## Visual change

```
BEFORE  [In Review] [Kudos] [My UI] [Alex Kim] [Has notes]              [Finalize]
AFTER   [In Review] [My UI]                                              [Finalize]
        Kudos · Jane Patel · 4/26/2026 · Run: 5/2 · 1 link · Has image · Assigned: Alex Kim · Has notes
```

## Test plan
- [x] Vitest suite passes locally (26/26)
- [x] Visual check at 1440×900 — 2-chip row, no overflow
- [x] Visual check at 1024×700 — secondary metadata wraps gracefully
- [x] All status badges render with their existing colors
- [ ] Reviewer eye-test on a populated staging dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)