### PR TITLE
Add in-app product feedback queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,9 @@ TRUSTED_ROLE_HEADER_SECRET=
 # Leave blank for public-only behavior; set to "staff" to expose editor tools.
 TRUSTED_ROLE_HEADER_ROLE=
 
+# Frontend build context
+VITE_APP_ENV=development
+
 # University calendar source
 CALENDAR_SOURCE_URL=https://www.qatrumba.com/events-calendar/ui/uidaho/vandals/vandal/event/events/calendar/moscow/idaho/id/university-of-idaho
 CALENDAR_REQUEST_TIMEOUT_SECONDS=10.0

--- a/backend/alembic/versions/7d3e5f9a1b2c_add_product_feedback.py
+++ b/backend/alembic/versions/7d3e5f9a1b2c_add_product_feedback.py
@@ -1,0 +1,52 @@
+"""add_product_feedback
+
+Revision ID: 7d3e5f9a1b2c
+Revises: 2b6a9d4c1e8f
+Create Date: 2026-05-01 11:05:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "7d3e5f9a1b2c"
+down_revision: Union[str, Sequence[str], None] = "2b6a9d4c1e8f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "product_feedback",
+        sa.Column("Id", sa.String(length=36), nullable=False),
+        sa.Column("Feedback_Type", sa.String(length=20), nullable=False),
+        sa.Column("Summary", sa.String(length=240), nullable=False),
+        sa.Column("Details", sa.Text(), nullable=False),
+        sa.Column("Contact_Email", sa.String(length=320), nullable=True),
+        sa.Column("Submitter_Role", sa.String(length=20), nullable=False),
+        sa.Column("Route", sa.String(length=500), nullable=False),
+        sa.Column("App_Environment", sa.String(length=100), nullable=False),
+        sa.Column("Host", sa.String(length=255), nullable=False),
+        sa.Column("Browser", sa.Text(), nullable=False),
+        sa.Column("Viewport", sa.String(length=50), nullable=False),
+        sa.Column("Status", sa.String(length=30), nullable=False),
+        sa.Column("GitHub_URL", sa.String(length=500), nullable=True),
+        sa.Column("Created_At", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("Updated_At", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("Id"),
+    )
+    op.create_index("ix_product_feedback_Created_At", "product_feedback", ["Created_At"])
+    op.create_index("ix_product_feedback_Feedback_Type", "product_feedback", ["Feedback_Type"])
+    op.create_index("ix_product_feedback_Status", "product_feedback", ["Status"])
+    op.create_index("ix_product_feedback_Submitter_Role", "product_feedback", ["Submitter_Role"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_product_feedback_Submitter_Role", table_name="product_feedback")
+    op.drop_index("ix_product_feedback_Status", table_name="product_feedback")
+    op.drop_index("ix_product_feedback_Feedback_Type", table_name="product_feedback")
+    op.drop_index("ix_product_feedback_Created_At", table_name="product_feedback")
+    op.drop_table("product_feedback")

--- a/backend/app/api/v1/feedback.py
+++ b/backend/app/api/v1/feedback.py
@@ -1,0 +1,71 @@
+"""In-app product feedback API endpoints."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_db, require_staff
+from app.schemas.feedback import (
+    ProductFeedbackCreate,
+    ProductFeedbackExportResponse,
+    ProductFeedbackResponse,
+    ProductFeedbackUpdate,
+)
+from app.services import feedback_service
+
+router = APIRouter(prefix="/feedback", tags=["feedback"])
+
+
+@router.post("", response_model=ProductFeedbackResponse, status_code=201)
+async def create_feedback(
+    data: ProductFeedbackCreate,
+    db: AsyncSession = Depends(get_db),
+):
+    """Capture a user-submitted bug report or product idea."""
+    return await feedback_service.create_feedback(db, data)
+
+
+@router.get("", response_model=list[ProductFeedbackResponse])
+async def list_feedback(
+    status: str | None = None,
+    feedback_type: str | None = None,
+    db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
+):
+    """List product feedback for staff review."""
+    return await feedback_service.list_feedback(
+        db,
+        status=status,
+        feedback_type=feedback_type,
+    )
+
+
+@router.patch("/{feedback_id}", response_model=ProductFeedbackResponse)
+async def update_feedback(
+    feedback_id: str,
+    data: ProductFeedbackUpdate,
+    db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
+):
+    """Update staff review metadata for a feedback item."""
+    feedback = await feedback_service.update_feedback(
+        db,
+        feedback_id,
+        **data.model_dump(exclude_unset=True),
+    )
+    if not feedback:
+        raise HTTPException(status_code=404, detail="Feedback item not found")
+    return feedback
+
+
+@router.get("/{feedback_id}/github-export", response_model=ProductFeedbackExportResponse)
+async def export_feedback_to_github_markdown(
+    feedback_id: str,
+    db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
+):
+    """Return a GitHub-ready title and Markdown body for staff export."""
+    feedback = await feedback_service.get_feedback(db, feedback_id)
+    if not feedback:
+        raise HTTPException(status_code=404, detail="Feedback item not found")
+    title, body = feedback_service.build_github_export(feedback)
+    return ProductFeedbackExportResponse(Title=title, Body=body)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -10,6 +10,7 @@ from app.api.v1.sections import router as sections_router
 from app.api.v1.schedule import router as schedule_router
 from app.api.v1.allowed_values import router as allowed_values_router
 from app.api.v1.settings import router as settings_router
+from app.api.v1.feedback import router as feedback_router
 
 router = APIRouter(prefix="/api/v1")
 
