### PR TITLE
Polish calendar, builder imports, and trusted auth docs

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,6 +2,13 @@
 
 All endpoints are prefixed with `/api/v1`. Responses use JSON. Errors return standard `{ "detail": "..." }` bodies.
 
+## Authorization
+
+Public requests have no role headers. Staff and SLC access must come from the
+trusted auth boundary: the reverse proxy injects `X-Trusted-User-Role` and
+`X-Trusted-Auth-Secret`, and the backend accepts the role only when the secret
+matches `TRUSTED_ROLE_HEADER_SECRET`. Client-supplied `X-User-Role` is rejected.
+
 ## Health
 
 | Method | Path              | Description          |

--- a/docs/data-governance.md
+++ b/docs/data-governance.md
@@ -71,9 +71,18 @@ External Data Sources ──▶ Backend:
 - Optional image upload (media)
 - Optional submitter notes (free text — may inadvertently contain PII)
 
-**Access control:** Public submitters see only their own submissions. Staff see all submissions.
+**Access control:** Public submitters can create submissions and receive the
+created submission response. Submission list/detail views, images, destructive
+actions, AI edits, newsletter assembly, style rules, schedule configuration, and
+recurring-message management are staff-only. Authorized SLC viewers can read the
+SLC calendar feed with submitter PII redacted.
 
-**Authentication model:** Header-based role assignment (`X-User-Role`). No cryptographic token verification at the application layer — relies on network/proxy controls.
+**Authentication model:** Role assignment comes from a trusted auth boundary.
+The backend rejects client-controlled `X-User-Role` headers. Staff and SLC roles
+must be asserted through `X-Trusted-User-Role` plus a matching
+`X-Trusted-Auth-Secret`, which should be injected by nginx, a campus auth
+gateway, or another server-side reverse proxy after stripping any inbound trusted
+headers from the client.
 
 ### 2. AI Editing Pipeline
 
@@ -212,14 +221,15 @@ extension rationale, and recommended governance artifacts.
 
 | Role | Can Create | Can Read | Can Edit | Can Delete | Can Export |
 |------|-----------|---------|---------|-----------|-----------|
-| Public | Submissions | Public-redacted submission responses | Submissions (limited fields) | Some delete endpoints are not role-gated | Published newsletters |
-| Staff | All submissions, newsletters, recurring messages | All submissions and configuration | All submissions + newsletters + configuration | Destructive endpoints available through API | All newsletters |
+| Public | Submissions | Created submission response and public allowed values | Limited submission fields when the submission ID is known | No staff-gated deletes | No staff-gated exports |
+| SLC | SLC event submissions | Redacted SLC calendar feed | Same limited public submission fields | No staff-gated deletes | No staff-gated exports |
+| Staff | All submissions, newsletters, recurring messages, style rules, and schedule records | All submissions and configuration | All editorial, newsletter, recurring-message, style-rule, and schedule workflows | Staff-gated destructive endpoints | All newsletters |
 
-**Note:** There is no admin role. The current role model is header-based
-(`X-User-Role`) and assumes network/proxy controls around the application.
-Several staff-only workflows are checked in the API, but this is not a
-cryptographically verified authentication model. Until stronger authentication is
-implemented, deployment controls are part of the access-control boundary.
+**Note:** There is no admin role. The current role model is still perimeter
+trusted rather than per-user OAuth/JWT authorization: the application validates a
+shared trusted-header secret, but it does not identify individual users or verify
+campus identity tokens directly. Until stronger authentication is implemented,
+deployment controls remain part of the access-control boundary.
 
 ---
 
@@ -240,7 +250,7 @@ If a data breach involving PII (submitter names/emails) is suspected:
 - [x] Implement EXIF stripping on image upload
 - [ ] Add PII sanitization to Submitter_Notes before LLM submission
 - [ ] Implement data retention cleanup job
-- [ ] Evaluate authentication hardening (JWT/OAuth vs. header-based roles)
+- [ ] Evaluate authentication hardening (JWT/OAuth vs. trusted perimeter roles)
 - [ ] Establish audit logging for data access events
 - [ ] Create submitter-facing privacy notice for the submission form
 - [ ] Add a column-level data dictionary with classifications, PII flags, and retention categories

