### PR TITLE
Polish: extend status tokens to calendar surfaces + warm AppShell canvas

### DIFF
--- a/frontend/src/components/dashboard/CalendarView.tsx
+++ b/frontend/src/components/dashboard/CalendarView.tsx
@@ -4,14 +4,14 @@ import { getOccurrenceDates } from '../../utils/submissionOccurrences';
 const DAYS_OF_WEEK = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 const STATUS_DOT_COLORS: Record<string, string> = {
-  new: 'bg-blue-400',
-  ai_edited: 'bg-purple-400',
-  in_review: 'bg-yellow-400',
-  approved: 'bg-green-400',
-  scheduled: 'bg-cyan-400',
-  published: 'bg-gray-400',
-  rejected: 'bg-red-400',
-  pending_info: 'bg-orange-400',
+  new: 'bg-status-info-500',
+  ai_edited: 'bg-status-edited-500',
+  in_review: 'bg-status-warning-500',
+  approved: 'bg-status-success-500',
+  scheduled: 'bg-ui-clearwater-500',
+  published: 'bg-status-muted-500',
+  rejected: 'bg-status-error-500',
+  pending_info: 'bg-status-attention-500',
 };
 
 interface CalendarViewProps {
@@ -196,23 +196,23 @@ export default function CalendarView({
         <div className="flex items-center gap-3 text-xs text-gray-500 flex-wrap">
           <span className="text-gray-400 font-medium">Status:</span>
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-blue-400" />
+            <span className="w-2 h-2 rounded-full bg-status-info-500" />
             New
           </span>
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-purple-400" />
+            <span className="w-2 h-2 rounded-full bg-status-edited-500" />
             AI Edited
           </span>
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-yellow-400" />
+            <span className="w-2 h-2 rounded-full bg-status-warning-500" />
             In Review
           </span>
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-green-400" />
+            <span className="w-2 h-2 rounded-full bg-status-success-500" />
             Approved
           </span>
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-cyan-400" />
+            <span className="w-2 h-2 rounded-full bg-ui-clearwater-500" />
             Scheduled
           </span>
         </div>

--- a/frontend/src/components/dashboard/DayDetail.tsx
+++ b/frontend/src/components/dashboard/DayDetail.tsx
@@ -5,14 +5,14 @@ import { getOccurrenceDates } from '../../utils/submissionOccurrences';
 import { rescheduleScheduleOccurrence } from '../../api/submissions';
 
 const STATUS_COLORS: Record<string, string> = {
-  new: 'bg-blue-100 text-blue-800',
-  ai_edited: 'bg-purple-100 text-purple-800',
-  in_review: 'bg-yellow-100 text-yellow-800',
-  approved: 'bg-green-100 text-green-800',
+  new: 'bg-status-info-100 text-status-info-800',
+  ai_edited: 'bg-status-edited-100 text-status-edited-800',
+  in_review: 'bg-status-warning-100 text-status-warning-800',
+  approved: 'bg-status-success-100 text-status-success-800',
   scheduled: 'bg-ui-clearwater-100 text-ui-clearwater-800',
-  published: 'bg-gray-100 text-gray-800',
-  rejected: 'bg-red-100 text-red-800',
-  pending_info: 'bg-orange-100 text-orange-800',
+  published: 'bg-status-muted-100 text-status-muted-800',
+  rejected: 'bg-status-error-100 text-status-error-800',
+  pending_info: 'bg-status-attention-100 text-status-attention-800',
 };
 
 const STATUS_LABELS: Record<string, string> = {

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -3,7 +3,7 @@ import Sidebar from './Sidebar';
 
 export default function AppShell() {
   return (
-    <div className="flex min-h-screen bg-gray-50">
+    <div className="flex min-h-screen bg-stone-50">
       <Sidebar />
       <main className="flex-1 p-8 overflow-auto">
         <Outlet />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -37,25 +37,36 @@
      raw Tailwind hue in JSX. The -100 variant is the soft background;
      the -800 variant is the strong foreground for text on it. */
 
+  /* -100: soft background under colored text. -500: mid-saturation,
+     for small visual elements (calendar dots, badges, vivid CTAs).
+     -800: strong foreground for accessible text on -100. */
+
   --color-status-info-100:      #DBEAFE;
+  --color-status-info-500:      #3B82F6;
   --color-status-info-800:      #1E40AF;
 
   --color-status-edited-100:    #E0E7FF;
+  --color-status-edited-500:    #6366F1;
   --color-status-edited-800:    #3730A3;
 
   --color-status-warning-100:   #FEF3C7;
+  --color-status-warning-500:   #F59E0B;
   --color-status-warning-800:   #92400E;
 
   --color-status-success-100:   #D1FAE5;
+  --color-status-success-500:   #10B981;
   --color-status-success-800:   #065F46;
 
   --color-status-attention-100: #FED7AA;
+  --color-status-attention-500: #F97316;
   --color-status-attention-800: #9A3412;
 
   --color-status-error-100:     #FEE2E2;
+  --color-status-error-500:     #EF4444;
   --color-status-error-800:     #991B1B;
 
   --color-status-muted-100:     #F3F4F6;
+  --color-status-muted-500:     #6B7280;
   --color-status-muted-800:     #374151;
 
   /* === Typography === */


### PR DESCRIPTION
## Summary
Final-pass polish that finishes the work in #157. The colorize PR migrated Dashboard / Edit / Builder to semantic status tokens but missed three sister surfaces (CalendarView dots, CalendarView legend, DayDetail status pills) that maintain their own STATUS_COLORS maps. A status now looks the same wherever it appears in the editor's workflow.

**Changes:**

- `index.css` — adds `-500` mid-saturation variants to every status token (`info / edited / warning / success / attention / error / muted`). Needed for small visual elements where `-100` is too pale and `-800` too heavy. Calendar dots are the immediate use case; future vivid-CTA / badge usage gets a clean home.
- `CalendarView.tsx` — `STATUS_DOT_COLORS` map and the legend swatches route through tokens instead of `bg-blue-400 / bg-purple-400 / bg-cyan-400 / etc.` AI-Edited dot moves from `purple-400` → indigo `edited-500`, finishing the no-purple-anywhere sweep.
- `DayDetail.tsx` — `STATUS_COLORS` pills migrate to the same tokens Dashboard's pills already use, so the day panel matches the list rows visually.
- `AppShell.tsx` — canvas moves from `bg-gray-50` (cool, slightly clinical) to `bg-stone-50` (warm-tinted neutral). Small editorial-newsroom warmth without changing perceptible color.

**Out of scope** (deliberately bounded): FlagList per-flag identity colors, DiffViewer's universal red/green diff highlighting, SubmissionMeta tags, BuilderPage / EditPage toast colors. Those belong in #149 (extract shared primitives) where the broader sweep is one coherent unit of work.

## Test plan
- [x] `npm test` — 26/26 pass
- [x] `npm run build` — clean (CSS dropped 36.86 kB → 36.72 kB)
- [x] Calendar dots verified via DOM inspection — all 8 statuses resolve to correct -500 hex (e.g. `bg-status-edited-500` = `#6366F1`)
- [x] AppShell canvas verified as `oklch(0.985 0.001 106.423)` = stone-50 (warm) vs previous gray-50 (cool)
- [x] TDR/MyUI pub-day dots unchanged — those are newsletter brand markers, not status
- [ ] Reviewer eye-test on dev (calendar view + day detail panel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)