### PR TITLE
Preserve the submitted original when finalizing an edit

### DIFF
--- a/backend/alembic/versions/b8d4e6f1a2c3_restore_clobbered_submission_originals.py
+++ b/backend/alembic/versions/b8d4e6f1a2c3_restore_clobbered_submission_originals.py
@@ -1,0 +1,61 @@
+"""restore clobbered submission originals
+
+Finalizing an edit used to overwrite Submission.Original_Headline/Original_Body
+with the editor's text. Where an 'original' EditVersion snapshot exists (created
+by the AI edit pipeline before the overwrite happened), restore the submission's
+original fields from the earliest such snapshot.
+
+Revision ID: b8d4e6f1a2c3
+Revises: 7d3e5f9a1b2c
+Create Date: 2026-07-17 14:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b8d4e6f1a2c3"
+down_revision: Union[str, Sequence[str], None] = "7d3e5f9a1b2c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            """
+            SELECT ev."Submission_Id", ev."Headline", ev."Body"
+            FROM edit_versions ev
+            WHERE ev."Version_Type" = 'original'
+              AND ev."Created_At" = (
+                  SELECT MIN(ev2."Created_At")
+                  FROM edit_versions ev2
+                  WHERE ev2."Submission_Id" = ev."Submission_Id"
+                    AND ev2."Version_Type" = 'original'
+              )
+            """
+        )
+    ).fetchall()
+
+    for submission_id, headline, body in rows:
+        bind.execute(
+            sa.text(
+                """
+                UPDATE submissions
+                SET "Original_Headline" = :headline, "Original_Body" = :body
+                WHERE "Id" = :submission_id
+                  AND ("Original_Headline" != :headline OR "Original_Body" != :body)
+                """
+            ),
+            {"headline": headline, "body": body, "submission_id": submission_id},
+        )
+
+
+def downgrade() -> None:
+    # The overwritten values are not recoverable once restored; nothing to undo.
+    pass

--- a/backend/app/api/v1/ai_edits.py
+++ b/backend/app/api/v1/ai_edits.py
@@ -291,6 +291,9 @@ async def save_editor_final(
     """Save the editor's final version of a submission.
 
     This creates an 'editor_final' EditVersion and updates the submission status.
