### PR TITLE
Make reference-data seeding insert-only by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,9 @@ JOB_POSTINGS_MAX_PAGES=5
 
 # CORS (comma-separated origins; JSON arrays are also supported)
 CORS_ORIGINS=http://localhost:5173
+
+# Reference-data seeding (runs on every backend container start).
+# Existing rows are never modified by default so staff edits made in the app
+# survive redeploys. Set to 1 to deliberately reset style rules, allowed
+# values, and schedule configs to the JSON files in backend/data/.
+SEED_OVERWRITE=

--- a/backend/app/db/seed.py
+++ b/backend/app/db/seed.py
@@ -3,10 +3,17 @@
 Seeds AllowedValue controlled vocabulary, newsletter sections, style rules,
 and schedule configurations. Idempotent — skips records that already exist
 based on unique key combinations.
+
+Existing rows are never modified by default: staff edit style rules, allowed
+values, and schedule configs through the app, and the seed runs on every
+container start (see backend/docker-entrypoint.sh), so updating existing rows
+would silently revert their edits on each deploy. Set SEED_OVERWRITE=1 to
+deliberately reset those fields to the JSON files.
 """
 
 import asyncio
 import json
+import os
 from datetime import date, time
 from pathlib import Path
 
@@ -23,6 +30,11 @@ from app.models.schedule_config import ScheduleConfig
 DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data"
 
 
+def overwrite_enabled() -> bool:
+    """Whether existing rows should be reset to the JSON seed values."""
+    return os.environ.get("SEED_OVERWRITE", "").lower() in ("1", "true", "yes")
+
+
 async def seed_allowed_values(session: AsyncSession) -> None:
     """Seed the AllowedValue table from allowed_values.json."""
     filepath = DATA_DIR / "allowed_values" / "allowed_values.json"
@@ -36,16 +48,16 @@ async def seed_allowed_values(session: AsyncSession) -> None:
         )
         existing_val = result.scalar_one_or_none()
         if existing_val:
-            # Update fields that may have changed
-            for attr, key in [
-                ("Visibility_Role", "Visibility_Role"),
-                ("Label", "Label"),
-                ("Description", "Description"),
-                ("Display_Order", "Display_Order"),
-            ]:
-                new_val = v.get(key, getattr(existing_val, attr))
-                if getattr(existing_val, attr) != new_val:
-                    setattr(existing_val, attr, new_val)
+            if overwrite_enabled():
+                for attr, key in [
+                    ("Visibility_Role", "Visibility_Role"),
+                    ("Label", "Label"),
+                    ("Description", "Description"),
+                    ("Display_Order", "Display_Order"),
+                ]:
+                    new_val = v.get(key, getattr(existing_val, attr))
+                    if getattr(existing_val, attr) != new_val:
+                        setattr(existing_val, attr, new_val)
             continue
         record = AllowedValue(
             Value_Group=v["Value_Group"],
@@ -104,8 +116,7 @@ async def seed_style_rules(session: AsyncSession) -> None:
             )
             existing_rule = result.scalar_one_or_none()
             if existing_rule:
-                # Update rule text and severity if they've changed
-                if (
+                if overwrite_enabled() and (
                     existing_rule.Rule_Text != r["rule_text"]
                     or existing_rule.Severity != r.get("severity", "warning")
                     or existing_rule.Category != r["category"]
@@ -139,9 +150,9 @@ async def seed_schedule_configs(session: AsyncSession) -> None:
         existing_config = result.scalar_one_or_none()
         h, m, s = (int(x) for x in c["deadline_time"].split(":"))
         if existing_config:
-            # Update fields that may have changed
-            existing_config.Holiday_Shift_Enabled = c.get("holiday_shift_enabled", False)
-            existing_config.Submission_Deadline_Description = c["submission_deadline_description"]
+            if overwrite_enabled():
+                existing_config.Holiday_Shift_Enabled = c.get("holiday_shift_enabled", False)
+                existing_config.Submission_Deadline_Description = c["submission_deadline_description"]
             continue
 
         config = ScheduleConfig(

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -1,0 +1,117 @@
+"""Tests for the reference-data seeder.
+
+The seed runs on every container start, so it must be insert-only by default:
+staff edits to style rules, allowed values, and schedule configs made through
+the app must survive a redeploy. SEED_OVERWRITE=1 deliberately resets those
+fields to the JSON seed files.
+"""
+
+import pytest
+from sqlalchemy import select
+
+from app.db import seed
+from app.models.allowed_value import AllowedValue
+from app.models.schedule_config import ScheduleConfig
+from app.models.style_rule import StyleRule
+from tests.conftest import TestSession
+
+
+async def seed_everything() -> None:
+    async with TestSession() as session:
+        await seed.seed_allowed_values(session)
+        await seed.seed_sections(session)
+        await seed.seed_style_rules(session)
+        await seed.seed_schedule_configs(session)
+        await seed.seed_blackout_dates(session)
+
+
+async def get_one(model, *conditions):
+    async with TestSession() as session:
+        result = await session.execute(select(model).where(*conditions))
+        return result.scalars().first()
+
+
+async def count_all(model) -> int:
+    async with TestSession() as session:
+        result = await session.execute(select(model))
+        return len(result.scalars().all())
+
+
+@pytest.mark.asyncio
+class TestSeed:
+    async def test_fresh_database_seeds_completely_and_is_idempotent(self):
+        await seed_everything()
+        first_counts = (
+            await count_all(AllowedValue),
+            await count_all(StyleRule),
+            await count_all(ScheduleConfig),
+        )
+        assert all(count > 0 for count in first_counts)
+
+        await seed_everything()
+        second_counts = (
+            await count_all(AllowedValue),
+            await count_all(StyleRule),
+            await count_all(ScheduleConfig),
+        )
+        assert second_counts == first_counts
+
+    async def test_reseed_preserves_app_edits(self):
+        await seed_everything()
+
+        async with TestSession() as session:
+            rule = (await session.execute(select(StyleRule))).scalars().first()
+            rule_key = (rule.Rule_Set, rule.Rule_Key)
+            rule.Rule_Text = "Edited by staff in the app"
+            rule.Severity = "error"
+
+            value = (await session.execute(select(AllowedValue))).scalars().first()
+            value_key = (value.Value_Group, value.Code)
+            value.Label = "Staff-edited label"
+
+            config = (await session.execute(select(ScheduleConfig))).scalars().first()
+            config_key = (config.Newsletter_Type, config.Mode)
+            config.Submission_Deadline_Description = "Noon Wednesdays during the academic year"
+            await session.commit()
+
+        await seed_everything()
+
+        rule = await get_one(
+            StyleRule, StyleRule.Rule_Set == rule_key[0], StyleRule.Rule_Key == rule_key[1]
+        )
+        assert rule.Rule_Text == "Edited by staff in the app"
+        assert rule.Severity == "error"
+
+        value = await get_one(
+            AllowedValue,
+            AllowedValue.Value_Group == value_key[0],
+            AllowedValue.Code == value_key[1],
+        )
+        assert value.Label == "Staff-edited label"
+
+        config = await get_one(
+            ScheduleConfig,
+            ScheduleConfig.Newsletter_Type == config_key[0],
+            ScheduleConfig.Mode == config_key[1],
+        )
+        assert config.Submission_Deadline_Description == "Noon Wednesdays during the academic year"
+
+    async def test_seed_overwrite_flag_resets_to_json_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        await seed_everything()
+
+        async with TestSession() as session:
+            rule = (await session.execute(select(StyleRule))).scalars().first()
+            rule_key = (rule.Rule_Set, rule.Rule_Key)
+            original_text = rule.Rule_Text
+            rule.Rule_Text = "Edited by staff in the app"
+            await session.commit()
+
+        monkeypatch.setenv("SEED_OVERWRITE", "1")
+        await seed_everything()
+
+        rule = await get_one(
+            StyleRule, StyleRule.Rule_Set == rule_key[0], StyleRule.Rule_Key == rule_key[1]
+        )
+        assert rule.Rule_Text == original_text

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       UPLOAD_DIR: /app/uploads
       CORS_ORIGINS: '${CORS_ORIGINS:?Set CORS_ORIGINS in .env}'
       TRUSTED_ROLE_HEADER_SECRET: ${TRUSTED_ROLE_HEADER_SECRET:-}
+      SEED_OVERWRITE: ${SEED_OVERWRITE:-}
     volumes:
       - uploads:/app/uploads
     networks:


### PR DESCRIPTION
## Summary
Fixes #195.

`python -m app.db.seed` runs on every backend container start (`docker-entrypoint.sh`) and force-reverted style-rule text/severity/category, AllowedValue labels/descriptions, and ScheduleConfig fields back to the JSON seed files whenever the database differed. Any edit staff made through the Style Rules or Settings UI was silently undone at the next deploy — the leading explanation for the same AI-editing complaint being reported as fixed-then-broken three times in the feedback queue.

- Existing rows are never modified by default; missing rows are still inserted (fresh databases seed completely, idempotent re-runs stay no-ops)
- `SEED_OVERWRITE=1` deliberately resets those fields to the JSON files, for when the repo is meant to be the source of truth
- Plumbed through `docker-compose.yml` and documented in `.env.example`
- New `tests/test_seed.py`: fresh-seed completeness + idempotency, app edits surviving a re-seed, and the overwrite flag

This unblocks #194 (loading the 13 requested style rules) — once merged and deployed, rules added via the UI stick.

## Verification
Full backend suite green (124 tests, 3 new); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)