--- a/docs/udm-alignment.md
+++ b/docs/udm-alignment.md
@@ -224,10 +224,13 @@ Add explicit lifecycle diagrams for:
 
 ### 5. Tighten access-control documentation
 
-Document the current header-based role model and its limits. Several endpoints
-gate staff-only behavior through `X-User-Role`, while some destructive actions
-currently rely on network/proxy controls rather than per-user authentication.
-This should be explicit in governance docs until stronger auth is implemented.
+Keep the trusted-boundary role model and its limits explicit in governance docs.
+The backend now rejects client-controlled `X-User-Role` headers and accepts
+staff/SLC roles only when `X-Trusted-User-Role` is paired with the configured
+`X-Trusted-Auth-Secret`. This is stronger than the earlier prototype header, but
+it is still perimeter-trusted rather than per-user OAuth/JWT authorization.
+Deployment controls, trusted-header stripping, and campus proxy configuration
+remain part of the access-control boundary until stronger auth is implemented.
 
 ## Change Management Policy
 

--- a/frontend/src/components/dashboard/CalendarView.tsx
+++ b/frontend/src/components/dashboard/CalendarView.tsx
@@ -4,14 +4,14 @@ import { getOccurrenceDates } from '../../utils/submissionOccurrences';
 const DAYS_OF_WEEK = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 const STATUS_DOT_COLORS: Record<string, string> = {
-  new: 'bg-blue-400',
-  ai_edited: 'bg-purple-400',
-  in_review: 'bg-yellow-400',
-  approved: 'bg-green-400',
-  scheduled: 'bg-cyan-400',
-  published: 'bg-gray-400',
-  rejected: 'bg-red-400',
-  pending_info: 'bg-orange-400',
+  new: 'bg-status-info-500',
+  ai_edited: 'bg-status-edited-500',
+  in_review: 'bg-status-warning-500',
+  approved: 'bg-status-success-500',
+  scheduled: 'bg-ui-clearwater-500',
+  published: 'bg-status-muted-500',
+  rejected: 'bg-status-error-500',
+  pending_info: 'bg-status-attention-500',
 };
 
 interface CalendarViewProps {
@@ -196,23 +196,23 @@ export default function CalendarView({
         <div className="flex items-center gap-3 text-xs text-gray-500 flex-wrap">
           <span className="text-gray-400 font-medium">Status:</span>
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-blue-400" />
+            <span className="w-2 h-2 rounded-full bg-status-info-500" />
             New
           </span>
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-purple-400" />
+            <span className="w-2 h-2 rounded-full bg-status-edited-500" />
             AI Edited
           </span>
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-yellow-400" />
+            <span className="w-2 h-2 rounded-full bg-status-warning-500" />
             In Review
           </span>
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-green-400" />
+            <span className="w-2 h-2 rounded-full bg-status-success-500" />
             Approved
           </span>
           <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-cyan-400" />
+            <span className="w-2 h-2 rounded-full bg-ui-clearwater-500" />
             Scheduled
           </span>
         </div>

--- a/frontend/src/components/dashboard/DayDetail.tsx
+++ b/frontend/src/components/dashboard/DayDetail.tsx
@@ -5,14 +5,14 @@ import { getOccurrenceDates } from '../../utils/submissionOccurrences';
 import { rescheduleScheduleOccurrence } from '../../api/submissions';
 
 const STATUS_COLORS: Record<string, string> = {
-  new: 'bg-blue-100 text-blue-800',
-  ai_edited: 'bg-purple-100 text-purple-800',
-  in_review: 'bg-yellow-100 text-yellow-800',
-  approved: 'bg-green-100 text-green-800',
+  new: 'bg-status-info-100 text-status-info-800',
+  ai_edited: 'bg-status-edited-100 text-status-edited-800',
+  in_review: 'bg-status-warning-100 text-status-warning-800',
+  approved: 'bg-status-success-100 text-status-success-800',
   scheduled: 'bg-ui-clearwater-100 text-ui-clearwater-800',
-  published: 'bg-gray-100 text-gray-800',
-  rejected: 'bg-red-100 text-red-800',
-  pending_info: 'bg-orange-100 text-orange-800',
+  published: 'bg-status-muted-100 text-status-muted-800',
+  rejected: 'bg-status-error-100 text-status-error-800',
+  pending_info: 'bg-status-attention-100 text-status-attention-800',
 };
 
 const STATUS_LABELS: Record<string, string> = {

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -3,7 +3,7 @@ import Sidebar from './Sidebar';
 
 export default function AppShell() {
   return (
-    <div className="flex min-h-screen bg-gray-50">
+    <div className="flex min-h-screen bg-stone-50">
       <Sidebar />
       <main className="flex-1 p-8 overflow-auto">
         <Outlet />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -37,25 +37,36 @@
      raw Tailwind hue in JSX. The -100 variant is the soft background;
      the -800 variant is the strong foreground for text on it. */
 
+  /* -100: soft background under colored text. -500: mid-saturation,
+     for small visual elements (calendar dots, badges, vivid CTAs).
+     -800: strong foreground for accessible text on -100. */
+
   --color-status-info-100:      #DBEAFE;
+  --color-status-info-500:      #3B82F6;
   --color-status-info-800:      #1E40AF;
 
   --color-status-edited-100:    #E0E7FF;
+  --color-status-edited-500:    #6366F1;
   --color-status-edited-800:    #3730A3;
 
   --color-status-warning-100:   #FEF3C7;
+  --color-status-warning-500:   #F59E0B;
   --color-status-warning-800:   #92400E;
 
   --color-status-success-100:   #D1FAE5;
+  --color-status-success-500:   #10B981;
   --color-status-success-800:   #065F46;
 
   --color-status-attention-100: #FED7AA;
+  --color-status-attention-500: #F97316;
   --color-status-attention-800: #9A3412;
 
   --color-status-error-100:     #FEE2E2;
+  --color-status-error-500:     #EF4444;
   --color-status-error-800:     #991B1B;
 
   --color-status-muted-100:     #F3F4F6;
+  --color-status-muted-500:     #6B7280;
   --color-status-muted-800:     #374151;
 
   /* === Typography === */

--- a/frontend/src/pages/BuilderPage.tsx
+++ b/frontend/src/pages/BuilderPage.tsx
@@ -83,6 +83,8 @@ interface CollapsibleCardProps {
   children: ReactNode;
 }
 
+type ImportPanelKey = 'recurringMessages' | 'calendarEvents' | 'jobPostings';
+
 function CollapsibleCard({
   title,
   subtitle,
@@ -119,6 +121,37 @@ function CollapsibleCard({
   );
 }
 
+interface ImportCandidatePillProps {
+  label: string;
+  count: number;
+  loading: boolean;
+  isOpen: boolean;
+  onClick: () => void;
+}
+
+function ImportCandidatePill({
+  label,
+  count,
+  loading,
+  isOpen,
+  onClick,
+}: ImportCandidatePillProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+        isOpen
+          ? 'border-ui-clearwater-300 bg-ui-clearwater-50 text-ui-clearwater-800'
+          : 'border-gray-200 bg-white text-gray-700 hover:border-ui-clearwater-300 hover:text-ui-clearwater-800'
+      }`}
+      aria-pressed={isOpen}
+    >
+      + {loading ? '...' : count} {label}
+    </button>
+  );
+}
+
 export default function BuilderPage() {
   const [newsletterType, setNewsletterType] = useState<'tdr' | 'myui'>('tdr');
   const [publishDate, setPublishDate] = useState(
@@ -137,9 +170,9 @@ export default function BuilderPage() {
   const [jobLoading, setJobLoading] = useState(false);
   const [jobError, setJobError] = useState<string | null>(null);
   const [panelOpen, setPanelOpen] = useState({
-    recurringMessages: true,
-    calendarEvents: true,
-    jobPostings: true,
+    recurringMessages: false,
+    calendarEvents: false,
+    jobPostings: false,
   });
   const [sectionOpen, setSectionOpen] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(false);
@@ -489,7 +522,7 @@ export default function BuilderPage() {
     setTimeout(() => setToast(null), 3000);
   };
 
-  const togglePanel = (panel: 'recurringMessages' | 'calendarEvents' | 'jobPostings') => {
+  const togglePanel = (panel: ImportPanelKey) => {
     setPanelOpen((current) => ({
       ...current,
       [panel]: !current[panel],
@@ -757,104 +790,131 @@ export default function BuilderPage() {
             </div>
           ) : (
             <div className="space-y-4">
-              <CollapsibleCard
-                title="Recurring Messages"
-                subtitle="Reusable editorial copy surfaced from the recurring-message library."
-                meta={`${recurringMessages.length} candidate${recurringMessages.length !== 1 ? 's' : ''}`}
-                isOpen={panelOpen.recurringMessages}
-                onToggle={() => togglePanel('recurringMessages')}
-                actions={(
-                  <button
-                    onClick={() => void loadRecurringMessages(newsletter.Id)}
-                    disabled={recurringLoading}
-                    className="px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50"
-                  >
-                    {recurringLoading ? 'Refreshing...' : 'Refresh Messages'}
-                  </button>
-                )}
-              >
-                {recurringError && (
-                  <div className="mb-3 rounded-md bg-red-50 border border-red-200 px-3 py-2 text-xs text-red-700">
-                    {recurringError}
-                  </div>
-                )}
-                {recurringMessages.length === 0 ? (
-                  <div className="rounded-md border border-dashed border-gray-200 px-4 py-6 text-center text-xs text-gray-400">
-                    {recurringLoading ? 'Loading recurring messages...' : 'No recurring messages apply to this issue date.'}
-                  </div>
-                ) : (
-                  <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
-                    {recurringMessages.map((message) => (
-                      <div
-                        key={message.Id}
-                        className={`rounded-lg border p-3 ${
-                          message.Selected
-                            ? 'border-green-200 bg-green-50'
-                            : message.Skipped
-                              ? 'border-amber-200 bg-amber-50'
-                              : 'border-gray-200 bg-white'
-                        }`}
-                      >
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="min-w-0">
-                            <div className="flex items-center gap-2 flex-wrap">
-                              <p className="text-sm font-medium text-gray-900">{message.Headline}</p>
-                              {message.Selected && (
-                                <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-[11px] font-medium text-green-700">
-                                  Added
-                                </span>
-                              )}
-                              {message.Skipped && (
-                                <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700">
-                                  Skipped
-                                </span>
-                              )}
-                            </div>
-                            <p className="text-xs text-gray-500 mt-1">
-                              {sectionNameById.get(message.Section_Id) ?? 'Unknown section'}
-                            </p>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <button
-                              onClick={() => void handleAddRecurringMessage(message.Id)}
-                              disabled={message.Selected}
-                              className={`px-3 py-1.5 text-xs font-medium rounded-md ${
-                                message.Selected
-                                  ? 'bg-green-100 text-green-700 cursor-default'
-                                  : 'bg-ui-gold-600 text-white hover:bg-ui-gold-700'
-                              }`}
-                            >
-                              {message.Skipped ? 'Restore' : message.Selected ? 'Added' : 'Add'}
-                            </button>
-                            <button
-                              onClick={() => void handleSkipRecurringMessage(message.Id)}
-                              disabled={message.Skipped}
-                              className={`px-3 py-1.5 text-xs font-medium rounded-md border ${
-                                message.Skipped
-                                  ? 'border-amber-200 text-amber-700 bg-amber-100 cursor-default'
-                                  : 'border-gray-300 text-gray-700 hover:bg-gray-50'
-                              }`}
-                            >
-                              Skip
-                            </button>
-                          </div>
-                        </div>
-                        <p className="text-xs text-gray-600 mt-2 line-clamp-3">
-                          {message.Body}
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </CollapsibleCard>
+              <div className="flex flex-wrap items-center gap-2">
+                <ImportCandidatePill
+                  label="recurring"
+                  count={recurringMessages.length}
+                  loading={recurringLoading}
+                  isOpen={panelOpen.recurringMessages}
+                  onClick={() => togglePanel('recurringMessages')}
+                />
+                <ImportCandidatePill
+                  label="events"
+                  count={calendarEvents.length}
+                  loading={calendarLoading}
+                  isOpen={panelOpen.calendarEvents}
+                  onClick={() => togglePanel('calendarEvents')}
+                />
+                <ImportCandidatePill
+                  label="jobs"
+                  count={jobPostings.length}
+                  loading={jobLoading}
+                  isOpen={panelOpen.jobPostings}
+                  onClick={() => togglePanel('jobPostings')}
+                />
+              </div>
 
+              {panelOpen.recurringMessages && (
+                <CollapsibleCard
+                  title="Recurring Messages"
+                  subtitle="Reusable editorial copy surfaced from the recurring-message library."
+                  meta={`${recurringMessages.length} candidate${recurringMessages.length !== 1 ? 's' : ''}`}
+                  isOpen
+                  onToggle={() => togglePanel('recurringMessages')}
+                  actions={(
+                    <button
+                      onClick={() => void loadRecurringMessages(newsletter.Id)}
+                      disabled={recurringLoading}
+                      className="px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                    >
+                      {recurringLoading ? 'Refreshing...' : 'Refresh Messages'}
+                    </button>
+                  )}
+                >
+                  {recurringError && (
+                    <div className="mb-3 rounded-md bg-red-50 border border-red-200 px-3 py-2 text-xs text-red-700">
+                      {recurringError}
+                    </div>
+                  )}
+                  {recurringMessages.length === 0 ? (
+                    <div className="rounded-md border border-dashed border-gray-200 px-4 py-6 text-center text-xs text-gray-400">
+                      {recurringLoading ? 'Loading recurring messages...' : 'No recurring messages apply to this issue date.'}
+                    </div>
+                  ) : (
+                    <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
+                      {recurringMessages.map((message) => (
+                        <div
+                          key={message.Id}
+                          className={`rounded-lg border p-3 ${
+                            message.Selected
+                              ? 'border-green-200 bg-green-50'
+                              : message.Skipped
+                                ? 'border-amber-200 bg-amber-50'
+                                : 'border-gray-200 bg-white'
+                          }`}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <div className="flex items-center gap-2 flex-wrap">
+                                <p className="text-sm font-medium text-gray-900">{message.Headline}</p>
+                                {message.Selected && (
+                                  <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-[11px] font-medium text-green-700">
+                                    Added
+                                  </span>
+                                )}
+                                {message.Skipped && (
+                                  <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                                    Skipped
+                                  </span>
+                                )}
+                              </div>
+                              <p className="text-xs text-gray-500 mt-1">
+                                {sectionNameById.get(message.Section_Id) ?? 'Unknown section'}
+                              </p>
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <button
+                                onClick={() => void handleAddRecurringMessage(message.Id)}
+                                disabled={message.Selected}
+                                className={`px-3 py-1.5 text-xs font-medium rounded-md ${
+                                  message.Selected
+                                    ? 'bg-green-100 text-green-700 cursor-default'
+                                    : 'bg-ui-gold-600 text-white hover:bg-ui-gold-700'
+                                }`}
+                              >
+                                {message.Skipped ? 'Restore' : message.Selected ? 'Added' : 'Add'}
+                              </button>
+                              <button
+                                onClick={() => void handleSkipRecurringMessage(message.Id)}
+                                disabled={message.Skipped}
+                                className={`px-3 py-1.5 text-xs font-medium rounded-md border ${
+                                  message.Skipped
+                                    ? 'border-amber-200 text-amber-700 bg-amber-100 cursor-default'
+                                    : 'border-gray-300 text-gray-700 hover:bg-gray-50'
+                                }`}
+                              >
+                                Skip
+                              </button>
+                            </div>
+                          </div>
+                          <p className="text-xs text-gray-600 mt-2 line-clamp-3">
+                            {message.Body}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </CollapsibleCard>
+              )}
+
+              {panelOpen.calendarEvents && (
               <CollapsibleCard
                 title="Import Calendar Events"
                 subtitle={`Pull upcoming events from the U of I events calendar into the ${
                   newsletterType === 'tdr' ? "Today's Events" : 'Weekly Events'
                 } section. These are external calendar events, not submitted announcements.`}
                 meta={`${calendarEvents.length} candidate${calendarEvents.length !== 1 ? 's' : ''}`}
-                isOpen={panelOpen.calendarEvents}
+                isOpen
                 onToggle={() => togglePanel('calendarEvents')}
                 actions={(
                   <button
@@ -932,14 +992,16 @@ export default function BuilderPage() {
                   </div>
                 )}
               </CollapsibleCard>
+              )}
 
+              {panelOpen.jobPostings && (
               <CollapsibleCard
                 title="Job Postings"
                 subtitle={`Import U of I job postings into the ${
                   newsletterType === 'tdr' ? 'Job Opportunities' : 'Help Wanted'
                 } section.`}
                 meta={`${jobPostings.length} candidate${jobPostings.length !== 1 ? 's' : ''}`}
-                isOpen={panelOpen.jobPostings}
+                isOpen
                 onToggle={() => togglePanel('jobPostings')}
                 actions={(
                   <button
@@ -1013,6 +1075,7 @@ export default function BuilderPage() {
                   </div>
                 )}
               </CollapsibleCard>
+              )}
 
               {/* Newsletter header */}
               <div className="bg-white rounded-lg shadow p-4 flex items-center justify-between">

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -12,6 +12,7 @@ import {
   deleteCustomDate,
 } from '../api/schedule';
 import type { BlackoutDate, ScheduleModeOverride, CustomPublishDate } from '../types/schedule';
+import { formatScheduleFrequency } from '../utils/scheduleFrequency';
 
 interface ScheduleConfig {
   Id: string;
@@ -47,7 +48,6 @@ interface AISettings {
   providers: Record<string, ProviderInfo>;
 }
 
-const DAY_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 const MONTH_NAMES = [
   '', 'January', 'February', 'March', 'April', 'May', 'June',
   'July', 'August', 'September', 'October', 'November', 'December',
@@ -683,13 +683,7 @@ export default function SettingsPage() {
                     {MODE_LABELS[config.Mode] ?? config.Mode}
                   </td>
                   <td className="py-2 text-gray-700">
-                    {config.Is_Daily
-                      ? 'Daily (weekdays)'
-                      : config.Publish_Day_Of_Week !== null
-                        ? `Weekly (${DAY_NAMES[config.Publish_Day_Of_Week]})`
-                        : config.Mode === 'winter_break'
-                          ? 'Custom dates'
-                          : 'Not published'}
+                    {formatScheduleFrequency(config)}
                   </td>
                   <td className="py-2 text-gray-700 text-xs">
                     {config.Submission_Deadline_Description}

--- a/frontend/src/utils/scheduleFrequency.test.ts
+++ b/frontend/src/utils/scheduleFrequency.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { formatScheduleFrequency } from './scheduleFrequency';
+
+describe('formatScheduleFrequency', () => {
+  it('uses backend Python weekday numbers for weekly schedules', () => {
+    expect(formatScheduleFrequency({
+      Is_Daily: false,
+      Publish_Day_Of_Week: 0,
+      Mode: 'academic_year',
+    })).toBe('Weekly (Monday)');
+    expect(formatScheduleFrequency({
+      Is_Daily: false,
+      Publish_Day_Of_Week: 6,
+      Mode: 'academic_year',
+    })).toBe('Weekly (Sunday)');
+  });
+
+  it('formats daily and custom-date schedules', () => {
+    expect(formatScheduleFrequency({
+      Is_Daily: true,
+      Publish_Day_Of_Week: null,
+      Mode: 'academic_year',
+    })).toBe('Daily (weekdays)');
+    expect(formatScheduleFrequency({
+      Is_Daily: false,
+      Publish_Day_Of_Week: null,
+      Mode: 'winter_break',
+    })).toBe('Custom dates');
+  });
+});

--- a/frontend/src/utils/scheduleFrequency.ts
+++ b/frontend/src/utils/scheduleFrequency.ts
@@ -1,0 +1,17 @@
+interface ScheduleFrequencyConfig {
+  Is_Daily: boolean;
+  Publish_Day_Of_Week: number | null;
+  Mode: string;
+}
+
+const PYTHON_WEEKDAY_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+export function formatScheduleFrequency(config: ScheduleFrequencyConfig): string {
+  if (config.Is_Daily) return 'Daily (weekdays)';
+  if (config.Publish_Day_Of_Week !== null) {
+    // Backend schedule configs use Python's date.weekday() convention: Monday=0 ... Sunday=6.
+    return `Weekly (${PYTHON_WEEKDAY_NAMES[config.Publish_Day_Of_Week] ?? 'unknown day'})`;
+  }
+  if (config.Mode === 'winter_break') return 'Custom dates';
+  return 'Not published';
+}


### PR DESCRIPTION
## Summary
- extend calendar/status-token polish already on this branch
- make Settings weekly schedule labels use an explicit backend weekday formatter with regression coverage
- collapse builder import panels by default and surface recurring/event/job counts as inline pills
- update API/governance docs for the trusted-header auth boundary

## Issues
Closes #149
Closes #151
Closes #153

## Verification
- cd frontend && npm test
- cd frontend && npm run build
- cd frontend && npm run lint
- cd backend && ./.venv/bin/pytest