### PR TITLE
Add Enterprise AI Framework evidence manifest

### DIFF
--- a/docs/governance/enterprise-ai-framework/approved-stack-evidence.md
+++ b/docs/governance/enterprise-ai-framework/approved-stack-evidence.md
@@ -1,0 +1,69 @@
+# Approved Stack Evidence Matrix
+
+Validated: 2026-05-05  
+Validator: Codex  
+Source standard: OIT Enterprise AI Development Framework discussion draft,
+April 2026
+
+This matrix maps UCM Daily Register against the approved technology stack in
+the OIT draft. It is evidence-first: each row identifies the current assertion,
+the repo evidence, and the follow-up issue or exception path for anything that
+is not fully aligned.
+
+## Status Legend
+
+| Status | Meaning |
+| --- | --- |
+| `aligned` | UCM Daily Register meets the draft requirement and has repo evidence available |
+| `partially_aligned` | UCM Daily Register meets part of the requirement, but more implementation or evidence is needed |
+| `gap` | UCM Daily Register does not currently meet the requirement |
+| `not_applicable` | The requirement does not currently apply to UCM Daily Register |
+| `needs_decision` | Compliance depends on an OIT, security, or ownership decision |
+
+## Matrix
+
+| OIT layer | Draft standard | Current assertion | Evidence | Follow-up / exception path |
+| --- | --- | --- | --- | --- |
+| Backend API | FastAPI + Uvicorn (Python) | `aligned` | `backend/pyproject.toml` lists `fastapi` and `uvicorn[standard]`; `backend/Dockerfile` runs `uvicorn app.main:app` on port 8001; `docs/architecture.md` documents the FastAPI REST API layer. | None |
+| Frontend | React + Vite + TypeScript | `aligned` | `frontend/package.json` lists React, TypeScript, Vite, and `@vitejs/plugin-react`; `frontend/Dockerfile` runs `npm run build`; `docs/architecture.md` documents the React SPA layer. | None |
+| Database | PostgreSQL + pgvector, pgaudit, pgsodium, containerized per application | `partially_aligned` | `docs/deployment.md` documents PostgreSQL for deployed environments on `insight-db-net`; `docker-compose.yml` requires `DATABASE_URL` and joins `insight-db-net`; `.github/workflows/ci.yml` runs a PostgreSQL 16 smoke job. SQLite remains the local default and no pgvector/pgaudit/pgsodium evidence is present. | PostgreSQL topology and extension review tracked in [#180](https://github.com/ui-insight/UCMDailyRegister/issues/180). |
+| ORM / migrations | SQLAlchemy + Alembic | `aligned` | `backend/pyproject.toml` lists `sqlalchemy[asyncio]` and `alembic`; `backend/alembic/` contains checked-in migrations; `.github/workflows/ci.yml` runs `alembic upgrade head` and `alembic check` in the PostgreSQL smoke job. | None |
+| Python dependency management | uv + pyproject.toml | `partially_aligned` | `backend/pyproject.toml` is the Python manifest; Docker and CI currently use `pip install -e`, not `uv`. | Tooling delta tracked in [#171](https://github.com/ui-insight/UCMDailyRegister/issues/171). |
+| Python lint/format/type checks | Ruff + Pyright | `partially_aligned` | `backend/pyproject.toml` configures Ruff; `.github/workflows/ci.yml` runs `ruff check .`. No Ruff format gate or Pyright configuration is present. | Ruff format and Pyright adoption or exception tracked in [#171](https://github.com/ui-insight/UCMDailyRegister/issues/171). |
+| JS/TS lint/format checks | Biome | `gap` | `frontend/package.json` uses `eslint .`; `.github/workflows/ci.yml` runs `npm run lint -- --max-warnings=0`. No Biome config is present. | Biome migration or exception tracked in [#171](https://github.com/ui-insight/UCMDailyRegister/issues/171). |
+| Python testing | pytest | `aligned` | `backend/pyproject.toml` includes `pytest`, `pytest-asyncio`, and `pytest-cov`; `.github/workflows/ci.yml` runs `pytest`; `backend/tests/` contains async API and service tests. | None |
+| JS/TS testing | Vitest + Testing Library | `aligned` | `frontend/package.json` includes `vitest`, jsdom, and Testing Library packages; the `test` script runs `vitest run`; frontend test files are under `frontend/src/`; the build workflow compiles TypeScript and Vite. | None |
+| CI/CD | Azure Pipelines; GitHub Actions under review | `needs_decision` | `.github/workflows/ci.yml` runs backend, PostgreSQL smoke, frontend lint/build; `.github/workflows/docs.yml` deploys MkDocs to GitHub Pages. No Azure Pipelines evidence is present. | OIT deployment path tracked in [#173](https://github.com/ui-insight/UCMDailyRegister/issues/173); source-control and GitHub Actions approval tracked in [#181](https://github.com/ui-insight/UCMDailyRegister/issues/181). |
+| GitOps deployment | ArgoCD + Kustomize | `gap` | Current deployment evidence is Docker Compose plus `deploy.sh`; no ArgoCD application or Kustomize overlays are present. | GitOps path tracked in [#173](https://github.com/ui-insight/UCMDailyRegister/issues/173). |
+| Source control | ADO; GitHub Enterprise under review | `needs_decision` | The repo is hosted at `ui-insight/UCMDailyRegister`; `docs/contributing.md` documents GitHub branch and PR workflow; `.github/` contains workflows and Dependabot config. | Source-control approval or exception tracked in [#181](https://github.com/ui-insight/UCMDailyRegister/issues/181). |
+| Authentication | Microsoft Entra ID (OAuth2/OIDC) | `gap` | `SECURITY.md`, `docs/deployment.md`, and `backend/app/api/deps.py` document and implement trusted reverse-proxy role headers, not Entra ID/OIDC token validation. | Production Entra ID/OIDC evidence tracked in [#172](https://github.com/ui-insight/UCMDailyRegister/issues/172). |
+| Email integration | Microsoft Graph API | `not_applicable` | No production email-sending integration is documented as an active runtime dependency. The app stores submitter email for editorial contact and exports newsletter copy to `.docx`; it does not send email. | If email sending is added, use Microsoft Graph or record an exception in [#171](https://github.com/ui-insight/UCMDailyRegister/issues/171). |
+| Session storage | PostgreSQL | `partially_aligned` | Staff access currently depends on stateless trusted headers from a perimeter proxy; submission/editorial data is persisted in PostgreSQL for deployed environments. There is no first-party session store or OIDC session implementation. | Resolve with production authentication design in [#172](https://github.com/ui-insight/UCMDailyRegister/issues/172). |
+| Secrets management | 1Password Connect | `partially_aligned` | `.env.example`, `backend/app/config.py`, `docker-compose.yml`, and `SECURITY.md` show runtime environment variable injection and no committed secret values. No 1Password Connect evidence is present. | Runtime vault integration tracked in [#174](https://github.com/ui-insight/UCMDailyRegister/issues/174). |
+| Observability | OpenTelemetry, Prometheus, Jaeger, Splunk | `gap` | `docs/audit-logging.md` defines logging and monitoring expectations; `docker-compose.yml` has backend health checks; `deploy.sh` runs smoke checks. No OTel/Prometheus/Jaeger/Splunk implementation evidence is present. | Observability implementation and evidence tracked in [#175](https://github.com/ui-insight/UCMDailyRegister/issues/175). |
+| AI model gateway | Under evaluation | `needs_decision` | `docs/ai-editing.md` and `backend/app/services/ai/` document provider abstraction for Claude, OpenAI, and MindRouter; production deployment examples prefer MindRouter, but gateway requirements are not formally decided. | Gateway and provider exception decisions tracked in [#178](https://github.com/ui-insight/UCMDailyRegister/issues/178). |
+| Approved AI models | MindRouter operated by U of I; others TBD | `needs_decision` | `backend/app/config.py` defaults MindRouter to `openai/gpt-oss-120b`; `docs/ai-editing.md` documents Claude, OpenAI, and MindRouter options. No approved-model registry mapping exists yet. | Approved-model mapping tracked in [#178](https://github.com/ui-insight/UCMDailyRegister/issues/178). |
+
+## Validation Evidence
+
+Local checks run for this evidence update:
+
+```bash
+python3 -m json.tool docs/governance/enterprise-ai-framework/evidence.json >/dev/null
+python3 -c "import json, pathlib; from jsonschema import Draft202012Validator; schema=json.load(open('docs/governance/enterprise-ai-framework/evidence.schema.json', encoding='utf-8')); data=json.load(open('docs/governance/enterprise-ai-framework/evidence.json', encoding='utf-8')); Draft202012Validator(schema).validate(data); missing=[(r['id'], s['path']) for r in data['requirements'] for s in r['evidence_sources'] if s.get('path') and s['type'] in {'repo_file','repo_directory'} and not pathlib.Path(s['path']).exists()]; assert not missing, missing; print('manifest valid and paths ok')"
+python3 -m mkdocs build --strict
+git diff --check
+```
+
+## Open Follow-Ups
+
+The matrix opens the first evidence trail for [#171](https://github.com/ui-insight/UCMDailyRegister/issues/171), but these rows remain open until implementation, OIT approval, or an explicit exception is recorded:
+
+- [#172](https://github.com/ui-insight/UCMDailyRegister/issues/172): Microsoft Entra ID/OIDC authentication
+- [#173](https://github.com/ui-insight/UCMDailyRegister/issues/173): Azure Pipelines, ArgoCD, and Kustomize deployment path
+- [#174](https://github.com/ui-insight/UCMDailyRegister/issues/174): 1Password Connect runtime secrets
+- [#175](https://github.com/ui-insight/UCMDailyRegister/issues/175): OTel, Prometheus, Jaeger, and Splunk observability
+- [#176](https://github.com/ui-insight/UCMDailyRegister/issues/176): APM 30.11 data classification
+- [#178](https://github.com/ui-insight/UCMDailyRegister/issues/178): AI model gateway and approved-model registry
+- [#180](https://github.com/ui-insight/UCMDailyRegister/issues/180): PostgreSQL hosting and extensions posture
+- [#181](https://github.com/ui-insight/UCMDailyRegister/issues/181): Source-control and GitHub Actions approval

--- a/docs/governance/enterprise-ai-framework/evidence.json
+++ b/docs/governance/enterprise-ai-framework/evidence.json
@@ -1,0 +1,584 @@
+{
+  "$schema": "./evidence.schema.json",
+  "schema_version": "1.0.0",
+  "project": {
+    "slug": "ucm-daily-register",
+    "name": "UCM Daily Register",
+    "repository": "https://github.com/ui-insight/UCMDailyRegister",
+    "evidence_label": "standards-evidence",
+    "issue_tracker": {
+      "type": "github",
+      "owner": "ui-insight",
+      "repo": "UCMDailyRegister",
+      "parent_issue": {
+        "number": 170,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/170",
+        "state": "open"
+      },
+      "evidence_query_url": "https://github.com/ui-insight/UCMDailyRegister/issues?q=is%3Aissue%20label%3Astandards-evidence"
+    }
+  },
+  "framework": {
+    "id": "uidaho-oit-enterprise-ai-development-framework",
+    "title": "University of Idaho Enterprise AI Development Framework",
+    "version": "discussion-draft-2026-04",
+    "source_url": "https://dev.azure.com/uidaho/Development/_wiki/wikis/Development.wiki/19540/Enterprise-AI-Development-Framework",
+    "source_status": "discussion_draft",
+    "published_at": "2026-04-01"
+  },
+  "ingestion": {
+    "canonical_manifest_path": "docs/governance/enterprise-ai-framework/evidence.json",
+    "raw_manifest_url": "https://raw.githubusercontent.com/ui-insight/UCMDailyRegister/main/docs/governance/enterprise-ai-framework/evidence.json",
+    "schema_path": "docs/governance/enterprise-ai-framework/evidence.schema.json",
+    "primary_key": "project.slug + framework.id + requirements[].id",
+    "refresh_strategy": "Fetch this manifest from main, then refresh linked GitHub issue state by issue number.",
+    "github_status_source": "GitHub issue state is authoritative for work status; current_assertion is authoritative for compliance assertion status."
+  },
+  "status_values": [
+    {
+      "status": "not_started",
+      "meaning": "No compliance claim has been validated yet."
+    },
+    {
+      "status": "aligned",
+      "meaning": "UCM Daily Register appears to meet the requirement and has evidence ready for review."
+    },
+    {
+      "status": "partially_aligned",
+      "meaning": "UCM Daily Register meets part of the requirement, but needs more implementation, validation, or evidence."
+    },
+    {
+      "status": "gap",
+      "meaning": "UCM Daily Register does not currently meet the requirement."
+    },
+    {
+      "status": "not_applicable",
+      "meaning": "The requirement does not apply to UCM Daily Register, with rationale captured in evidence."
+    },
+    {
+      "status": "needs_decision",
+      "meaning": "Compliance depends on an OIT, security, product ownership, or governance decision."
+    }
+  ],
+  "requirements": [
+    {
+      "id": "OIT-EAI-STACK",
+      "title": "Approved technology stack alignment",
+      "category": "approved_technology_stack",
+      "aispeg_standard_ids": ["i-1", "i-7"],
+      "requirement_summary": "Validate UCM Daily Register against the approved stack, including FastAPI, React/Vite/TypeScript, PostgreSQL, SQLAlchemy/Alembic, Python and JavaScript tooling, testing, CI/CD, GitOps, source control, auth, secrets, observability, and AI gateway/model choices.",
+      "current_assertion": {
+        "status": "partially_aligned",
+        "summary": "Core application runtime choices are close to the draft stack: FastAPI/Uvicorn, React/Vite/TypeScript, SQLAlchemy/Alembic, pytest, Vitest, PostgreSQL for deployed environments, Docker, and GitHub Actions are present. Gaps or decisions remain for uv, Pyright, Biome, Azure Pipelines, ArgoCD/Kustomize, Entra ID, 1Password Connect, full observability, and approved model/gateway evidence.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 171,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/171",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_file", "label": "Approved stack evidence matrix", "path": "docs/governance/enterprise-ai-framework/approved-stack-evidence.md" },
+        { "type": "repo_file", "label": "Backend dependency manifest", "path": "backend/pyproject.toml" },
+        { "type": "repo_file", "label": "Frontend dependency manifest", "path": "frontend/package.json" },
+        { "type": "repo_directory", "label": "GitHub Actions workflows", "path": ".github/workflows" },
+        { "type": "repo_file", "label": "Docker Compose deployment", "path": "docker-compose.yml" }
+      ],
+      "required_evidence": [
+        "Approved-stack matrix with one row per OIT stack item",
+        "Validation commands and latest successful outputs",
+        "Exception or follow-up links for any deviations"
+      ],
+      "blockers": [],
+      "tags": ["deployment", "code-quality", "documentation"]
+    },
+    {
+      "id": "OIT-EAI-AUTH",
+      "title": "Microsoft Entra ID OIDC production authentication",
+      "category": "authentication",
+      "aispeg_standard_ids": ["i-1", "i-2", "i-4"],
+      "requirement_summary": "Production authentication must use Microsoft Entra ID through OAuth2/OIDC, with applications designed to be auth-provider-agnostic and without custom production auth.",
+      "current_assertion": {
+        "status": "gap",
+        "summary": "The repository documents and implements a trusted reverse-proxy header boundary using X-Trusted-User-Role and X-Trusted-Auth-Secret. There is no direct Microsoft Entra ID/OIDC token validation, app registration evidence, or group/claim mapping yet.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 172,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/172",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_file", "label": "Security policy authentication section", "path": "SECURITY.md" },
+        { "type": "repo_file", "label": "API dependency trusted role logic", "path": "backend/app/api/deps.py" },
+        { "type": "repo_file", "label": "Deployment trusted auth boundary notes", "path": "docs/deployment.md" },
+        { "type": "repo_file", "label": "Authorization tests", "path": "backend/tests/test_authorization.py" }
+      ],
+      "required_evidence": [
+        "OIDC adapter implementation and tests or approved exception",
+        "Role/group claim mapping",
+        "Production configuration guide",
+        "OIT Entra app registration decision"
+      ],
+      "blockers": [
+        "OIT decision on Entra app registration ownership, group names, and trusted gateway claim contract"
+      ],
+      "tags": ["security", "integration", "deployment"]
+    },
+    {
+      "id": "OIT-EAI-CICD",
+      "title": "Azure Pipelines, ArgoCD, and Kustomize deployment path",
+      "category": "cicd_gitops",
+      "aispeg_standard_ids": ["i-5", "i-8"],
+      "requirement_summary": "Hosted deployments should use Azure Pipelines, ArgoCD, Kustomize, OIT-provisioned namespaces, and no direct cluster access in test or production.",
+      "current_assertion": {
+        "status": "gap",
+        "summary": "The repository has GitHub Actions CI and Docker Compose deployment documentation for the openera host. It does not contain Azure Pipelines, ArgoCD application definitions, Kustomize overlays, or OIT namespace/RBAC evidence.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 173,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/173",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_file", "label": "Deployment guide", "path": "docs/deployment.md" },
+        { "type": "repo_file", "label": "Docker Compose deployment file", "path": "docker-compose.yml" },
+        { "type": "repo_file", "label": "Deploy script", "path": "deploy.sh" },
+        { "type": "repo_directory", "label": "GitHub Actions workflows", "path": ".github/workflows" }
+      ],
+      "required_evidence": [
+        "Azure Pipeline YAML or deployment repository link",
+        "ArgoCD application evidence",
+        "Kustomize overlays",
+        "Image digest and namespace/RBAC evidence"
+      ],
+      "blockers": [
+        "OIT namespace provisioning",
+        "OIT decision on GitHub Actions/GitHub Enterprise approval for this application"
+      ],
+      "tags": ["deployment", "integration", "documentation"]
+    },
+    {
+      "id": "OIT-EAI-SECRETS",
+      "title": "1Password Connect runtime secrets",
+      "category": "secrets_management",
+      "aispeg_standard_ids": ["i-4", "i-5"],
+      "requirement_summary": "Credentials must come from the secrets vault at runtime, with nothing hardcoded in code or container images.",
+      "current_assertion": {
+        "status": "partially_aligned",
+        "summary": "Secrets are configured through runtime environment variables and the repository includes an env template without secret values. There is no 1Password Connect runtime injection evidence or OIT vault ownership record yet.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 174,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/174",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_file", "label": "Environment variable template", "path": ".env.example" },
+        { "type": "repo_file", "label": "Backend settings", "path": "backend/app/config.py" },
+        { "type": "repo_file", "label": "Docker Compose runtime env", "path": "docker-compose.yml" },
+        { "type": "repo_file", "label": "Security policy secrets section", "path": "SECURITY.md" }
+      ],
+      "required_evidence": [
+        "Runtime secret inventory",
+        "1Password Connect manifests or OIT-provided integration evidence",
+        "Image inspection evidence",
+        "Secret rotation procedure"
+      ],
+      "blockers": [
+        "OIT decision on exact 1Password Connect pattern and vault ownership"
+      ],
+      "tags": ["security", "deployment", "documentation"]
+    },
+    {
+      "id": "OIT-EAI-OBSERVABILITY",
+      "title": "OpenTelemetry, Prometheus, Jaeger, and Splunk observability",
+      "category": "observability",
+      "aispeg_standard_ids": ["i-10"],
+      "requirement_summary": "All four observability components are required, with Splunk deployed first and ownership assigned before production.",
+      "current_assertion": {
+        "status": "gap",
+        "summary": "The repository has health endpoints, Docker health checks, deployment smoke checks, and an audit logging and monitoring plan. It does not yet implement or document hosted OpenTelemetry, Prometheus, Jaeger, or Splunk integration evidence.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 175,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/175",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_file", "label": "Audit logging and monitoring plan", "path": "docs/audit-logging.md" },
+        { "type": "repo_file", "label": "Docker Compose health checks", "path": "docker-compose.yml" },
+        { "type": "repo_file", "label": "Deployment smoke checks", "path": "deploy.sh" },
+        { "type": "repo_file", "label": "Health API route", "path": "backend/app/api/v1/health.py" }
+      ],
+      "required_evidence": [
+        "Instrumentation PRs and config",
+        "Splunk log query evidence",
+        "Jaeger trace sample",
+        "Prometheus or OTel collector metrics evidence",
+        "Alert/runbook ownership record"
+      ],
+      "blockers": [
+        "OIT observability endpoint details",
+        "Splunk index ownership",
+        "Collector deployment pattern"
+      ],
+      "tags": ["deployment", "security", "integration"]
+    },
+    {
+      "id": "OIT-EAI-DATA-CLASSIFICATION",
+      "title": "APM 30.11 data classification and regulated-data inventory",
+      "category": "data_classification",
+      "aispeg_standard_ids": ["i-3", "i-4"],
+      "requirement_summary": "Use APM 30.11 Low/Moderate/High classification, classify mixed datasets at the highest level present, and classify prompt/completion logs with the underlying data.",
+      "current_assertion": {
+        "status": "partially_aligned",
+        "summary": "The repository documents Public, Internal, and Confidential data classes, PII inventory, AI prompt data handling, and FERPA considerations. It still needs an explicit APM 30.11 mapping for each module, prompt/completion logs, uploads, and mixed datasets.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 176,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/176",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_file", "label": "Data governance and privacy", "path": "docs/data-governance.md" },
+        { "type": "repo_file", "label": "Security policy data protection section", "path": "SECURITY.md" },
+        { "type": "repo_file", "label": "AI editing data flow", "path": "docs/ai-editing.md" },
+        { "type": "repo_file", "label": "Data model documentation", "path": "docs/data-model.md" }
+      ],
+      "required_evidence": [
+        "Module-level APM 30.11 classification table",
+        "Regulated-data inventory",
+        "Prompt/completion logging classification statement",
+        "Security review or sign-off"
+      ],
+      "blockers": [
+        "Security review of whether submitter PII and incidental submitter-note PII require Moderate classification"
+      ],
+      "tags": ["security", "data-governance", "ai-pipeline"]
+    },
+    {
+      "id": "OIT-EAI-DEPLOYMENT-ARTIFACTS",
+      "title": "Required deployment artifacts",
+      "category": "deployment_artifacts",
+      "aispeg_standard_ids": ["i-1", "i-3", "i-6"],
+      "requirement_summary": "The project should keep repeatable deployment artifacts, runtime configuration references, environment documentation, SBOMs, backup/recovery procedures, and validation evidence.",
+      "current_assertion": {
+        "status": "partially_aligned",
+        "summary": "The repository includes Dockerfiles, docker-compose.yml, deploy.sh, MkDocs deployment docs, backup/recovery docs, SBOMs, Alembic migrations, health checks, and smoke checks. It still needs OIT-hosted deployment artifacts and formal runbook/ownership sign-off.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 177,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/177",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_file", "label": "Backend Dockerfile", "path": "backend/Dockerfile" },
+        { "type": "repo_file", "label": "Frontend Dockerfile", "path": "frontend/Dockerfile" },
+        { "type": "repo_file", "label": "Docker Compose deployment", "path": "docker-compose.yml" },
+        { "type": "repo_file", "label": "Deployment script", "path": "deploy.sh" },
+        { "type": "repo_file", "label": "Deployment guide", "path": "docs/deployment.md" },
+        { "type": "repo_file", "label": "Backup and recovery guide", "path": "docs/backup-and-recovery.md" },
+        { "type": "repo_directory", "label": "SBOM artifacts", "path": "sbom" },
+        { "type": "repo_directory", "label": "Alembic migrations", "path": "backend/alembic" }
+      ],
+      "required_evidence": [
+        "Container build and deployment artifacts",
+        "Runtime configuration reference",
+        "Migration and seed procedure",
+        "Backup, recovery, and rollback procedure",
+        "OIT-hosted deployment artifact mapping"
+      ],
+      "blockers": [
+        "OIT decision on target deployment platform and required deployment repository structure"
+      ],
+      "tags": ["deployment", "operations", "documentation"]
+    },
+    {
+      "id": "OIT-EAI-MODEL-GATEWAY",
+      "title": "AI model gateway, approved model, and registry evidence",
+      "category": "ai_model_gateway",
+      "aispeg_standard_ids": ["i-3", "i-4", "i-8"],
+      "requirement_summary": "AI model calls should use the approved gateway and models, with registry evidence for model selection, data classification, and exception handling.",
+      "current_assertion": {
+        "status": "needs_decision",
+        "summary": "The application supports Anthropic, OpenAI, and University of Idaho MindRouter through a provider abstraction. Deployment docs recommend MindRouter for on-prem use, but the approved model list, mandatory gateway path, and exception posture for external providers are not yet recorded.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 178,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/178",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_file", "label": "AI editing provider abstraction docs", "path": "docs/ai-editing.md" },
+        { "type": "repo_file", "label": "AI provider factory", "path": "backend/app/services/ai/factory.py" },
+        { "type": "repo_file", "label": "MindRouter provider", "path": "backend/app/services/ai/mindrouter_provider.py" },
+        { "type": "repo_file", "label": "Backend settings model defaults", "path": "backend/app/config.py" }
+      ],
+      "required_evidence": [
+        "Approved model registry entry or mapping",
+        "Gateway configuration evidence",
+        "Data classification for prompts and completions",
+        "Exception path for non-gateway providers if retained"
+      ],
+      "blockers": [
+        "OIT and MindRouter owner decision on approved models and external provider exception path"
+      ],
+      "tags": ["ai-pipeline", "security", "integration"]
+    },
+    {
+      "id": "OIT-EAI-AUDITABILITY",
+      "title": "Auditability for model calls, data access, and deployments",
+      "category": "auditability",
+      "aispeg_standard_ids": ["i-3", "i-4", "i-10"],
+      "requirement_summary": "Model calls, sensitive data access, configuration changes, and deployments should be auditable without logging protected content.",
+      "current_assertion": {
+        "status": "partially_aligned",
+        "summary": "AI editing creates immutable EditVersion records and the audit logging plan defines event types and PII redaction rules. Structured production audit logging for model calls, staff data access, configuration changes, and deployment events is not yet implemented end to end.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 179,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/179",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_file", "label": "Audit logging and monitoring plan", "path": "docs/audit-logging.md" },
+        { "type": "repo_file", "label": "AI editing edit-version docs", "path": "docs/ai-editing.md" },
+        { "type": "repo_file", "label": "Edit history model", "path": "backend/app/models/edit_history.py" },
+        { "type": "repo_file", "label": "Deployment script smoke checks", "path": "deploy.sh" }
+      ],
+      "required_evidence": [
+        "Structured application logging implementation",
+        "Model-call audit records with prompt/content redaction",
+        "Data access audit records for staff-only views",
+        "Deployment event records",
+        "Retention and review procedure"
+      ],
+      "blockers": [
+        "Observability platform and log destination decision"
+      ],
+      "tags": ["security", "observability", "ai-pipeline"]
+    },
+    {
+      "id": "OIT-EAI-POSTGRES",
+      "title": "PostgreSQL hosting standard and extensions",
+      "category": "database",
+      "aispeg_standard_ids": ["i-3", "i-5"],
+      "requirement_summary": "Hosted database posture should use the approved PostgreSQL deployment pattern and required extensions where applicable.",
+      "current_assertion": {
+        "status": "partially_aligned",
+        "summary": "Deployed environments use an external PostgreSQL database on insight-db-net and CI includes a PostgreSQL 16 smoke job with Alembic migrations. Local development defaults to SQLite, and there is no evidence yet for pgvector, pgaudit, pgsodium, or an OIT-managed PostgreSQL topology decision.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 180,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/180",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_file", "label": "Deployment database topology", "path": "docs/deployment.md" },
+        { "type": "repo_file", "label": "Docker Compose external Postgres network", "path": "docker-compose.yml" },
+        { "type": "repo_file", "label": "Backend database engine", "path": "backend/app/db/engine.py" },
+        { "type": "repo_file", "label": "Alembic config", "path": "backend/alembic.ini" },
+        { "type": "repo_file", "label": "PostgreSQL CI smoke test", "path": "backend/tests/postgres_smoke.py" }
+      ],
+      "required_evidence": [
+        "Production PostgreSQL hosting decision",
+        "Required extension inventory and validation",
+        "Backup and restore validation",
+        "Migration and drift-control evidence"
+      ],
+      "blockers": [
+        "OIT database-hosting decision and extension applicability review"
+      ],
+      "tags": ["database", "deployment", "security"]
+    },
+    {
+      "id": "OIT-EAI-SOURCE-CONTROL",
+      "title": "Source-control and GitHub Actions approval",
+      "category": "source_control",
+      "aispeg_standard_ids": ["i-5", "i-8"],
+      "requirement_summary": "Source-control and CI systems must be approved for the project and preserve review, branch protection, and deployment traceability.",
+      "current_assertion": {
+        "status": "needs_decision",
+        "summary": "The project is hosted in GitHub under ui-insight/UCMDailyRegister and uses GitHub Actions for backend, PostgreSQL smoke, frontend, and docs workflows. The OIT draft appears to prefer Azure DevOps/Azure Pipelines or a formal GitHub approval/exception, which has not been recorded for this repo.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 181,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/181",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_directory", "label": "GitHub Actions workflows", "path": ".github/workflows" },
+        { "type": "repo_file", "label": "Contributing branch and PR guidance", "path": "docs/contributing.md" },
+        { "type": "external_url", "label": "GitHub repository", "url": "https://github.com/ui-insight/UCMDailyRegister" }
+      ],
+      "required_evidence": [
+        "Approved source-control decision",
+        "CI platform approval or exception",
+        "Branch protection and review settings",
+        "Traceability from PR to deployment"
+      ],
+      "blockers": [
+        "OIT decision on GitHub/GitHub Actions approval for this project"
+      ],
+      "tags": ["source-control", "ci", "governance"]
+    },
+    {
+      "id": "OIT-EAI-OWNERSHIP",
+      "title": "Application ownership and long-term support",
+      "category": "ownership",
+      "aispeg_standard_ids": ["i-6", "i-8"],
+      "requirement_summary": "The application must have named business and technical owners, support expectations, security reporting, and long-term maintenance posture.",
+      "current_assertion": {
+        "status": "partially_aligned",
+        "summary": "The repository documents UCM as the business context, IIDS/security reporting paths, deployment host details, backup/recovery, and incident response. Named business owner, named technical owner, and long-term support commitments are not yet captured as formal evidence.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 182,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/182",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_file", "label": "Project README", "path": "README.md" },
+        { "type": "repo_file", "label": "Security policy", "path": "SECURITY.md" },
+        { "type": "repo_file", "label": "Backup and recovery guide", "path": "docs/backup-and-recovery.md" },
+        { "type": "repo_file", "label": "Deployment guide target server", "path": "docs/deployment.md" }
+      ],
+      "required_evidence": [
+        "Named business owner",
+        "Named technical owner",
+        "Support and escalation policy",
+        "Maintenance cadence",
+        "Security response ownership"
+      ],
+      "blockers": [
+        "Confirm formal owner names and support expectations with UCM and IIDS"
+      ],
+      "tags": ["ownership", "operations", "documentation"]
+    },
+    {
+      "id": "OIT-EAI-DEVTEST-DATA",
+      "title": "Dev/test data policy and synthetic-data evidence",
+      "category": "non_production_data",
+      "aispeg_standard_ids": ["i-3", "i-4"],
+      "requirement_summary": "Development and test environments must avoid unapproved production data and document synthetic, scrubbed, or minimized datasets.",
+      "current_assertion": {
+        "status": "partially_aligned",
+        "summary": "Tests use in-memory SQLite and repository seed JSON for controlled vocabularies, style rules, schedules, and sections. The docs identify PII and retention risks, but there is no explicit policy for copying production submissions, uploaded images, submitter notes, or prompt/completion data into dev/test environments.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 183,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/183",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_directory", "label": "Backend tests", "path": "backend/tests" },
+        { "type": "repo_directory", "label": "Frontend tests", "path": "frontend/src" },
+        { "type": "repo_directory", "label": "Seed data", "path": "backend/data" },
+        { "type": "repo_file", "label": "Data governance PII inventory", "path": "docs/data-governance.md" },
+        { "type": "repo_file", "label": "Pytest configuration", "path": "pytest.ini" }
+      ],
+      "required_evidence": [
+        "Non-production data policy",
+        "Production data copy prohibition or approved scrub process",
+        "Synthetic or seed data inventory",
+        "Upload and prompt data handling in dev/test"
+      ],
+      "blockers": [
+        "Policy decision on whether production submissions or uploads may be used outside production"
+      ],
+      "tags": ["data-governance", "testing", "security"]
+    },
+    {
+      "id": "OIT-EAI-LOCAL-AI-TOOLS",
+      "title": "Local AI tooling policy for development and CI",
+      "category": "local_ai_tooling",
+      "aispeg_standard_ids": ["i-4", "i-8"],
+      "requirement_summary": "Developers and CI workflows must follow policy for local AI tools, especially around prompts, code, secrets, protected data, and generated artifacts.",
+      "current_assertion": {
+        "status": "needs_decision",
+        "summary": "The repository contains agent conventions, but no project-specific local AI tooling policy for real submissions, submitter notes, secrets, prompt/completion content, or CI usage. A policy decision and documentation are needed before making a compliance assertion.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 184,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/184",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_file", "label": "Agent conventions", "path": "CLAUDE.md" },
+        { "type": "repo_file", "label": "Data governance prompt data discussion", "path": "docs/data-governance.md" },
+        { "type": "repo_file", "label": "Security policy external data transmission", "path": "SECURITY.md" }
+      ],
+      "required_evidence": [
+        "Permitted and prohibited local AI tool uses",
+        "Rules for real submissions, submitter notes, and PII",
+        "Secrets handling guidance",
+        "CI and generated-artifact policy"
+      ],
+      "blockers": [
+        "OIT or project owner decision on local AI tool policy for this application"
+      ],
+      "tags": ["ai-policy", "security", "governance"]
+    },
+    {
+      "id": "OIT-EAI-INTAKE-APPROVALS",
+      "title": "OIT intake, EAR, VASA, namespace, and gateway access",
+      "category": "formal_intake",
+      "aispeg_standard_ids": ["i-6", "i-8"],
+      "requirement_summary": "Formal OIT intake and approval artifacts should be tracked, including EAR, VASA, namespace request, gateway access, production auth, and exception approvals.",
+      "current_assertion": {
+        "status": "gap",
+        "summary": "No OIT intake, EAR, VASA, namespace, gateway access, or formal exception artifacts were found in the repository. These may exist outside the repo, but they are not linked as evidence yet.",
+        "validated_at": "2026-05-05",
+        "validated_by": "Codex"
+      },
+      "github_issue": {
+        "number": 185,
+        "url": "https://github.com/ui-insight/UCMDailyRegister/issues/185",
+        "state": "open"
+      },
+      "evidence_sources": [
+        { "type": "repo_file", "label": "Deployment guide target server", "path": "docs/deployment.md" },
+        { "type": "github_issue", "label": "Parent standards tracker", "url": "https://github.com/ui-insight/UCMDailyRegister/issues/170" },
+        { "type": "manual_artifact", "label": "OIT intake, EAR, VASA, namespace, and gateway access artifacts", "notes": "Manual artifacts should be linked from the GitHub issue without exposing sensitive content." }
+      ],
+      "required_evidence": [
+        "OIT intake record",
+        "EAR and VASA artifacts or approval references",
+        "Namespace request and approval",
+        "Gateway/model access approval",
+        "Exception approvals where needed"
+      ],
+      "blockers": [
+        "Locate or file formal OIT intake artifacts and record non-sensitive references"
+      ],
+      "tags": ["governance", "deployment", "security"]
+    }
+  ]
+}

--- a/docs/governance/enterprise-ai-framework/evidence.schema.json
+++ b/docs/governance/enterprise-ai-framework/evidence.schema.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/ui-insight/UCMDailyRegister/main/docs/governance/enterprise-ai-framework/evidence.schema.json",
+  "title": "UCM Daily Register Enterprise AI Framework Evidence Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "project",
+    "framework",
+    "ingestion",
+    "status_values",
+    "requirements"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "project": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "slug",
+        "name",
+        "repository",
+        "issue_tracker",
+        "evidence_label"
+      ],
+      "properties": {
+        "slug": { "type": "string" },
+        "name": { "type": "string" },
+        "repository": { "type": "string", "format": "uri" },
+        "issue_tracker": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "owner",
+            "repo",
+            "parent_issue",
+            "evidence_query_url"
+          ],
+          "properties": {
+            "type": { "const": "github" },
+            "owner": { "type": "string" },
+            "repo": { "type": "string" },
+            "parent_issue": { "$ref": "#/$defs/github_issue" },
+            "evidence_query_url": { "type": "string", "format": "uri" }
+          }
+        },
+        "evidence_label": { "type": "string" }
+      }
+    },
+    "framework": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "title",
+        "version",
+        "source_url",
+        "source_status",
+        "published_at"
+      ],
+      "properties": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "version": { "type": "string" },
+        "source_url": { "type": "string", "format": "uri" },
+        "source_status": {
+          "enum": ["discussion_draft", "published", "superseded"]
+        },
+        "published_at": { "type": "string", "format": "date" }
+      }
+    },
+    "ingestion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "canonical_manifest_path",
+        "raw_manifest_url",
+        "schema_path",
+        "primary_key",
+        "refresh_strategy",
+        "github_status_source"
+      ],
+      "properties": {
+        "canonical_manifest_path": { "type": "string" },
+        "raw_manifest_url": { "type": "string", "format": "uri" },
+        "schema_path": { "type": "string" },
+        "primary_key": { "type": "string" },
+        "refresh_strategy": { "type": "string" },
+        "github_status_source": { "type": "string" }
+      }
+    },
+    "status_values": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/status_definition" },
+      "minItems": 1
+    },
+    "requirements": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/requirement" },
+      "minItems": 1
+    }
+  },
+  "$defs": {
+    "github_issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["number", "url", "state"],
+      "properties": {
+        "number": { "type": "integer", "minimum": 1 },
+        "url": { "type": "string", "format": "uri" },
+        "state": { "enum": ["open", "closed"] }
+      }
+    },
+    "status_definition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "meaning"],
+      "properties": {
+        "status": {
+          "enum": [
+            "not_started",
+            "aligned",
+            "partially_aligned",
+            "gap",
+            "not_applicable",
+            "needs_decision"
+          ]
+        },
+        "meaning": { "type": "string" }
+      }
+    },
+    "assertion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "summary", "validated_at", "validated_by"],
+      "properties": {
+        "status": {
+          "enum": [
+            "not_started",
+            "aligned",
+            "partially_aligned",
+            "gap",
+            "not_applicable",
+            "needs_decision"
+          ]
+        },
+        "summary": { "type": "string" },
+        "validated_at": {
+          "type": ["string", "null"],
+          "format": "date"
+        },
+        "validated_by": { "type": ["string", "null"] }
+      }
+    },
+    "evidence_source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "label"],
+      "properties": {
+        "type": {
+          "enum": [
+            "repo_file",
+            "repo_directory",
+            "github_issue",
+            "github_query",
+            "external_url",
+            "command",
+            "manual_artifact"
+          ]
+        },
+        "label": { "type": "string" },
+        "path": { "type": "string" },
+        "url": { "type": "string" },
+        "command": { "type": "string" },
+        "notes": { "type": "string" }
+      }
+    },
+    "requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "title",
+        "category",
+        "aispeg_standard_ids",
+        "requirement_summary",
+        "current_assertion",
+        "github_issue",
+        "evidence_sources",
+        "required_evidence",
+        "blockers",
+        "tags"
+      ],
+      "properties": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "category": { "type": "string" },
+        "aispeg_standard_ids": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "requirement_summary": { "type": "string" },
+        "current_assertion": { "$ref": "#/$defs/assertion" },
+        "github_issue": { "$ref": "#/$defs/github_issue" },
+        "evidence_sources": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/evidence_source" }
+        },
+        "required_evidence": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "blockers": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/docs/governance/enterprise-ai-framework/index.md
+++ b/docs/governance/enterprise-ai-framework/index.md
@@ -1,0 +1,74 @@
+# Enterprise AI Framework Evidence
+
+UCM Daily Register publishes a machine-readable evidence manifest for the
+University of Idaho Enterprise AI Development Framework discussion draft. The
+manifest is the source this project owns; aggregation systems such as AISPEG can
+ingest it without scraping GitHub issue prose or Markdown documentation.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| [`evidence.json`](evidence.json) | UCM Daily Register compliance assertions, evidence links, GitHub issue references, and blockers |
+| [`evidence.schema.json`](evidence.schema.json) | JSON Schema for validating the manifest before ingestion |
+| [`approved-stack-evidence.md`](approved-stack-evidence.md) | Human-readable evidence matrix for OIT approved-stack issue #171 |
+
+Canonical raw URL:
+
+```text
+https://raw.githubusercontent.com/ui-insight/UCMDailyRegister/main/docs/governance/enterprise-ai-framework/evidence.json
+```
+
+Schema raw URL:
+
+```text
+https://raw.githubusercontent.com/ui-insight/UCMDailyRegister/main/docs/governance/enterprise-ai-framework/evidence.schema.json
+```
+
+## Ingestion Contract
+
+Aggregation tools should use this sequence:
+
+1. Fetch `evidence.json` from the raw GitHub URL above.
+2. Validate the payload against `evidence.schema.json`.
+3. Use `project.slug + framework.id + requirements[].id` as the stable primary
+   key.
+4. Refresh linked GitHub issue state from each `requirements[].github_issue`
+   number.
+5. Treat `current_assertion.status` as the compliance claim and GitHub issue
+   state as the work-tracking state.
+
+The manifest intentionally separates those two states. A requirement can have a
+closed issue because the evidence packet is complete, while the assertion status
+may still be `needs_decision` if OIT has not made a policy decision yet.
+
+## Assertion Status Values
+
+| Status | Meaning |
+| --- | --- |
+| `not_started` | No compliance claim has been validated yet |
+| `aligned` | UCM Daily Register appears to meet the requirement and has evidence ready for review |
+| `partially_aligned` | UCM Daily Register meets part of the requirement, but needs more implementation, validation, or evidence |
+| `gap` | UCM Daily Register does not currently meet the requirement |
+| `not_applicable` | The requirement does not apply to UCM Daily Register, with rationale captured in evidence |
+| `needs_decision` | Compliance depends on an OIT, security, product ownership, or governance decision |
+
+## Evidence Lifecycle
+
+Each requirement in the manifest points to a GitHub issue labeled
+`standards-evidence`. The issue is where implementation notes, review comments,
+manual evidence, and final validation notes accumulate.
+
+When evidence changes:
+
+1. Update the GitHub issue with the evidence or validation note.
+2. Update `evidence.json` if the compliance assertion, evidence source list, or
+   blockers changed.
+3. Keep repo file links stable where possible so aggregation systems can retain
+   history by requirement ID.
+
+The parent tracking issue is
+[#170](https://github.com/ui-insight/UCMDailyRegister/issues/170).
+
+AISPEG ingestion is tracked in
+[#258](https://github.com/ui-insight/AISPEG/issues/258).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,9 @@ nav:
   - API Reference: api-reference.md
   - Deployment: deployment.md
   - Data Governance: data-governance.md
+  - Enterprise AI Framework:
+      - Overview: governance/enterprise-ai-framework/index.md
+      - Approved Stack Evidence: governance/enterprise-ai-framework/approved-stack-evidence.md
   - Backup & Recovery: backup-and-recovery.md
   - Audit Logging: audit-logging.md
   - Contributing: contributing.md


### PR DESCRIPTION
## Summary

- Adds a project-local Enterprise AI Framework evidence packet under `docs/governance/enterprise-ai-framework/`.
- Publishes a stable JSON manifest and schema for AISPEG ingestion, keyed by `project.slug + framework.id + requirements[].id`.
- Adds a human-readable approved-stack evidence matrix and wires the new governance docs into MkDocs navigation.
- Creates/links the GitHub evidence tracker set: parent #170 and child requirements #171-#185.

## Manifest URLs

- Raw manifest: https://raw.githubusercontent.com/ui-insight/UCMDailyRegister/main/docs/governance/enterprise-ai-framework/evidence.json
- Schema: https://raw.githubusercontent.com/ui-insight/UCMDailyRegister/main/docs/governance/enterprise-ai-framework/evidence.schema.json

## AISPEG ingestion

- ui-insight/AISPEG#258

## Validation

- `python3 -m json.tool docs/governance/enterprise-ai-framework/evidence.json >/dev/null`
- `python3 -c "import json, pathlib; from jsonschema import Draft202012Validator; schema=json.load(open('docs/governance/enterprise-ai-framework/evidence.schema.json', encoding='utf-8')); data=json.load(open('docs/governance/enterprise-ai-framework/evidence.json', encoding='utf-8')); Draft202012Validator(schema).validate(data); missing=[(r['id'], s['path']) for r in data['requirements'] for s in r['evidence_sources'] if s.get('path') and s['type'] in {'repo_file','repo_directory'} and not pathlib.Path(s['path']).exists()]; assert not missing, missing; print('manifest valid and paths ok')"`
- `python3 -m mkdocs build --strict`
- `git diff --check`

## Standards issues

Advances #170, #171, #172, #173, #174, #175, #176, #177, #178, #179, #180, #181, #182, #183, #184, and #185. These remain open for implementation, OIT decisions, or formal evidence that is outside this initial manifest PR.