@@ -23,3 +24,4 @@ router.include_router(sections_router)
 router.include_router(schedule_router)
 router.include_router(allowed_values_router)
 router.include_router(settings_router)
+router.include_router(feedback_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -21,6 +21,7 @@ Models included:
     NewsletterExternalItem   -- Imported external item placed within a newsletter
     RecurringMessage         -- Centrally managed recurring editorial content
     RecurringMessageIssueOverride -- Issue-level skip/override markers
+    ProductFeedback        -- In-app bug reports and feature ideas
     NewsletterSection        -- Section catalog (Announcements, Kudos, etc.)
     StyleRule                -- Writing-style rules for the AI pipeline
     ScheduleConfig           -- Publication cadence and deadline rules
@@ -32,6 +33,7 @@ from app.models.blackout_date import BlackoutDate
 from app.models.custom_publish_date import CustomPublishDate
 from app.models.edit_history import EditVersion
 from app.models.newsletter import Newsletter, NewsletterExternalItem, NewsletterItem
+from app.models.feedback import ProductFeedback
 from app.models.recurring_message import RecurringMessage, RecurringMessageIssueOverride
 from app.models.schedule_config import ScheduleConfig
 from app.models.schedule_mode_override import ScheduleModeOverride
@@ -47,6 +49,7 @@ __all__ = [
     "Newsletter",
     "NewsletterExternalItem",
     "NewsletterItem",
+    "ProductFeedback",
     "RecurringMessage",
     "RecurringMessageIssueOverride",
     "NewsletterSection",

--- a/backend/app/models/feedback.py
+++ b/backend/app/models/feedback.py
@@ -1,0 +1,49 @@
+"""Product feedback captured from users inside the application.
+
+Feedback records are operational support data for the UCM Daily Register
+product itself. They let submitters, editors, and SLC users report bugs or
+suggest improvements without needing a GitHub account or knowing where the
+project tracker lives.
+
+The model deliberately stores only lightweight diagnostic context about the
+app surface where the report was filed. It does not collect submission body
+text, submitter PII from newsletter records, editorial notes, or other content
+payloads automatically. Staff can review these records and later attach a
+GitHub issue URL once an item has been exported to the engineering tracker.
+"""
+
+import uuid
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class ProductFeedback(Base):
+    """A bug report or feature idea submitted from the app UI."""
+
+    __tablename__ = "product_feedback"
+
+    Id: Mapped[str] = mapped_column(
+        sa.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    Feedback_Type: Mapped[str] = mapped_column(sa.String(20), nullable=False, index=True)
+    Summary: Mapped[str] = mapped_column(sa.String(240), nullable=False)
+    Details: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    Contact_Email: Mapped[str | None] = mapped_column(sa.String(320), nullable=True)
+    Submitter_Role: Mapped[str] = mapped_column(sa.String(20), nullable=False, index=True)
+    Route: Mapped[str] = mapped_column(sa.String(500), nullable=False)
+    App_Environment: Mapped[str] = mapped_column(sa.String(100), nullable=False)
+    Host: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    Browser: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    Viewport: Mapped[str] = mapped_column(sa.String(50), nullable=False)
+    Status: Mapped[str] = mapped_column(sa.String(30), nullable=False, default="new", index=True)
+    GitHub_URL: Mapped[str | None] = mapped_column(sa.String(500), nullable=True)
+    Created_At: Mapped[datetime] = mapped_column(
+        sa.DateTime, nullable=False, server_default=sa.func.now(), index=True
+    )
+    Updated_At: Mapped[datetime] = mapped_column(
+        sa.DateTime, nullable=False, server_default=sa.func.now(), onupdate=sa.func.now()
+    )

--- a/backend/app/schemas/feedback.py
+++ b/backend/app/schemas/feedback.py
@@ -1,0 +1,73 @@
+"""Pydantic schemas for in-app product feedback."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+
+FEEDBACK_TYPE_PATTERN = r"^(bug|idea)$"
+FEEDBACK_STATUS_PATTERN = r"^(new|reviewed|exported|closed)$"
+ROLE_PATTERN = r"^(public|staff|slc)$"
+
+
+class ProductFeedbackCreate(BaseModel):
+    Feedback_Type: str = Field(..., pattern=FEEDBACK_TYPE_PATTERN)
+    Summary: str = Field(..., min_length=3, max_length=240)
+    Details: str = Field(..., min_length=5, max_length=5000)
+    Contact_Email: str | None = Field(None, max_length=320)
+    Submitter_Role: str = Field(..., pattern=ROLE_PATTERN)
+    Route: str = Field(..., min_length=1, max_length=500)
+    App_Environment: str = Field("unknown", max_length=100)
+    Host: str = Field("unknown", max_length=255)
+    Browser: str = Field("unknown", max_length=1000)
+    Viewport: str = Field("unknown", max_length=50)
+
+    @field_validator("Contact_Email")
+    @classmethod
+    def normalize_contact_email(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        if "@" not in cleaned or " " in cleaned:
+            raise ValueError("Contact_Email must be a valid email address")
+        return cleaned
+
+
+class ProductFeedbackUpdate(BaseModel):
+    Status: str | None = Field(None, pattern=FEEDBACK_STATUS_PATTERN)
+    GitHub_URL: str | None = Field(None, max_length=500)
+
+    @field_validator("GitHub_URL")
+    @classmethod
+    def normalize_github_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        return cleaned or None
+
+
+class ProductFeedbackResponse(BaseModel):
+    Id: str
+    Feedback_Type: str
+    Summary: str
+    Details: str
+    Contact_Email: str | None
+    Submitter_Role: str
+    Route: str
+    App_Environment: str
+    Host: str
+    Browser: str
+    Viewport: str
+    Status: str
+    GitHub_URL: str | None
+    Created_At: datetime
+    Updated_At: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ProductFeedbackExportResponse(BaseModel):
+    Title: str
+    Body: str

--- a/backend/app/services/feedback_service.py
+++ b/backend/app/services/feedback_service.py
@@ -1,0 +1,88 @@
+"""Business logic for in-app product feedback."""
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.feedback import ProductFeedback
+from app.schemas.feedback import ProductFeedbackCreate
+
+
+async def create_feedback(
+    db: AsyncSession,
+    data: ProductFeedbackCreate,
+) -> ProductFeedback:
+    feedback = ProductFeedback(**data.model_dump())
+    db.add(feedback)
+    await db.commit()
+    await db.refresh(feedback)
+    return feedback
+
+
+async def list_feedback(
+    db: AsyncSession,
+    *,
+    status: str | None = None,
+    feedback_type: str | None = None,
+) -> list[ProductFeedback]:
+    query = sa.select(ProductFeedback).order_by(ProductFeedback.Created_At.desc())
+    if status:
+        query = query.where(ProductFeedback.Status == status)
+    if feedback_type:
+        query = query.where(ProductFeedback.Feedback_Type == feedback_type)
+    result = await db.execute(query)
+    return list(result.scalars().all())
+
+
+async def get_feedback(
+    db: AsyncSession,
+    feedback_id: str,
+) -> ProductFeedback | None:
+    result = await db.execute(
+        sa.select(ProductFeedback).where(ProductFeedback.Id == feedback_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def update_feedback(
+    db: AsyncSession,
+    feedback_id: str,
+    **kwargs,
+) -> ProductFeedback | None:
+    feedback = await get_feedback(db, feedback_id)
+    if not feedback:
+        return None
+
+    for key, value in kwargs.items():
+        if value is not None or key == "GitHub_URL":
+            setattr(feedback, key, value)
+
+    await db.commit()
+    await db.refresh(feedback)
+    return feedback
+
+
+def build_github_export(feedback: ProductFeedback) -> tuple[str, str]:
+    title_prefix = "Bug" if feedback.Feedback_Type == "bug" else "Idea"
+    title = f"{title_prefix}: {feedback.Summary}"
+    body = "\n".join(
+        [
+            "## User Report",
+            "",
+            feedback.Details,
+            "",
+            "## Reporter Context",
+            "",
+            f"- Submitted: {feedback.Created_At.isoformat()}",
+            f"- Type: {feedback.Feedback_Type}",
+            f"- Mode: {feedback.Submitter_Role}",
+            f"- Route: {feedback.Route}",
+            f"- Environment: {feedback.App_Environment}",
+            f"- Host: {feedback.Host}",
+            f"- Viewport: {feedback.Viewport}",
+            f"- Browser: {feedback.Browser}",
+            f"- Contact email provided: {'yes' if feedback.Contact_Email else 'no'}",
+            "",
+            "_Imported from UCM Daily Register in-app feedback. Sensitive submission body text, submitter contact details from newsletter records, and editorial notes were not collected automatically._",
+        ]
+    )
+    return title, body

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -1,0 +1,89 @@
+"""Tests for in-app product feedback capture and staff review."""
+
+import pytest
+from httpx import AsyncClient
+
+
+def make_feedback_payload(**overrides) -> dict:
+    payload = {
+        "Feedback_Type": "bug",
+        "Summary": "The dashboard filter is confusing",
+        "Details": "I expected the status filter to keep my selection after refresh.",
+        "Contact_Email": "editor@uidaho.edu",
+        "Submitter_Role": "staff",
+        "Route": "/dashboard",
+        "App_Environment": "test",
+        "Host": "localhost:5173",
+        "Browser": "pytest",
+        "Viewport": "1280x720",
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.asyncio
+class TestProductFeedback:
+    async def test_public_user_can_create_feedback(
+        self,
+        client: AsyncClient,
+    ):
+        resp = await client.post("/api/v1/feedback", json=make_feedback_payload())
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["Feedback_Type"] == "bug"
+        assert data["Summary"] == "The dashboard filter is confusing"
+        assert data["Status"] == "new"
+        assert data["GitHub_URL"] is None
+
+    async def test_public_user_cannot_list_feedback(
+        self,
+        client: AsyncClient,
+    ):
+        resp = await client.get("/api/v1/feedback")
+
+        assert resp.status_code == 403
+
+    async def test_staff_can_list_update_and_export_feedback(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+    ):
+        create_resp = await client.post(
+            "/api/v1/feedback",
+            json=make_feedback_payload(
+                Feedback_Type="idea",
+                Summary="Add saved dashboard views",
+                Details="It would help to save a filter set for morning triage.",
+                Contact_Email="",
+            ),
+        )
+        assert create_resp.status_code == 201
+        feedback_id = create_resp.json()["Id"]
+
+        list_resp = await client.get("/api/v1/feedback", headers=staff_headers)
+        assert list_resp.status_code == 200
+        assert len(list_resp.json()) == 1
+
+        export_resp = await client.get(
+            f"/api/v1/feedback/{feedback_id}/github-export",
+            headers=staff_headers,
+        )
+        assert export_resp.status_code == 200
+        export_data = export_resp.json()
+        assert export_data["Title"] == "Idea: Add saved dashboard views"
+        assert "## User Report" in export_data["Body"]
+        assert "Contact email provided: no" in export_data["Body"]
+        assert "Sensitive submission body text" in export_data["Body"]
+
+        update_resp = await client.patch(
+            f"/api/v1/feedback/{feedback_id}",
+            json={
+                "Status": "exported",
+                "GitHub_URL": "https://github.com/ui-insight/UCMDailyRegister/issues/999",
+            },
+            headers=staff_headers,
+        )
+        assert update_resp.status_code == 200
+        assert update_resp.json()["Status"] == "exported"
+        assert update_resp.json()["GitHub_URL"].endswith("/999")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,10 @@ services:
       start_period: 30s
 
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        VITE_APP_ENV: ${VITE_APP_ENV:-production}
     environment:
       TRUSTED_ROLE_HEADER_ROLE: ${TRUSTED_ROLE_HEADER_ROLE:-}
       TRUSTED_ROLE_HEADER_SECRET: ${TRUSTED_ROLE_HEADER_SECRET:-}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -50,6 +50,11 @@ npm run dev
 
 The Vite dev server starts on port **5173** and proxies `/api` requests to the backend at port **8001**.
 
+Optional frontend-only Vite settings, such as `VITE_APP_ENV`, can be placed in
+`frontend/.env.local` for local `npm run dev` sessions. Docker deployments read
+the same values from the project-level environment file and pass them into the
+frontend build.
+
 ### Environment Variables
 
 Create a `.env` file in the project root (for Docker) or `backend/` directory (for local dev):
@@ -241,6 +246,9 @@ ENVIRONMENT=production
 CORS_ORIGINS=https://ucmnews.insight.uidaho.edu
 # For deployed dev:
 # CORS_ORIGINS=https://ucmnews-dev.insight.uidaho.edu
+
+# Frontend build context
+VITE_APP_ENV=production
 
 # Trusted auth boundary
 TRUSTED_ROLE_HEADER_SECRET=

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,9 @@ FROM node:22-alpine AS build
 
 WORKDIR /app
 
+ARG VITE_APP_ENV=production
+ENV VITE_APP_ENV=$VITE_APP_ENV
+
 COPY package.json package-lock.json* ./
 RUN npm ci
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import LandingPage from './pages/LandingPage';
 import SLCCalendarPage from './pages/SLCCalendarPage';
 import SLCEventSubmitPage from './pages/SLCEventSubmitPage';
 import DataGovernancePage from './pages/DataGovernancePage';
+import FeedbackPage from './pages/FeedbackPage';
 
 export default function App() {
   return (
@@ -27,6 +28,7 @@ export default function App() {
           <Route path="/slc-calendar" element={<SLCCalendarPage />} />
           <Route path="/submit-slc-event" element={<SLCEventSubmitPage />} />
           <Route path="/style-rules" element={<StyleRulesPage />} />
+          <Route path="/feedback" element={<FeedbackPage />} />
           <Route path="/data-governance" element={<DataGovernancePage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Route>

--- a/frontend/src/api/feedback.ts
+++ b/frontend/src/api/feedback.ts
@@ -1,0 +1,44 @@
+import { apiFetch } from './client';
+import type {
+  FeedbackStatus,
+  FeedbackType,
+  ProductFeedback,
+  ProductFeedbackCreate,
+  ProductFeedbackExport,
+} from '../types/feedback';
+
+export async function createFeedback(
+  data: ProductFeedbackCreate,
+): Promise<ProductFeedback> {
+  return apiFetch<ProductFeedback>('/feedback', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function listFeedback(params?: {
+  status?: FeedbackStatus | '';
+  feedback_type?: FeedbackType | '';
+}): Promise<ProductFeedback[]> {
+  const searchParams = new URLSearchParams();
+  if (params?.status) searchParams.set('status', params.status);
+  if (params?.feedback_type) searchParams.set('feedback_type', params.feedback_type);
+  const query = searchParams.toString();
+  return apiFetch<ProductFeedback[]>(`/feedback${query ? `?${query}` : ''}`);
+}
+
+export async function updateFeedback(
+  id: string,
+  data: Partial<Pick<ProductFeedback, 'Status' | 'GitHub_URL'>>,
+): Promise<ProductFeedback> {
+  return apiFetch<ProductFeedback>(`/feedback/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function getFeedbackGitHubExport(
+  id: string,
+): Promise<ProductFeedbackExport> {
+  return apiFetch<ProductFeedbackExport>(`/feedback/${id}/github-export`);
+}

--- a/frontend/src/components/layout/FeedbackDialog.tsx
+++ b/frontend/src/components/layout/FeedbackDialog.tsx
@@ -1,0 +1,170 @@
+import { useState } from 'react';
+import { createFeedback } from '../../api/feedback';
+import type { FeedbackType } from '../../types/feedback';
+import { Button } from '../common';
+import type { FeedbackContext } from '../../utils/feedback';
+
+const TYPE_OPTIONS: Array<{ value: FeedbackType; label: string }> = [
+  { value: 'bug', label: 'Bug' },
+  { value: 'idea', label: 'Feature idea' },
+];
+
+interface FeedbackDialogProps {
+  open: boolean;
+  context: FeedbackContext;
+  onClose: () => void;
+  onSubmitted?: () => void;
+}
+
+export default function FeedbackDialog({
+  open,
+  context,
+  onClose,
+  onSubmitted,
+}: FeedbackDialogProps) {
+  const [feedbackType, setFeedbackType] = useState<FeedbackType>('bug');
+  const [summary, setSummary] = useState('');
+  const [details, setDetails] = useState('');
+  const [contactEmail, setContactEmail] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const resetAndClose = () => {
+    setError(null);
+    setSubmitting(false);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!summary.trim() || !details.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await createFeedback({
+        Feedback_Type: feedbackType,
+        Summary: summary.trim(),
+        Details: details.trim(),
+        Contact_Email: contactEmail.trim() || null,
+        ...context,
+      });
+      setFeedbackType('bug');
+      setSummary('');
+      setDetails('');
+      setContactEmail('');
+      onSubmitted?.();
+      resetAndClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to submit feedback');
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-gray-900/40 px-4">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="feedback-dialog-title"
+        className="w-full max-w-lg rounded-lg bg-white p-5 text-gray-900 shadow-xl"
+      >
+        <div className="mb-4">
+          <h2 id="feedback-dialog-title" className="text-base font-semibold text-gray-900">
+            Report a bug or feature idea
+          </h2>
+          <p className="mt-1 text-sm text-gray-600">
+            This goes directly to the UCM Daily Register feedback queue.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1">Type</label>
+            <div className="flex gap-2">
+              {TYPE_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setFeedbackType(option.value)}
+                  className={`rounded-md border px-3 py-1.5 text-sm font-medium ${
+                    feedbackType === option.value
+                      ? 'border-ui-gold-500 bg-ui-gold-50 text-ui-black'
+                      : 'border-gray-200 text-gray-600 hover:border-gray-300'
+                  }`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="feedback-summary" className="block text-xs font-medium text-gray-500 mb-1">
+              Short summary
+            </label>
+            <input
+              id="feedback-summary"
+              value={summary}
+              onChange={(event) => setSummary(event.target.value)}
+              maxLength={240}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400"
+              placeholder="What should we fix or improve?"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="feedback-details" className="block text-xs font-medium text-gray-500 mb-1">
+              Details
+            </label>
+            <textarea
+              id="feedback-details"
+              value={details}
+              onChange={(event) => setDetails(event.target.value)}
+              rows={5}
+              maxLength={5000}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400"
+              placeholder="What were you doing? What happened? What would have helped?"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="feedback-contact-email" className="block text-xs font-medium text-gray-500 mb-1">
+              Contact email <span className="font-normal text-gray-400">(optional)</span>
+            </label>
+            <input
+              id="feedback-contact-email"
+              type="email"
+              value={contactEmail}
+              onChange={(event) => setContactEmail(event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400"
+              placeholder="you@uidaho.edu"
+            />
+          </div>
+
+          <p className="rounded-md bg-gray-50 px-3 py-2 text-xs text-gray-500">
+            We include page route, app mode, environment, browser, and viewport. We do not
+            include submission text, submitter records, or editorial notes automatically.
+          </p>
+
+          {error && (
+            <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>
+          )}
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <Button variant="ghost" onClick={resetAndClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => void handleSubmit()}
+            disabled={submitting || summary.trim().length < 3 || details.trim().length < 5}
+          >
+            {submitting ? 'Submitting...' : 'Submit Feedback'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,9 @@
-import { NavLink } from 'react-router-dom';
+import { useState } from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
+import { getBrowserFeedbackContext } from '../../utils/feedback';
 import { getSubmitterRole } from '../../utils/submitterRole';
+import FeedbackDialog from './FeedbackDialog';
+import { Toast, useToast } from '../common';
 
 type NavItem = {
   to: string;
@@ -16,6 +20,7 @@ const navItems: NavItem[] = [
   { to: '/slc-calendar', label: 'SLC Calendar', icon: '', roles: ['staff', 'slc'] },
   { to: '/submit-slc-event', label: 'Submit SLC Event', icon: '+ ', roles: ['staff', 'slc'] },
   { to: '/style-rules', label: 'Style Rules', icon: '', roles: ['staff'] },
+  { to: '/feedback', label: 'Feedback', icon: '', roles: ['staff'] },
   { to: '/data-governance', label: 'Data Governance', icon: '', roles: ['staff'] },
   { to: '/settings', label: 'Settings', icon: '', roles: ['staff'] },
 ];
@@ -27,11 +32,22 @@ const ROLE_LABEL: Record<'public' | 'staff' | 'slc', string> = {
 };
 
 export default function Sidebar() {
+  const location = useLocation();
   const role = getSubmitterRole();
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const { toast, showToast, dismissToast } = useToast();
   const filteredNavItems = navItems.filter((item) => item.roles.includes(role));
+  const feedbackContext = getBrowserFeedbackContext(role, location.pathname);
 
   return (
     <aside className="w-64 bg-gray-900 text-white min-h-screen flex flex-col">
+      <Toast toast={toast} onDismiss={dismissToast} />
+      <FeedbackDialog
+        open={feedbackOpen}
+        context={feedbackContext}
+        onClose={() => setFeedbackOpen(false)}
+        onSubmitted={() => showToast('Feedback submitted')}
+      />
       <div className="p-6 border-b border-gray-700">
         <img
           src="/ui-logo-gold-white-horizontal.png"
@@ -50,6 +66,20 @@ export default function Sidebar() {
           >
             Switch mode
           </NavLink>
+          <button
+            type="button"
+            onClick={() => setFeedbackOpen(true)}
+            className="mt-2 flex items-center gap-2 rounded-md border border-gray-700 bg-gray-900/70 px-2.5 py-2 text-xs font-medium text-gray-200 transition hover:border-ui-gold-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-ui-gold-400"
+            title="Open the in-app feedback form"
+          >
+            <span
+              aria-hidden="true"
+              className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-ui-gold-500 text-[11px] font-semibold text-ui-black"
+            >
+              ?
+            </span>
+            Report bug or idea
+          </button>
         </div>
       </div>
       <nav className="flex-1 p-4 space-y-1">

--- a/frontend/src/pages/FeedbackPage.tsx
+++ b/frontend/src/pages/FeedbackPage.tsx
@@ -1,0 +1,311 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  getFeedbackGitHubExport,
+  listFeedback,
+  updateFeedback,
+} from '../api/feedback';
+import type { FeedbackStatus, FeedbackType, ProductFeedback } from '../types/feedback';
+import { buildGitHubIssueUrl } from '../utils/feedback';
+import { getSubmitterRole } from '../utils/submitterRole';
+import { Button, Card, EmptyState, Toast, useToast } from '../components/common';
+
+const STATUS_OPTIONS: Array<{ value: FeedbackStatus | ''; label: string }> = [
+  { value: '', label: 'All' },
+  { value: 'new', label: 'New' },
+  { value: 'reviewed', label: 'Reviewed' },
+  { value: 'exported', label: 'Exported' },
+  { value: 'closed', label: 'Closed' },
+];
+
+const TYPE_OPTIONS: Array<{ value: FeedbackType | ''; label: string }> = [
+  { value: '', label: 'All' },
+  { value: 'bug', label: 'Bugs' },
+  { value: 'idea', label: 'Ideas' },
+];
+
+const STATUS_CLASSES: Record<FeedbackStatus, string> = {
+  new: 'bg-status-attention-100 text-status-attention-800',
+  reviewed: 'bg-status-info-100 text-status-info-800',
+  exported: 'bg-status-success-100 text-status-success-800',
+  closed: 'bg-status-muted-100 text-status-muted-800',
+};
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+export default function FeedbackPage() {
+  const isStaff = getSubmitterRole() === 'staff';
+  const [items, setItems] = useState<ProductFeedback[]>([]);
+  const [selected, setSelected] = useState<ProductFeedback | null>(null);
+  const [statusFilter, setStatusFilter] = useState<FeedbackStatus | ''>('new');
+  const [typeFilter, setTypeFilter] = useState<FeedbackType | ''>('');
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const { toast, showToast, dismissToast } = useToast();
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const feedback = await listFeedback({
+        status: statusFilter,
+        feedback_type: typeFilter,
+      });
+      setItems(feedback);
+      setSelected((current) => {
+        if (!current) return feedback[0] ?? null;
+        return feedback.find((item) => item.Id === current.Id) ?? feedback[0] ?? null;
+      });
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : 'Failed to load feedback');
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, typeFilter]);
+
+  useEffect(() => {
+    if (!isStaff) return;
+    void loadData();
+  }, [isStaff, loadData]);
+
+  const handleStatusChange = async (item: ProductFeedback, status: FeedbackStatus) => {
+    try {
+      const updated = await updateFeedback(item.Id, { Status: status });
+      setSelected(updated);
+      showToast('Feedback updated');
+      await loadData();
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to update feedback', 'error');
+    }
+  };
+
+  const handleCopyExport = async (item: ProductFeedback) => {
+    try {
+      const exported = await getFeedbackGitHubExport(item.Id);
+      const url = buildGitHubIssueUrl(exported.Title, exported.Body);
+      await navigator.clipboard.writeText(`${exported.Title}\n\n${exported.Body}`);
+      showToast('GitHub-ready issue text copied');
+      window.open(url, '_blank', 'noreferrer');
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to prepare GitHub export', 'error');
+    }
+  };
+
+  const handleSaveGitHubUrl = async (item: ProductFeedback, url: string) => {
+    try {
+      const updated = await updateFeedback(item.Id, {
+        GitHub_URL: url,
+        Status: url ? 'exported' : item.Status,
+      });
+      setSelected(updated);
+      showToast(url ? 'GitHub URL saved' : 'GitHub URL cleared');
+      await loadData();
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to save GitHub URL', 'error');
+    }
+  };
+
+  if (!isStaff) {
+    return (
+      <Card className="p-8">
+        <h2 className="text-2xl font-bold text-gray-900 mb-3">Feedback</h2>
+        <p className="text-sm text-gray-600">The feedback queue is available to staff editors only.</p>
+      </Card>
+    );
+  }
+
+  return (
+    <div>
+      <Toast toast={toast} onDismiss={dismissToast} />
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">Feedback</h2>
+          <p className="mt-1 text-sm text-gray-500">
+            Review in-app bug reports and feature ideas before exporting them to GitHub.
+          </p>
+        </div>
+        <span className="rounded-md bg-white px-3 py-1.5 text-sm text-gray-500 shadow-sm">
+          {items.length} item{items.length === 1 ? '' : 's'}
+        </span>
+      </div>
+
+      <Card className="mb-6">
+        <div className="flex flex-wrap items-end gap-4">
+          <div>
+            <label className="mb-1 block text-xs text-gray-500">Status</label>
+            <select
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value as FeedbackStatus | '')}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+            >
+              {STATUS_OPTIONS.map((option) => (
+                <option key={option.value || 'all'} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="mb-1 block text-xs text-gray-500">Type</label>
+            <select
+              value={typeFilter}
+              onChange={(event) => setTypeFilter(event.target.value as FeedbackType | '')}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+            >
+              {TYPE_OPTIONS.map((option) => (
+                <option key={option.value || 'all'} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </Card>
+
+      {loadError && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {loadError}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="py-12 text-center text-gray-500">Loading...</div>
+      ) : items.length === 0 ? (
+        <EmptyState
+          title="No feedback matches these filters"
+          description="New bug reports and feature ideas will appear here after users submit them from the app."
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+          <div className="space-y-3">
+            {items.map((item) => (
+              <button
+                key={item.Id}
+                type="button"
+                onClick={() => setSelected(item)}
+                className={`w-full rounded-lg border bg-white p-4 text-left shadow-sm transition hover:border-ui-gold-300 ${
+                  selected?.Id === item.Id ? 'border-ui-gold-400 ring-1 ring-ui-gold-200' : 'border-gray-200'
+                }`}
+              >
+                <div className="mb-2 flex items-center gap-2">
+                  <span className="rounded bg-gray-100 px-1.5 py-0.5 text-[11px] font-medium uppercase text-gray-600">
+                    {item.Feedback_Type}
+                  </span>
+                  <span className={`rounded px-1.5 py-0.5 text-[11px] font-medium ${STATUS_CLASSES[item.Status]}`}>
+                    {item.Status}
+                  </span>
+                  <span className="ml-auto text-xs text-gray-400">{formatDate(item.Created_At)}</span>
+                </div>
+                <h3 className="text-sm font-semibold text-gray-900">{item.Summary}</h3>
+                <p className="mt-1 line-clamp-2 text-xs text-gray-500">{item.Details}</p>
+              </button>
+            ))}
+          </div>
+
+          {selected && (
+            <Card>
+              <div className="mb-4 flex items-start justify-between gap-4">
+                <div>
+                  <div className="mb-2 flex items-center gap-2">
+                    <span className="rounded bg-gray-100 px-1.5 py-0.5 text-[11px] font-medium uppercase text-gray-600">
+                      {selected.Feedback_Type}
+                    </span>
+                    <span className={`rounded px-1.5 py-0.5 text-[11px] font-medium ${STATUS_CLASSES[selected.Status]}`}>
+                      {selected.Status}
+                    </span>
+                  </div>
+                  <h3 className="text-lg font-semibold text-gray-900">{selected.Summary}</h3>
+                </div>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => void handleCopyExport(selected)}
+                >
+                  Export to GitHub
+                </Button>
+              </div>
+
+              <div className="prose prose-sm max-w-none">
+                <p className="whitespace-pre-wrap text-sm text-gray-700">{selected.Details}</p>
+              </div>
+
+              <dl className="mt-5 grid grid-cols-1 gap-3 border-t border-gray-100 pt-4 text-sm md:grid-cols-2">
+                <div>
+                  <dt className="text-xs text-gray-500">Route</dt>
+                  <dd className="font-mono text-xs text-gray-800">{selected.Route}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-gray-500">Mode</dt>
+                  <dd className="text-gray-800">{selected.Submitter_Role}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-gray-500">Environment</dt>
+                  <dd className="text-gray-800">{selected.App_Environment}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-gray-500">Contact</dt>
+                  <dd className="text-gray-800">{selected.Contact_Email ?? 'Not provided'}</dd>
+                </div>
+                <div className="md:col-span-2">
+                  <dt className="text-xs text-gray-500">Browser</dt>
+                  <dd className="break-words font-mono text-xs text-gray-800">{selected.Browser}</dd>
+                </div>
+              </dl>
+
+              <div className="mt-5 border-t border-gray-100 pt-4">
+                <label className="mb-1 block text-xs text-gray-500">Status</label>
+                <select
+                  value={selected.Status}
+                  onChange={(event) => void handleStatusChange(selected, event.target.value as FeedbackStatus)}
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+                >
+                  {STATUS_OPTIONS.filter((option) => option.value).map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="mt-4">
+                <label htmlFor="feedback-github-url" className="mb-1 block text-xs text-gray-500">
+                  GitHub issue URL
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    id="feedback-github-url"
+                    defaultValue={selected.GitHub_URL ?? ''}
+                    key={selected.Id}
+                    placeholder="https://github.com/ui-insight/UCMDailyRegister/issues/..."
+                    className="min-w-0 flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm"
+                    onBlur={(event) => {
+                      if (event.target.value !== (selected.GitHub_URL ?? '')) {
+                        void handleSaveGitHubUrl(selected, event.target.value);
+                      }
+                    }}
+                  />
+                  {selected.GitHub_URL && (
+                    <a
+                      href={selected.GitHub_URL}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                    >
+                      Open
+                    </a>
+                  )}
+                </div>
+              </div>
+            </Card>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,5 +1,9 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { setSubmitterRole, type SubmitterRole } from '../utils/submitterRole';
+import FeedbackDialog from '../components/layout/FeedbackDialog';
+import { Toast, useToast } from '../components/common';
+import { getBrowserFeedbackContext } from '../utils/feedback';
+import { getSubmitterRole, setSubmitterRole, type SubmitterRole } from '../utils/submitterRole';
 
 type RoleOption = {
   role: SubmitterRole;
@@ -34,6 +38,10 @@ const ROLES: RoleOption[] = [
 
 export default function LandingPage() {
   const navigate = useNavigate();
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const { toast, showToast, dismissToast } = useToast();
+  const role = getSubmitterRole();
+  const feedbackContext = getBrowserFeedbackContext(role, '/');
 
   const handleSelect = (role: SubmitterRole, target: string) => {
     setSubmitterRole(role);
@@ -42,6 +50,13 @@ export default function LandingPage() {
 
   return (
     <div className="min-h-screen bg-white">
+      <Toast toast={toast} onDismiss={dismissToast} />
+      <FeedbackDialog
+        open={feedbackOpen}
+        context={feedbackContext}
+        onClose={() => setFeedbackOpen(false)}
+        onSubmitted={() => showToast('Feedback submitted')}
+      />
       <header className="bg-gray-900">
         <div className="mx-auto max-w-3xl px-6 py-4">
           <img
@@ -87,6 +102,21 @@ export default function LandingPage() {
             </li>
           ))}
         </ul>
+
+        <button
+          type="button"
+          onClick={() => setFeedbackOpen(true)}
+          className="mt-8 inline-flex items-center gap-2 rounded-md border border-gray-200 px-3 py-2 text-sm font-medium text-ui-silver transition hover:border-ui-gold-400 hover:text-ui-black focus:outline-none focus-visible:ring-2 focus-visible:ring-ui-clearwater-500"
+          title="Open the in-app feedback form"
+        >
+          <span
+            aria-hidden="true"
+            className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-ui-gold-500 text-[11px] font-semibold text-ui-black"
+          >
+            ?
+          </span>
+          Report bug or idea
+        </button>
       </main>
     </div>
   );

--- a/frontend/src/types/feedback.ts
+++ b/frontend/src/types/feedback.ts
@@ -1,0 +1,38 @@
+export type FeedbackType = 'bug' | 'idea';
+export type FeedbackStatus = 'new' | 'reviewed' | 'exported' | 'closed';
+
+export interface ProductFeedback {
+  Id: string;
+  Feedback_Type: FeedbackType;
+  Summary: string;
+  Details: string;
+  Contact_Email: string | null;
+  Submitter_Role: 'public' | 'staff' | 'slc';
+  Route: string;
+  App_Environment: string;
+  Host: string;
+  Browser: string;
+  Viewport: string;
+  Status: FeedbackStatus;
+  GitHub_URL: string | null;
+  Created_At: string;
+  Updated_At: string;
+}
+
+export interface ProductFeedbackCreate {
+  Feedback_Type: FeedbackType;
+  Summary: string;
+  Details: string;
+  Contact_Email?: string | null;
+  Submitter_Role: 'public' | 'staff' | 'slc';
+  Route: string;
+  App_Environment: string;
+  Host: string;
+  Browser: string;
+  Viewport: string;
+}
+
+export interface ProductFeedbackExport {
+  Title: string;
+  Body: string;
+}

--- a/frontend/src/utils/feedback.test.ts
+++ b/frontend/src/utils/feedback.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { buildGitHubIssueUrl } from './feedback';
+
+describe('feedback helpers', () => {
+  it('builds a GitHub issue URL for staff export only', () => {
+    const href = buildGitHubIssueUrl('Bug: Filter resets', '## User Report\n\nIt reset.');
+    const url = new URL(href);
+
+    expect(url.hostname).toBe('github.com');
+    expect(url.pathname).toBe('/ui-insight/UCMDailyRegister/issues/new');
+    expect(url.searchParams.get('title')).toBe('Bug: Filter resets');
+    expect(url.searchParams.get('body')).toContain('It reset.');
+  });
+});

--- a/frontend/src/utils/feedback.ts
+++ b/frontend/src/utils/feedback.ts
@@ -1,0 +1,44 @@
+import type { SubmitterRole } from './submitterRole';
+
+export interface FeedbackContext {
+  Submitter_Role: SubmitterRole;
+  Route: string;
+  App_Environment: string;
+  Host: string;
+  Browser: string;
+  Viewport: string;
+}
+
+export function getBrowserFeedbackContext(
+  role: SubmitterRole,
+  route: string,
+): FeedbackContext {
+  const appEnvironment = import.meta.env.VITE_APP_ENV || import.meta.env.MODE || 'unknown';
+
+  if (typeof window === 'undefined') {
+    return {
+      Submitter_Role: role,
+      Route: route,
+      App_Environment: appEnvironment,
+      Host: 'unknown',
+      Browser: 'unknown',
+      Viewport: 'unknown',
+    };
+  }
+
+  return {
+    Submitter_Role: role,
+    Route: route,
+    App_Environment: appEnvironment,
+    Host: window.location.host || 'unknown',
+    Browser: window.navigator.userAgent,
+    Viewport: `${window.innerWidth}x${window.innerHeight}`,
+  };
+}
+
+export function buildGitHubIssueUrl(title: string, body: string): string {
+  const url = new URL('https://github.com/ui-insight/UCMDailyRegister/issues/new');
+  url.searchParams.set('title', title);
+  url.searchParams.set('body', body);
+  return url.toString();
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_ENV?: string;
+}


### PR DESCRIPTION
## Summary
- replace the external feedback link with an in-app bug/idea submission dialog
- add a `product_feedback` table, public create endpoint, and staff-only review/update/export endpoints
- add a staff Feedback page for reviewing items and preparing GitHub exports
- wire feedback navigation into the app shell and landing page

## Verification
- `./backend/.venv/bin/pytest`
- `cd backend && .venv/bin/ruff check .`
- `cd frontend && npm test`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `docker compose --env-file .env.example config --quiet`
- deployed to dev and smoke checks passed: https://ucmnews-dev.insight.uidaho.edu

Closes #164