+    The submitted Original_Headline/Original_Body are never modified — the
+    edited text lives in the version history, and newsletter assembly prefers
+    the 'editor_final' version via _get_best_text.
     """
     # Verify submission exists
     result = await session.execute(
@@ -299,6 +302,24 @@ async def save_editor_final(
     submission = result.scalar_one_or_none()
     if not submission:
         raise HTTPException(status_code=404, detail="Submission not found")
+
+    # Snapshot the original into the version history if no AI edit did so yet,
+    # so the timeline is complete even for purely manual edits
+    existing_original = await session.execute(
+        sa.select(EditVersion).where(
+            EditVersion.Submission_Id == submission_id,
+            EditVersion.Version_Type == "original",
+        )
+    )
+    if not existing_original.scalar_one_or_none():
+        session.add(
+            EditVersion(
+                Submission_Id=submission_id,
+                Version_Type="original",
+                Headline=submission.Original_Headline,
+                Body=submission.Original_Body,
+            )
+        )
 
     # Create final version
     version = EditVersion(
@@ -310,9 +331,6 @@ async def save_editor_final(
     )
     session.add(version)
 
-    # Persist the edited content on the submission so it is reflected everywhere
-    submission.Original_Headline = data.Headline
-    submission.Original_Body = data.Body
     submission.Status = "in_review"
     await session.commit()
     await session.refresh(version)

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -225,3 +225,101 @@ class TestAIEditTasks:
             json={"Headline": "Final", "Body": "Final body."},
         )
         assert finalize_resp.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestFinalizePreservesOriginal:
+    async def test_finalize_without_prior_ai_edit_keeps_original_and_snapshots_it(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+    ):
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(),
+        )
+        assert submission_resp.status_code == 201
+        created = submission_resp.json()
+        submission_id = created["Id"]
+        original_headline = created["Original_Headline"]
+        original_body = created["Original_Body"]
+
+        finalize_resp = await client.post(
+            f"/api/v1/ai-edits/{submission_id}/finalize",
+            json={"Headline": "Editor headline", "Body": "Editor body."},
+            headers=staff_headers,
+        )
+        assert finalize_resp.status_code == 200
+        assert finalize_resp.json()["Version_Type"] == "editor_final"
+
+        detail_resp = await client.get(
+            f"/api/v1/submissions/{submission_id}",
+            headers=staff_headers,
+        )
+        assert detail_resp.status_code == 200
+        detail = detail_resp.json()
+        assert detail["Original_Headline"] == original_headline
+        assert detail["Original_Body"] == original_body
+        assert detail["Status"] == "in_review"
+
+        versions_resp = await client.get(
+            f"/api/v1/ai-edits/{submission_id}/versions",
+            headers=staff_headers,
+        )
+        assert versions_resp.status_code == 200
+        versions = versions_resp.json()
+        assert [v["Version_Type"] for v in versions] == ["original", "editor_final"]
+        assert versions[0]["Headline"] == original_headline
+        assert versions[0]["Body"] == original_body
+        assert versions[1]["Headline"] == "Editor headline"
+        assert versions[1]["Body"] == "Editor body."
+
+    async def test_repeated_finalize_keeps_single_original_snapshot(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: SuccessfulProvider(),
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(),
+        )
+        assert submission_resp.status_code == 201
+        created = submission_resp.json()
+        submission_id = created["Id"]
+
+        # AI edit first (creates the 'original' snapshot), then finalize twice
+        edit_resp = await client.post(
+            f"/api/v1/ai-edits/{submission_id}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+        assert edit_resp.status_code == 202
+        task = await wait_for_task(client, edit_resp.json()["Task_Id"], staff_headers)
+        assert task["Status"] == "succeeded"
+
+        for headline in ("First final", "Second final"):
+            finalize_resp = await client.post(
+                f"/api/v1/ai-edits/{submission_id}/finalize",
+                json={"Headline": headline, "Body": f"{headline} body."},
+                headers=staff_headers,
+            )
+            assert finalize_resp.status_code == 200
+
+        detail_resp = await client.get(
+            f"/api/v1/submissions/{submission_id}",
+            headers=staff_headers,
+        )
+        assert detail_resp.json()["Original_Headline"] == created["Original_Headline"]
+
+        versions_resp = await client.get(
+            f"/api/v1/ai-edits/{submission_id}/versions",
+            headers=staff_headers,
+        )
+        version_types = [v["Version_Type"] for v in versions_resp.json()]
+        assert version_types.count("original") == 1
+        assert version_types.count("editor_final") == 2


### PR DESCRIPTION
## Summary
Fixes #193.

`POST /ai-edits/{id}/finalize` wrote the editor's text into `Submission.Original_Headline`/`Original_Body`, permanently destroying the submitter's words unless an AI edit happened to snapshot them first. Newsletter assembly already prefers the `editor_final` EditVersion via `_get_best_text`, and the edit page already seeds from the latest `editor_final` version, so the overwrite was unnecessary — removing it also makes the edit screen's Original panel show the true original side-by-side with the edit, which is exactly what the feedback asked for.

- Stop mutating `Original_*` in finalize
- Snapshot an `original` EditVersion on first finalize if the AI pipeline hasn't already, keeping the version timeline complete for purely manual edits
- Data migration `b8d4e6f1a2c3` restores already-clobbered originals from the earliest `original` EditVersion snapshot where one exists (no-op otherwise)

## Verification
- Full backend suite green (121 tests, 2 new: finalize preserves the original with/without a prior AI edit; repeated finalize keeps a single original snapshot); ruff clean
- Migration chain runs clean on a fresh database
- Exercised end-to-end against a live dev server: finalized a real submission with new text — `Original_Headline` unchanged, versions list = `[original, editor_final]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)