### PR TITLE
Fix UTC off-by-one parsing of date-only strings

### DIFF
--- a/frontend/src/components/dashboard/CalendarView.tsx
+++ b/frontend/src/components/dashboard/CalendarView.tsx
@@ -1,5 +1,6 @@
 import type { Submission } from '../../types/submission';
 import { getOccurrenceDates } from '../../utils/submissionOccurrences';
+import { toISODate } from '../../utils/date';
 
 const DAYS_OF_WEEK = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
@@ -21,13 +22,6 @@ interface CalendarViewProps {
   currentMonth: Date;
   onMonthChange: (date: Date) => void;
   validDates?: Map<string, string[]>;
-}
-
-function toISODate(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
 }
 
 function getSubmissionsByDate(submissions: Submission[]): Map<string, Submission[]> {

--- a/frontend/src/components/editor/SubmissionMeta.tsx
+++ b/frontend/src/components/editor/SubmissionMeta.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { Submission, TargetNewsletter } from '../../types/submission';
 import { getValidDates } from '../../api/schedule';
+import { parseISODate, addDaysISO } from '../../utils/date';
 
 interface SubmissionMetaProps {
   submission: Submission;
@@ -61,17 +62,9 @@ export default function SubmissionMeta({
   const [addDateError, setAddDateError] = useState('');
   const [validDatesSet, setValidDatesSet] = useState<Set<string>>(new Set());
 
-  const getMinDate = () => {
-    const tomorrow = new Date();
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    return tomorrow.toISOString().split('T')[0];
-  };
+  const getMinDate = () => addDaysISO(1);
 
-  const getMaxDate = () => {
-    const d = new Date();
-    d.setDate(d.getDate() + 90);
-    return d.toISOString().split('T')[0];
-  };
+  const getMaxDate = () => addDaysISO(90);
 
   const resolveNewsletter = useCallback(() => {
     if (submission.Target_Newsletter === 'both') return addDateNewsletter;
@@ -184,7 +177,7 @@ export default function SubmissionMeta({
           <div>
             <dt className="text-xs text-gray-500">Survey Ends</dt>
             <dd className="text-gray-900">
-              {new Date(submission.Survey_End_Date).toLocaleDateString(undefined, {
+              {parseISODate(submission.Survey_End_Date).toLocaleDateString(undefined, {
                 weekday: 'short',
                 year: 'numeric',
                 month: 'short',
@@ -200,7 +193,7 @@ export default function SubmissionMeta({
               <dd key={req.Id} className="mt-1 text-gray-900 font-medium">
                 <div>
                   {req.Requested_Date
-                    ? new Date(req.Requested_Date).toLocaleDateString(undefined, {
+                    ? parseISODate(req.Requested_Date).toLocaleDateString(undefined, {
                         weekday: 'short',
                         year: 'numeric',
                         month: 'short',
@@ -226,7 +219,7 @@ export default function SubmissionMeta({
                 </div>
                 {req.Recurrence_End_Date && (
                   <div className="text-xs text-gray-500 font-normal mt-0.5">
-                    Ends: {new Date(req.Recurrence_End_Date).toLocaleDateString()}
+                    Ends: {parseISODate(req.Recurrence_End_Date).toLocaleDateString()}
                   </div>
                 )}
                 {req.Excluded_Dates.length > 0 && (
@@ -250,7 +243,7 @@ export default function SubmissionMeta({
                         <div key={`${req.Id}-${occurrenceDate}`} className="flex flex-col gap-2">
                           <div className="flex items-center justify-between gap-2">
                             <span className="text-xs font-normal text-gray-700">
-                              {new Date(`${occurrenceDate}T12:00:00`).toLocaleDateString(undefined, {
+                              {parseISODate(occurrenceDate).toLocaleDateString(undefined, {
                                 weekday: 'short',
                                 year: 'numeric',
                                 month: 'short',

--- a/frontend/src/components/submission/SchedulePrefs.tsx
+++ b/frontend/src/components/submission/SchedulePrefs.tsx
@@ -1,4 +1,5 @@
 import type { TargetNewsletter } from '../../types/submission';
+import { parseISODate, addDaysISO } from '../../utils/date';
 
 interface ScheduleEntry {
   Requested_Date: string;
@@ -37,7 +38,7 @@ function validateDate(
   }
 
   // Fallback: client-side validation
-  const d = new Date(dateStr + 'T00:00:00');
+  const d = parseISODate(dateStr);
   const day = d.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
 
   if (target === 'myui') {
@@ -54,15 +55,13 @@ function validateDate(
 /** Validate a date specifically for My UI (Monday only). */
 function validateMyUIDate(dateStr: string): string | null {
   if (!dateStr) return null;
-  const d = new Date(dateStr + 'T00:00:00');
+  const d = parseISODate(dateStr);
   if (d.getDay() !== 1) return 'My UI publishes on Mondays only.';
   return null;
 }
 
 function getMinDate(): string {
-  const tomorrow = new Date();
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  return tomorrow.toISOString().split('T')[0];
+  return addDaysISO(1);
 }
 
 export default function SchedulePrefs({

--- a/frontend/src/components/submission/SubmissionForm.test.tsx
+++ b/frontend/src/components/submission/SubmissionForm.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { listAllowedValues } from '../../api/allowedValues';
 import { getValidDates } from '../../api/schedule';
 import { createSubmission } from '../../api/submissions';
@@ -114,6 +114,9 @@ async function fillStandardAnnouncement(user: ReturnType<typeof userEvent.setup>
 }
 
 beforeEach(() => {
+  // Pin the clock so the hardcoded run dates below stay in the future
+  // (the date inputs enforce min = tomorrow).
+  vi.useFakeTimers({ shouldAdvanceTime: true, now: new Date(2026, 4, 1, 9, 0, 0) });
   vi.clearAllMocks();
   submitterRoleMock.value = 'public';
   listAllowedValuesMock.mockResolvedValue(allowedCategories);
@@ -126,6 +129,10 @@ beforeEach(() => {
     blackout_dates: [],
   });
   createSubmissionMock.mockResolvedValue(makeSubmission());
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('SubmissionForm', () => {

--- a/frontend/src/components/submission/SubmissionForm.tsx
+++ b/frontend/src/components/submission/SubmissionForm.tsx
@@ -5,6 +5,7 @@ import type { AllowedValue } from '../../types/allowedValue';
 import { createSubmission } from '../../api/submissions';
 import { getValidDates } from '../../api/schedule';
 import { getSubmitterRole } from '../../utils/submitterRole';
+import { parseISODate, todayISO, addDaysISO, addMonthsISO } from '../../utils/date';
 import CategorySelect from './CategorySelect';
 import NewsletterTargetSelect from './NewsletterTargetSelect';
 import LinkEditor from './LinkEditor';
@@ -125,11 +126,7 @@ export default function SubmissionForm() {
   const [submitterEmail, setSubmitterEmail] = useState('');
   const [notes, setNotes] = useState('');
   const [surveyEndDate, setSurveyEndDate] = useState('');
-  const getMinDate = (): string => {
-    const tomorrow = new Date();
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    return tomorrow.toISOString().split('T')[0];
-  };
+  const getMinDate = (): string => addDaysISO(1);
 
   // Job Opportunity fields
   const [jobUrl, setJobUrl] = useState('');
@@ -211,11 +208,8 @@ export default function SubmissionForm() {
   useEffect(() => {
     const fetchDates = async () => {
       try {
-        const today = new Date();
-        const from = today.toISOString().split('T')[0];
-        const future = new Date(today);
-        future.setMonth(future.getMonth() + 3);
-        const to = future.toISOString().split('T')[0];
+        const from = todayISO();
+        const to = addMonthsISO(3);
         if (effectiveTargetNewsletter === 'both') {
           const data = await getValidDates(from, to);
           setValidDates(new Set(
@@ -287,7 +281,7 @@ export default function SubmissionForm() {
       return !validDates.has(schedule.Requested_Date);
     }
     // Fallback client-side check
-    const d = new Date(schedule.Requested_Date + 'T00:00:00');
+    const d = parseISODate(schedule.Requested_Date);
     const day = d.getDay();
     if (effectiveTargetNewsletter === 'myui' || effectiveTargetNewsletter === 'both') return day !== 1;
     if (effectiveTargetNewsletter === 'tdr') return day === 0 || day === 6;
@@ -302,7 +296,7 @@ export default function SubmissionForm() {
       if (secondaryValidDates.size > 0 && !secondaryValidDates.has(schedule.Second_Requested_Date)) {
         return 'Please select a valid My UI run date.';
       }
-      const d = new Date(`${schedule.Second_Requested_Date}T00:00:00`);
+      const d = parseISODate(schedule.Second_Requested_Date);
       if (d.getDay() !== 1) {
         return 'Please select a valid My UI run date.';
       }
@@ -316,7 +310,7 @@ export default function SubmissionForm() {
       return 'Please select a valid second run date for the chosen newsletter.';
     }
 
-    const d = new Date(`${schedule.Second_Requested_Date}T00:00:00`);
+    const d = parseISODate(schedule.Second_Requested_Date);
     const day = d.getDay();
     if (effectiveTargetNewsletter === 'myui' && day !== 1) {
       return 'Please select a valid second run date for the chosen newsletter.';

--- a/frontend/src/pages/BuilderPage.tsx
+++ b/frontend/src/pages/BuilderPage.tsx
@@ -27,6 +27,7 @@ import type {
 import type { NewsletterSection } from '../types/newsletter';
 import type { RecurringMessageIssueCandidate } from '../types/recurringMessage';
 import { EmptyState, Toast, useToast } from '../components/common';
+import { parseISODate, todayISO } from '../utils/date';
 
 interface BuilderSectionItemBase {
   Id: string;
@@ -155,9 +156,7 @@ function ImportCandidatePill({
 
 export default function BuilderPage() {
   const [newsletterType, setNewsletterType] = useState<'tdr' | 'myui'>('tdr');
-  const [publishDate, setPublishDate] = useState(
-    new Date().toISOString().split('T')[0],
-  );
+  const [publishDate, setPublishDate] = useState(todayISO());
   const [newsletter, setNewsletter] = useState<NewsletterDetailResponse | null>(null);
   const [newsletters, setNewsletters] = useState<NewsletterDetailResponse[]>([]);
   const [sections, setSections] = useState<NewsletterSection[]>([]);
@@ -1082,7 +1081,7 @@ export default function BuilderPage() {
                     {newsletterType === 'tdr' ? 'The Daily Register' : 'My UI'}
                   </h3>
                   <p className="text-sm text-gray-500">
-                    {new Date(newsletter.Publish_Date).toLocaleDateString('en-US', {
+                    {parseISODate(newsletter.Publish_Date).toLocaleDateString('en-US', {
                       weekday: 'long',
                       year: 'numeric',
                       month: 'long',
@@ -1314,7 +1313,7 @@ export default function BuilderPage() {
                     }`}
                   >
                     <p className="font-medium text-gray-900">
-                      {new Date(nl.Publish_Date).toLocaleDateString()}
+                      {parseISODate(nl.Publish_Date).toLocaleDateString()}
                     </p>
                     <p className="text-xs text-gray-500">
                       <span

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -8,6 +8,7 @@ import WeekOverview from '../components/dashboard/WeekOverview';
 import DayDetail from '../components/dashboard/DayDetail';
 import { getPrimaryOccurrenceDate } from '../utils/submissionOccurrences';
 import { Button, Card, EmptyState, SegmentedToggle } from '../components/common';
+import { toISODate } from '../utils/date';
 
 const STATUS_COLORS: Record<string, string> = {
   new: 'bg-status-info-100 text-status-info-800',
@@ -48,13 +49,6 @@ const NEWSLETTER_LABELS: Record<string, string> = {
   both: 'Both',
   none: 'SLC only',
 };
-
-function toISODate(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
-}
 
 export default function DashboardPage() {
   const navigate = useNavigate();

--- a/frontend/src/pages/SLCCalendarPage.tsx
+++ b/frontend/src/pages/SLCCalendarPage.tsx
@@ -5,18 +5,12 @@ import CalendarView from '../components/dashboard/CalendarView';
 import { getSubmitterRole } from '../utils/submitterRole';
 import { getOccurrenceDates } from '../utils/submissionOccurrences';
 import { EmptyState } from '../components/common';
+import { toISODate } from '../utils/date';
 
 const CLASSIFICATION_STYLES: Record<EventClassification, string> = {
   strategic: 'bg-ui-clearwater-50 text-ui-clearwater-700 border-ui-clearwater-200',
   signature: 'bg-ui-gold-50 text-ui-gold-700 border-ui-gold-200',
 };
-
-function toISODate(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
-}
 
 export default function SLCCalendarPage() {
   const role = getSubmitterRole();
@@ -25,7 +19,7 @@ export default function SLCCalendarPage() {
   const [submissions, setSubmissions] = useState<Submission[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [currentMonth, setCurrentMonth] = useState(() => new Date(2026, 3, 1));
+  const [currentMonth, setCurrentMonth] = useState(() => new Date());
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [classificationFilter, setClassificationFilter] = useState<'' | EventClassification>('');
 

--- a/frontend/src/utils/date.test.ts
+++ b/frontend/src/utils/date.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { parseISODate, toISODate, todayISO, addDaysISO, addMonthsISO } from './date';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('parseISODate', () => {
+  it('keeps the calendar date in the local timezone', () => {
+    const d = parseISODate('2026-07-20');
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(6);
+    expect(d.getDate()).toBe(20);
+  });
+
+  it('renders the correct weekday for a Monday', () => {
+    // 2026-07-20 is a Monday; UTC parsing would render Sunday in US timezones
+    expect(parseISODate('2026-07-20').getDay()).toBe(1);
+  });
+});
+
+describe('toISODate', () => {
+  it('round-trips with parseISODate', () => {
+    expect(toISODate(parseISODate('2026-02-28'))).toBe('2026-02-28');
+    expect(toISODate(parseISODate('2026-12-31'))).toBe('2026-12-31');
+  });
+
+  it('uses the local calendar date, not UTC', () => {
+    // 23:30 local on Jul 17 is already Jul 18 in UTC for US timezones;
+    // toISODate must still report the local date.
+    const lateEvening = new Date(2026, 6, 17, 23, 30, 0);
+    expect(toISODate(lateEvening)).toBe('2026-07-17');
+    expect(lateEvening.toISOString().split('T')[0]).not.toBe('2026-07-17');
+  });
+});
+
+describe('today/offset helpers', () => {
+  it('computes today, tomorrow, and month offsets in local time', () => {
+    vi.useFakeTimers({ now: new Date(2026, 6, 17, 22, 0, 0) });
+    expect(todayISO()).toBe('2026-07-17');
+    expect(addDaysISO(1)).toBe('2026-07-18');
+    expect(addDaysISO(90)).toBe('2026-10-15');
+    expect(addMonthsISO(3)).toBe('2026-10-17');
+  });
+});

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,0 +1,40 @@
+/**
+ * Helpers for date-only strings (YYYY-MM-DD).
+ *
+ * `new Date('YYYY-MM-DD')` parses as UTC midnight, which renders as the
+ * previous calendar day in US timezones. Likewise `toISOString()` converts
+ * to UTC, so local evening times roll forward a day. Always go through
+ * these helpers when converting between Date objects and date-only strings.
+ */
+
+/** Parse a YYYY-MM-DD string as local time (noon avoids DST edge cases). */
+export function parseISODate(dateStr: string): Date {
+  return new Date(`${dateStr}T12:00:00`);
+}
+
+/** Format a Date as YYYY-MM-DD using the local calendar date. */
+export function toISODate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/** Today's local date as YYYY-MM-DD. */
+export function todayISO(): string {
+  return toISODate(new Date());
+}
+
+/** The local date `days` days from today as YYYY-MM-DD. */
+export function addDaysISO(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return toISODate(d);
+}
+
+/** The local date `months` months from today as YYYY-MM-DD. */
+export function addMonthsISO(months: number): string {
+  const d = new Date();
+  d.setMonth(d.getMonth() + months);
+  return toISODate(d);
+}


### PR DESCRIPTION
## Summary
Fixes #192 — the most-reported problem in the feedback queue (~10 of 48 reports).

Date-only strings (`YYYY-MM-DD`) were parsed with `new Date()`, which interprets them as UTC midnight and renders the **previous calendar day** in US timezones. Editors saw requested run dates, the Builder issue header, and sidebar dates one day off; `toISOString()`-based today/tomorrow math shifted a day forward in the evening.

- New `src/utils/date.ts`: `parseISODate` (local noon), `toISODate`, `todayISO`, `addDaysISO`, `addMonthsISO` — with unit tests covering the timezone boundary cases
- Applied in SubmissionMeta, SubmissionForm, SchedulePrefs, BuilderPage; deduped the three copy-pasted local `toISODate` helpers (CalendarView, DashboardPage, SLCCalendarPage)
- SLC calendar now opens on the current month instead of hardcoded April 2026
- Un-time-bombed the SubmissionForm tests (fixtures dated May 2026 had expired against the `min = tomorrow` constraint, so the suite was red since May) by pinning the test clock

## Verification
- `npm run build`, `npm run lint`, `vitest run` all green (35 tests, was 30 with 4 failing)
- Verified in the browser against the reported scenario: a My UI newsletter dated Monday 2026-09-14 now renders **"Monday, September 14, 2026"** in the Builder header and "9/14/2026" in the Recent Newsletters sidebar (previously Sunday, Sept. 13 in Mountain/Pacific time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)