### PR TITLE
Semantic status tokens + brand-color drift fixes (closes #146, #150)

### DIFF
--- a/frontend/src/components/editor/SideBySideView.tsx
+++ b/frontend/src/components/editor/SideBySideView.tsx
@@ -43,7 +43,7 @@ export default function SideBySideView({
           <label className="block text-xs font-medium text-gray-500 mb-1">
             Headline
           </label>
-          <p className="text-sm font-medium text-gray-900 bg-green-50 p-3 rounded">
+          <p className="text-sm font-medium text-emerald-900 bg-green-50 p-3 rounded">
             {aiHeadline}
           </p>
         </div>
@@ -51,7 +51,7 @@ export default function SideBySideView({
           <label className="block text-xs font-medium text-gray-500 mb-1">
             Body
           </label>
-          <RichBody text={aiBody} className="text-sm text-gray-700 bg-green-50 p-3 rounded" />
+          <RichBody text={aiBody} className="text-sm text-emerald-800 bg-green-50 p-3 rounded" />
         </div>
       </div>
     </div>

--- a/frontend/src/components/submission/SubmissionForm.tsx
+++ b/frontend/src/components/submission/SubmissionForm.tsx
@@ -431,11 +431,11 @@ export default function SubmissionForm() {
   return (
     <form onSubmit={handleSubmit} className="max-w-3xl space-y-6">
       {isStaff && (
-        <div className="rounded-md bg-purple-50 border border-purple-200 px-4 py-2 flex items-center gap-2">
-          <span className="inline-flex items-center rounded-full bg-purple-500 px-2 py-0.5 text-xs font-medium text-white">
+        <div className="rounded-md bg-ui-clearwater-50 border border-ui-clearwater-200 px-4 py-2 flex items-center gap-2">
+          <span className="inline-flex items-center rounded-full bg-ui-clearwater-500 px-2 py-0.5 text-xs font-medium text-white">
             Staff
           </span>
-          <p className="text-sm text-purple-800">
+          <p className="text-sm text-ui-clearwater-800">
             UCM staff mode — additional announcement types are available.
           </p>
         </div>
@@ -451,7 +451,7 @@ export default function SubmissionForm() {
           About Your Announcement
         </h3>
         {isJobOpportunity && (
-          <p className="text-xs text-gray-500 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
+          <p className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
             Job postings run in The Daily Register only.
           </p>
         )}
@@ -494,7 +494,7 @@ export default function SubmissionForm() {
         {category === 'job_opportunity' ? (
           /* --- Simplified Job Opportunity form --- */
           <div className="space-y-4">
-            <p className="text-xs text-gray-500 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
+            <p className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
               Job listings run in The Daily Register for two weeks. Provide the PeopleAdmin URL and position details below.
             </p>
             <div>
@@ -695,7 +695,7 @@ export default function SubmissionForm() {
         <button
           type="submit"
           disabled={submitting}
-          className="px-6 py-3 bg-yellow-400 text-black font-medium rounded-lg hover:bg-yellow-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="px-6 py-3 bg-ui-gold-500 text-ui-black font-medium rounded-lg hover:bg-ui-gold-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
           {submitting ? 'Submitting...' : 'Submit Announcement'}
         </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -31,6 +31,33 @@
   --color-ui-black: #323232;
   --color-ui-silver: #808080;
 
+  /* === Semantic Status Tokens === */
+  /* Status pills route through these so every page maps the same
+     semantic role to the same color. Add a new role here, never a
+     raw Tailwind hue in JSX. The -100 variant is the soft background;
+     the -800 variant is the strong foreground for text on it. */
+
+  --color-status-info-100:      #DBEAFE;
+  --color-status-info-800:      #1E40AF;
+
+  --color-status-edited-100:    #E0E7FF;
+  --color-status-edited-800:    #3730A3;
+
+  --color-status-warning-100:   #FEF3C7;
+  --color-status-warning-800:   #92400E;
+
+  --color-status-success-100:   #D1FAE5;
+  --color-status-success-800:   #065F46;
+
+  --color-status-attention-100: #FED7AA;
+  --color-status-attention-800: #9A3412;
+
+  --color-status-error-100:     #FEE2E2;
+  --color-status-error-800:     #991B1B;
+
+  --color-status-muted-100:     #F3F4F6;
+  --color-status-muted-800:     #374151;
+
   /* === Typography === */
   --font-sans: 'Public Sans', ui-sans-serif, system-ui, sans-serif;
 }

--- a/frontend/src/pages/BuilderPage.tsx
+++ b/frontend/src/pages/BuilderPage.tsx
@@ -647,11 +647,11 @@ export default function BuilderPage() {
   const sectionNameById = new Map(sections.map((section) => [section.Id, section.Name]));
 
   const STATUS_COLORS: Record<string, string> = {
-    draft: 'bg-gray-100 text-gray-800',
-    in_progress: 'bg-blue-100 text-blue-800',
-    ready_for_review: 'bg-yellow-100 text-yellow-800',
+    draft: 'bg-status-muted-100 text-status-muted-800',
+    in_progress: 'bg-status-info-100 text-status-info-800',
+    ready_for_review: 'bg-status-warning-100 text-status-warning-800',
     submitted: 'bg-ui-clearwater-100 text-ui-clearwater-800',
-    published: 'bg-green-100 text-green-800',
+    published: 'bg-status-success-100 text-status-success-800',
   };
 
   return (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -9,14 +9,14 @@ import DayDetail from '../components/dashboard/DayDetail';
 import { getPrimaryOccurrenceDate } from '../utils/submissionOccurrences';
 
 const STATUS_COLORS: Record<string, string> = {
-  new: 'bg-blue-100 text-blue-800',
-  ai_edited: 'bg-purple-100 text-purple-800',
-  in_review: 'bg-yellow-100 text-yellow-800',
-  approved: 'bg-green-100 text-green-800',
+  new: 'bg-status-info-100 text-status-info-800',
+  ai_edited: 'bg-status-edited-100 text-status-edited-800',
+  in_review: 'bg-status-warning-100 text-status-warning-800',
+  approved: 'bg-status-success-100 text-status-success-800',
   scheduled: 'bg-ui-clearwater-100 text-ui-clearwater-800',
-  published: 'bg-gray-100 text-gray-800',
-  rejected: 'bg-red-100 text-red-800',
-  pending_info: 'bg-orange-100 text-orange-800',
+  published: 'bg-status-muted-100 text-status-muted-800',
+  rejected: 'bg-status-error-100 text-status-error-800',
+  pending_info: 'bg-status-attention-100 text-status-attention-800',
 };
 
 const STATUS_LABELS: Record<string, string> = {

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -25,14 +25,14 @@ type Tab = 'original' | 'ai_edit' | 'editor';
 type ViewMode = 'diff' | 'side_by_side';
 
 const STATUS_COLORS: Record<string, string> = {
-  new: 'bg-blue-100 text-blue-800',
-  ai_edited: 'bg-purple-100 text-purple-800',
-  in_review: 'bg-yellow-100 text-yellow-800',
-  approved: 'bg-green-100 text-green-800',
+  new: 'bg-status-info-100 text-status-info-800',
+  ai_edited: 'bg-status-edited-100 text-status-edited-800',
+  in_review: 'bg-status-warning-100 text-status-warning-800',
+  approved: 'bg-status-success-100 text-status-success-800',
   scheduled: 'bg-ui-clearwater-100 text-ui-clearwater-800',
-  published: 'bg-gray-100 text-gray-800',
-  rejected: 'bg-red-100 text-red-800',
-  pending_info: 'bg-orange-100 text-orange-800',
+  published: 'bg-status-muted-100 text-status-muted-800',
+  rejected: 'bg-status-error-100 text-status-error-800',
+  pending_info: 'bg-status-attention-100 text-status-attention-800',
 };
 
 export default function EditPage() {
@@ -525,7 +525,7 @@ export default function EditPage() {
                         <label className="block text-xs font-medium text-gray-500 mb-1">
                           AI Headline
                         </label>
-                        <p className="text-sm font-medium text-gray-900 bg-green-50 p-3 rounded">
+                        <p className="text-sm font-medium text-emerald-900 bg-green-50 p-3 rounded">
                           {aiVersion.Headline}
                         </p>
                       </div>
@@ -537,7 +537,7 @@ export default function EditPage() {
                         <label className="block text-xs font-medium text-gray-500 mb-1">
                           AI Body
                         </label>
-                        <RichBody text={aiVersion.Body} className="text-sm text-gray-700 bg-green-50 p-3 rounded" />
+                        <RichBody text={aiVersion.Body} className="text-sm text-emerald-800 bg-green-50 p-3 rounded" />
                       </div>
                     )}
                   </>


### PR DESCRIPTION
## Summary
- Adds a **semantic status token system** in `frontend/src/index.css` (`--color-status-{info,edited,warning,success,attention,error,muted}-{100,800}`) and routes every `STATUS_COLORS` map (Dashboard, Edit, Builder) through it. Adding a new status now means defining a token, never typing a raw Tailwind color into JSX.
- **Submit button** moves from raw `bg-yellow-400 text-black` → `bg-ui-gold-500 text-ui-black` with hover on `ui-gold-600`.
- **Staff-mode banner** moves from purple → `ui-clearwater-{50,200,500,800}` (purple is a non-brand color per `PRODUCT.md` anti-references).
- **AI-Edited status pill** moves from purple → indigo via the `edited` token so no surface in the app advertises a non-brand color anymore.
- **6 WCAG AA contrast failures** fixed: gray text on `bg-green-50` / `bg-amber-50` → emerald / amber-family text. Re-running `npx impeccable --json --fast frontend/src` returns zero findings (was 6).

Resolves #146 and #150.

## Token reference
```
--color-status-info-100/800       → "new"           (was blue-100/800)
--color-status-edited-100/800     → "ai_edited"     (was purple-100/800)
--color-status-warning-100/800    → "in_review"     (was yellow-100/800)
--color-status-success-100/800    → "approved"      (was green-100/800)
--color-status-attention-100/800  → "pending_info"  (was orange-100/800)
--color-status-error-100/800      → "rejected"      (was red-100/800)
--color-status-muted-100/800      → "published"     (was gray-100/800)
"scheduled" already used ui-clearwater — kept.
```

## Test plan
- [x] `npm test` — 26/26 pass
- [x] `npm run build` — clean
- [x] `npx impeccable --json --fast frontend/src` — zero findings (was 6)
- [x] Verified all 8 status pills resolve to correct hex values via DOM inspection
- [x] Verified submit button bg = `#F1B300` (ui-gold-500), text = `#323232` (ui-black)
- [x] Verified staff banner bg = `#EEFBFB` (ui-clearwater-50), pill = `#008080` (ui-clearwater-500)
- [ ] Reviewer eye-test on populated staging dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)