### PR TITLE
Add the 13 requested AP-style rule adjustments to the AI editing rules

### DIFF
--- a/backend/alembic/versions/c4f8a2d6e9b1_apply_joy_style_rule_updates.py
+++ b/backend/alembic/versions/c4f8a2d6e9b1_apply_joy_style_rule_updates.py
@@ -1,0 +1,287 @@
+"""apply Joy style rule updates
+
+Revision ID: c4f8a2d6e9b1
+Revises: b8d4e6f1a2c3
+Create Date: 2026-07-18 09:00:00.000000
+
+Apply only the style-rule changes requested in feedback issue #194. This data
+migration intentionally avoids ``SEED_OVERWRITE=1``, which would reset every
+staff-managed style rule, allowed value and schedule configuration.
+
+It also removes the obsolete My UI ``title_case`` row left behind when that
+seed key was renamed to ``sentence_case``. Insert-only seeding correctly
+preserves staff changes, but it cannot remove a stale row that conflicts with
+the current sentence-case instruction.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c4f8a2d6e9b1"
+down_revision: str | Sequence[str] | None = "b8d4e6f1a2c3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+STYLE_RULE_UPDATES = [
+    {
+        "rule_set": "shared",
+        "category": "formatting",
+        "rule_key": "ap_style_times",
+        "rule_text": (
+            "Use AP style for times: lowercase a.m. and p.m. with periods. Use noon "
+            "and midnight instead of 12 p.m. and 12 a.m. Use figures: 1 p.m., 3:30 "
+            "p.m. Use a hyphen for same-period time ranges: '3-4 p.m.' Use 'from' "
+            "with 'to' only when spanning a.m. to p.m.: 'from 9 a.m. to 3 p.m.' "
+            "Avoid 'o'clock'. Remove redundant time phrases such as 'this morning' "
+            "or 'tonight'."
+        ),
+        "severity": "warning",
+    },
+    {
+        "rule_set": "shared",
+        "category": "formatting",
+        "rule_key": "event_detail_ordering",
+        "rule_text": (
+            "Order event details as: time, day, date, location. Example: '3-4 p.m. "
+            "Wednesday, Feb. 12, in the Pitman Center Vandal Ballroom'. Do not "
+            "reorder or omit these elements. If the event is more than one month "
+            "away, omit the day of the week."
+        ),
+        "severity": "warning",
+    },
+    {
+        "rule_set": "shared",
+        "category": "formatting",
+        "rule_key": "spell_out_acronyms",
+        "rule_text": (
+            "Spell out acronyms on first reference and define key terms. Use the "
+            "acronym in parentheses after the first spelled-out reference. Acronyms "
+            "are allowed in headlines if the full term is spelled out on first "
+            "reference in the body text."
+        ),
+        "severity": "warning",
+    },
+    {
+        "rule_set": "shared",
+        "category": "voice",
+        "rule_key": "short_sentences",
+        "rule_text": (
+            "Write short, clear sentences. Avoid run-on sentences and "
+            "compound-complex structures. Break long sentences into two or more "
+            "shorter ones for readability. Replace semicolons with periods."
+        ),
+        "severity": "warning",
+    },
+    {
+        "rule_set": "tdr",
+        "category": "headlines",
+        "rule_key": "sentence_case",
+        "rule_text": (
+            "Headlines must be sentence case: capitalize only the first word and "
+            "proper nouns. Capitalize proper nouns, including official names of "
+            "departments, offices, buildings and programs (e.g., Copy Print Center, "
+            "Creative Services, Elizabeth Bradfield). Never leave proper names in "
+            "lowercase. Example: 'Attend the research awards ceremony' not 'Attend "
+            "the Research Awards Ceremony'."
+        ),
+        "severity": "error",
+    },
+    {
+        "rule_set": "myui",
+        "category": "headlines",
+        "rule_key": "sentence_case",
+        "rule_text": (
+            "Headlines must be sentence case: capitalize only the first word and "
+            "proper nouns. Capitalize proper nouns, including official names of "
+            "departments, offices, buildings and programs (e.g., Copy Print Center, "
+            "Creative Services, Elizabeth Bradfield). Never leave proper names in "
+            "lowercase. Example: 'Register for spring break activities' not "
+            "'Register for Spring Break Activities'."
+        ),
+        "severity": "error",
+    },
+    {
+        "rule_set": "shared",
+        "category": "formatting",
+        "rule_key": "spell_out_state_names",
+        "rule_text": (
+            "Always spell out the name of a state. Example: 'Moscow, Idaho' not "
+            "'Moscow, ID'."
+        ),
+        "severity": "warning",
+    },
+    {
+        "rule_set": "shared",
+        "category": "formatting",
+        "rule_key": "ampersand_to_and",
+        "rule_text": (
+            "Replace '&' with 'and' in plain text. Keep '&' only when it is part of "
+            "an official title or event name that uses it."
+        ),
+        "severity": "warning",
+    },
+    {
+        "rule_set": "shared",
+        "category": "formatting",
+        "rule_key": "preserve_event_title_case",
+        "rule_text": (
+            "Do not change event titles. Keep event titles in title case exactly as "
+            "submitted, even when the surrounding text uses sentence case."
+        ),
+        "severity": "error",
+    },
+    {
+        "rule_set": "shared",
+        "category": "formatting",
+        "rule_key": "mountain_time_not_mdt",
+        "rule_text": (
+            "If the submission includes 'Mountain time', retain it exactly as "
+            "written. If 'MDT' or 'MST' appears, replace it with 'Mountain time'. "
+            "Do not omit, rephrase or alter this wording."
+        ),
+        "severity": "warning",
+    },
+    {
+        "rule_set": "shared",
+        "category": "formatting",
+        "rule_key": "directional_abbreviation_periods",
+        "rule_text": (
+            "When an address includes a directional abbreviation (N, S, E or W), "
+            "add a period after the letter. Example: '1000 W. Pullman Road'. Do not "
+            "leave directional abbreviations without a period."
+        ),
+        "severity": "warning",
+    },
+    {
+        "rule_set": "shared",
+        "category": "voice",
+        "rule_key": "cta_structure",
+        "rule_text": (
+            "Structure announcements around a clear call to action: open with the "
+            "action the reader should take, follow with context, dates and "
+            "incentives, and close with an explicit final call to action such as "
+            "'Learn more and register'. Replace vague instructions with explicit "
+            "actions. Do not introduce audience qualifiers that are not in the "
+            "original submission. When the submission provides a contact's full "
+            "name, use it rather than a bare email address."
+        ),
+        "severity": "warning",
+    },
+]
+
+
+PREVIOUS_RULE_TEXT = {
+    ("shared", "ap_style_times"): (
+        "Use AP style for times: lowercase a.m. and p.m. with periods. Use noon "
+        "and midnight instead of 12 p.m. and 12 a.m. Use figures: 1 p.m., 3:30 "
+        "p.m. Use a hyphen for same-period time ranges: '3-4 p.m.' Use 'from' "
+        "with 'to' only when spanning a.m. to p.m.: 'from 9 a.m. to 3 p.m.'"
+    ),
+    ("shared", "event_detail_ordering"): (
+        "Order event details as: time, day, date, location. Example: '3-4 p.m. "
+        "Wednesday, Feb. 12, in the Pitman Center Vandal Ballroom'."
+    ),
+    ("shared", "spell_out_acronyms"): (
+        "Spell out acronyms on first reference and define key terms. Use the "
+        "acronym in parentheses after the first spelled-out reference."
+    ),
+    ("shared", "short_sentences"): (
+        "Write short, clear sentences. Avoid run-on sentences and "
+        "compound-complex structures. Break long sentences into two or more "
+        "shorter ones for readability."
+    ),
+    ("tdr", "sentence_case"): (
+        "Headlines must be sentence case (capitalize only the first word and "
+        "proper nouns). Example: 'Attend the research awards ceremony' not "
+        "'Attend the Research Awards Ceremony'."
+    ),
+    ("myui", "sentence_case"): (
+        "Headlines must be sentence case (capitalize only the first word and "
+        "proper nouns). Example: 'Register for spring break activities' not "
+        "'Register for Spring Break Activities'."
+    ),
+}
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _apply_style_rule_updates(bind: sa.Connection) -> None:
+    """Apply the focused rule upserts; exposed separately for regression tests."""
+    bind.execute(
+        sa.delete(style_rules).where(
+            style_rules.c.Rule_Set == "myui",
+            style_rules.c.Rule_Key == "title_case",
+        )
+    )
+
+    for rule in STYLE_RULE_UPDATES:
+        values = {
+            "Category": rule["category"],
+            "Rule_Text": rule["rule_text"],
+            "Is_Active": True,
+            "Severity": rule["severity"],
+        }
+        result = bind.execute(
+            sa.update(style_rules)
+            .where(
+                style_rules.c.Rule_Set == rule["rule_set"],
+                style_rules.c.Rule_Key == rule["rule_key"],
+            )
+            .values(**values)
+        )
+        if result.rowcount == 0:
+            bind.execute(
+                sa.insert(style_rules).values(
+                    Id=str(uuid.uuid4()),
+                    Rule_Set=rule["rule_set"],
+                    Rule_Key=rule["rule_key"],
+                    **values,
+                )
+            )
+
+
+def upgrade() -> None:
+    _apply_style_rule_updates(op.get_bind())
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    for rule in STYLE_RULE_UPDATES:
+        key = (rule["rule_set"], rule["rule_key"])
+        previous_text = PREVIOUS_RULE_TEXT.get(key)
+        if previous_text is None:
+            bind.execute(
+                sa.delete(style_rules).where(
+                    style_rules.c.Rule_Set == rule["rule_set"],
+                    style_rules.c.Rule_Key == rule["rule_key"],
+                )
+            )
+            continue
+
+        bind.execute(
+            sa.update(style_rules)
+            .where(
+                style_rules.c.Rule_Set == rule["rule_set"],
+                style_rules.c.Rule_Key == rule["rule_key"],
+            )
+            .values(Rule_Text=previous_text)
+        )
+
+    # Do not recreate myui/title_case: it was obsolete production drift, not
+    # intentional pre-migration state.

--- a/backend/app/utils/text.py
+++ b/backend/app/utils/text.py
@@ -35,36 +35,23 @@ LOCATION_PATTERN = re.compile(
 
 
 def to_sentence_case(text: str) -> str:
-    """Convert a headline to sentence case (capitalize first word and proper nouns only).
+    """Normalize the first character without destroying meaningful capitalization.
 
-    Since we can't reliably detect proper nouns, this lowercases everything
-    except the first character and known proper nouns/acronyms.
+    The LLM is responsible for sentence case because deterministic code cannot
+    distinguish an incorrectly capitalized common noun from a proper name. The
+    previous implementation lowercased the entire headline and then restored a
+    small allowlist, corrupting names such as ``Elizabeth Bradfield`` and official
+    names such as ``Copy Print Center`` after the model had formatted them correctly.
     """
     if not text:
         return text
 
-    # Known proper nouns and acronyms to preserve
-    preserve = {
-        "University of Idaho", "U of I", "Idaho", "Moscow", "Boise",
-        "Coeur d'Alene", "Vandal", "Vandals", "ASUI", "UCM", "UI",
-        "ISUB", "SUB", "Kibbie", "Pitman", "TLC", "VandalStar",
-        "PeopleAdmin", "VandalWeb", "USA", "NCAA", "AP", "HR",
-    }
+    first_letter = re.search(r"[A-Za-z]", text)
+    if not first_letter:
+        return text
 
-    # Start by lowercasing everything
-    result = text[0].upper() + text[1:].lower() if len(text) > 1 else text.upper()
-
-    # Restore preserved terms
-    for term in preserve:
-        pattern = re.compile(re.escape(term), re.IGNORECASE)
-        for match in pattern.finditer(text):
-            original = match.group()
-            start = match.start()
-            end = match.end()
-            # Find the corresponding position in result
-            result = result[:start] + original + result[end:]
-
-    return result
+    index = first_letter.start()
+    return text[:index] + text[index].upper() + text[index + 1 :]
 
 
 def to_title_case(text: str) -> str:

--- a/backend/data/style_rules/myui_rules.json
+++ b/backend/data/style_rules/myui_rules.json
@@ -2,7 +2,7 @@
   {
     "category": "headlines",
     "rule_key": "sentence_case",
-    "rule_text": "Headlines must be sentence case (capitalize only the first word and proper nouns). Example: 'Register for spring break activities' not 'Register for Spring Break Activities'.",
+    "rule_text": "Headlines must be sentence case: capitalize only the first word and proper nouns. Capitalize proper nouns, including official names of departments, offices, buildings and programs (e.g., Copy Print Center, Creative Services, Elizabeth Bradfield). Never leave proper names in lowercase. Example: 'Register for spring break activities' not 'Register for Spring Break Activities'.",
     "severity": "error"
   },
   {

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -44,7 +44,7 @@
   {
     "category": "formatting",
     "rule_key": "ap_style_times",
-    "rule_text": "Use AP style for times: lowercase a.m. and p.m. with periods. Use noon and midnight instead of 12 p.m. and 12 a.m. Use figures: 1 p.m., 3:30 p.m. Use a hyphen for same-period time ranges: '3-4 p.m.' Use 'from' with 'to' only when spanning a.m. to p.m.: 'from 9 a.m. to 3 p.m.'",
+    "rule_text": "Use AP style for times: lowercase a.m. and p.m. with periods. Use noon and midnight instead of 12 p.m. and 12 a.m. Use figures: 1 p.m., 3:30 p.m. Use a hyphen for same-period time ranges: '3-4 p.m.' Use 'from' with 'to' only when spanning a.m. to p.m.: 'from 9 a.m. to 3 p.m.' Avoid 'o'clock'. Remove redundant time phrases such as 'this morning' or 'tonight'.",
     "severity": "warning"
   },
   {
@@ -188,7 +188,7 @@
   {
     "category": "formatting",
     "rule_key": "event_detail_ordering",
-    "rule_text": "Order event details as: time, day, date, location. Example: '3-4 p.m. Wednesday, Feb. 12, in the Pitman Center Vandal Ballroom'.",
+    "rule_text": "Order event details as: time, day, date, location. Example: '3-4 p.m. Wednesday, Feb. 12, in the Pitman Center Vandal Ballroom'. Do not reorder or omit these elements. If the event is more than one month away, omit the day of the week.",
     "severity": "warning"
   },
   {
@@ -212,7 +212,7 @@
   {
     "category": "formatting",
     "rule_key": "spell_out_acronyms",
-    "rule_text": "Spell out acronyms on first reference and define key terms. Use the acronym in parentheses after the first spelled-out reference.",
+    "rule_text": "Spell out acronyms on first reference and define key terms. Use the acronym in parentheses after the first spelled-out reference. Acronyms are allowed in headlines if the full term is spelled out on first reference in the body text.",
     "severity": "warning"
   },
   {
@@ -248,7 +248,7 @@
   {
     "category": "voice",
     "rule_key": "short_sentences",
-    "rule_text": "Write short, clear sentences. Avoid run-on sentences and compound-complex structures. Break long sentences into two or more shorter ones for readability.",
+    "rule_text": "Write short, clear sentences. Avoid run-on sentences and compound-complex structures. Break long sentences into two or more shorter ones for readability. Replace semicolons with periods.",
     "severity": "warning"
   },
   {
@@ -261,6 +261,42 @@
     "category": "headlines",
     "rule_key": "headline_reader_perspective",
     "rule_text": "Headlines must be written from the reader's perspective using verbs that address what the reader can do. Example: 'Participate in VR research study' not 'Recruit research participants'. The headline should tell the reader what action they can take.",
+    "severity": "warning"
+  },
+  {
+    "category": "formatting",
+    "rule_key": "spell_out_state_names",
+    "rule_text": "Always spell out the name of a state. Example: 'Moscow, Idaho' not 'Moscow, ID'.",
+    "severity": "warning"
+  },
+  {
+    "category": "formatting",
+    "rule_key": "ampersand_to_and",
+    "rule_text": "Replace '&' with 'and' in plain text. Keep '&' only when it is part of an official title or event name that uses it.",
+    "severity": "warning"
+  },
+  {
+    "category": "formatting",
+    "rule_key": "preserve_event_title_case",
+    "rule_text": "Do not change event titles. Keep event titles in title case exactly as submitted, even when the surrounding text uses sentence case.",
+    "severity": "error"
+  },
+  {
+    "category": "formatting",
+    "rule_key": "mountain_time_not_mdt",
+    "rule_text": "If the submission includes 'Mountain time', retain it exactly as written. If 'MDT' or 'MST' appears, replace it with 'Mountain time'. Do not omit, rephrase or alter this wording.",
+    "severity": "warning"
+  },
+  {
+    "category": "formatting",
+    "rule_key": "directional_abbreviation_periods",
+    "rule_text": "When an address includes a directional abbreviation (N, S, E or W), add a period after the letter. Example: '1000 W. Pullman Road'. Do not leave directional abbreviations without a period.",
+    "severity": "warning"
+  },
+  {
+    "category": "voice",
+    "rule_key": "cta_structure",
+    "rule_text": "Structure announcements around a clear call to action: open with the action the reader should take, follow with context, dates and incentives, and close with an explicit final call to action such as 'Learn more and register'. Replace vague instructions with explicit actions. Do not introduce audience qualifiers that are not in the original submission. When the submission provides a contact's full name, use it rather than a bare email address.",
     "severity": "warning"
   }
 ]

--- a/backend/data/style_rules/tdr_rules.json
+++ b/backend/data/style_rules/tdr_rules.json
@@ -2,7 +2,7 @@
   {
     "category": "headlines",
     "rule_key": "sentence_case",
-    "rule_text": "Headlines must be sentence case (capitalize only the first word and proper nouns). Example: 'Attend the research awards ceremony' not 'Attend the Research Awards Ceremony'.",
+    "rule_text": "Headlines must be sentence case: capitalize only the first word and proper nouns. Capitalize proper nouns, including official names of departments, offices, buildings and programs (e.g., Copy Print Center, Creative Services, Elizabeth Bradfield). Never leave proper names in lowercase. Example: 'Attend the research awards ceremony' not 'Attend the Research Awards Ceremony'.",
     "severity": "error"
   },
   {

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -51,6 +51,23 @@ class FailingProvider:
         raise RuntimeError("provider unavailable")
 
 
+class ProperNounProvider:
+    model = "test-model"
+
+    async def complete(self, *args, **kwargs):  # pragma: no cover - unused interface method
+        raise NotImplementedError
+
+    async def complete_json(self, *args, **kwargs):
+        return {
+            "edited_headline": "Attend Elizabeth Bradfield reading from SoFar",
+            "edited_body": "Elizabeth Bradfield will read from SoFar.",
+            "changes_made": ["Rewrote the headline in sentence case"],
+            "flags": [],
+            "embedded_links": [],
+            "confidence": 0.95,
+        }
+
+
 async def wait_for_task(
     client: AsyncClient,
     task_id: str,
@@ -155,6 +172,45 @@ class TestAIEditTasks:
         ai_version = versions_resp.json()[-1]
         assert ai_version["Version_Type"] == "ai_suggested"
         assert ai_version["Editor_Instructions"] == "Tighten the first sentence."
+
+    async def test_ai_edit_preserves_proper_nouns_in_sentence_case_headline(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Do not undo correct proper-noun casing returned by the model.
+
+        This is the exact failure pattern from Joy's feedback: a model can return
+        sentence case with a correctly capitalized name, but deterministic
+        post-processing must not lowercase that name afterward.
+        """
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: ProperNounProvider(),
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Original_Headline="ELIZABETH BRADFIELD READING FROM SOFAR",
+            ),
+        )
+        assert submission_resp.status_code == 201
+        submission_id = submission_resp.json()["Id"]
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_id}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+
+        assert resp.status_code == 202
+        task = await wait_for_task(client, resp.json()["Task_Id"], staff_headers)
+        assert task["Status"] == "succeeded"
+        assert (
+            task["Result"]["Edited_Headline"]
+            == "Attend Elizabeth Bradfield reading from SoFar"
+        )
 
     async def test_provider_failure_does_not_save_ai_version_or_mark_ai_edited(
         self,

--- a/backend/tests/test_joy_style_rule_migration.py
+++ b/backend/tests/test_joy_style_rule_migration.py
@@ -1,0 +1,121 @@
+"""Regression coverage for the targeted Joy style-rule data migration."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "c4f8a2d6e9b1_apply_joy_style_rule_updates.py"
+)
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("joy_style_rule_migration", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def style_rules_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+
+
+def test_migration_repairs_drift_without_touching_unrelated_staff_rules():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert(),
+            [
+                {
+                    "Id": "stale-title-case",
+                    "Rule_Set": "myui",
+                    "Category": "headlines",
+                    "Rule_Key": "title_case",
+                    "Rule_Text": "Headlines must be title case.",
+                    "Is_Active": True,
+                    "Severity": "error",
+                },
+                {
+                    "Id": "old-sentence-case",
+                    "Rule_Set": "myui",
+                    "Category": "headlines",
+                    "Rule_Key": "sentence_case",
+                    "Rule_Text": "Old sentence-case text.",
+                    "Is_Active": True,
+                    "Severity": "warning",
+                },
+                {
+                    "Id": "custom-staff-rule",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "staff_custom",
+                    "Rule_Text": "A staff-authored rule that must survive.",
+                    "Is_Active": False,
+                    "Severity": "info",
+                },
+            ],
+        )
+
+        migration._apply_style_rule_updates(connection)
+        # The helper should be safe if a migration is retried during recovery.
+        migration._apply_style_rule_updates(connection)
+
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    by_key = {(row["Rule_Set"], row["Rule_Key"]): row for row in rows}
+    assert ("myui", "title_case") not in by_key
+
+    expected = {
+        (rule["rule_set"], rule["rule_key"]): rule
+        for rule in migration.STYLE_RULE_UPDATES
+    }
+    for key, rule in expected.items():
+        assert by_key[key]["Rule_Text"] == rule["rule_text"]
+        assert by_key[key]["Category"] == rule["category"]
+        assert by_key[key]["Severity"] == rule["severity"]
+        assert by_key[key]["Is_Active"] is True
+
+    custom = by_key[("shared", "staff_custom")]
+    assert custom["Rule_Text"] == "A staff-authored rule that must survive."
+    assert custom["Is_Active"] is False
+    assert len(rows) == len(expected) + 1
+
+
+def test_migration_values_match_the_style_rule_seed_files():
+    migration = load_migration()
+    data_dir = Path(__file__).parents[1] / "data" / "style_rules"
+    seeded = {}
+    for rule_set in ("shared", "tdr", "myui"):
+        rules = json.loads((data_dir / f"{rule_set}_rules.json").read_text())
+        seeded.update({(rule_set, rule["rule_key"]): rule for rule in rules})
+
+    for rule in migration.STYLE_RULE_UPDATES:
+        key = (rule["rule_set"], rule["rule_key"])
+        assert seeded[key]["category"] == rule["category"]
+        assert seeded[key]["rule_text"] == rule["rule_text"]
+        assert seeded[key]["severity"] == rule["severity"]
+
+    assert ("myui", "title_case") not in seeded

--- a/backend/tests/test_text.py
+++ b/backend/tests/test_text.py
@@ -1,0 +1,22 @@
+"""Tests for deterministic text post-processing utilities."""
+
+import pytest
+
+from app.utils.text import to_sentence_case
+
+
+@pytest.mark.parametrize(
+    ("headline", "expected"),
+    [
+        (
+            "Attend Elizabeth Bradfield reading from SoFar",
+            "Attend Elizabeth Bradfield reading from SoFar",
+        ),
+        ('"visit Copy Print Center"', '"Visit Copy Print Center"'),
+        ("meet Creative Services", "Meet Creative Services"),
+        ("2026 UCM planning session", "2026 UCM planning session"),
+        ("", ""),
+    ],
+)
+def test_to_sentence_case_preserves_model_casing(headline: str, expected: str):
+    assert to_sentence_case(headline) == expected


### PR DESCRIPTION
## Summary

Fixes #194 by applying Joy's requested AP-style rule changes and correcting the deterministic post-processing that could undo valid AI edits.

### What changed

- Amended six existing style rules and added six new rules across shared, TDR, and My UI rule sets.
- Preserved proper nouns and intentional casing in the sentence-case post-processor.
- Added Alembic migration `c4f8a2d6e9b1` to upsert only the affected rules in existing databases.
- Removed the stale conflicting My UI `title_case` rule while preserving unrelated database customizations.
- Added regression coverage for proper nouns, AI edit post-processing, migration behavior, and seed/migration parity.

### Root cause

The original seed-data changes were insert-only for existing databases, and a stale database rule could still conflict with the corrected JSON. Separately, `to_sentence_case()` lowercased all characters after the first one, so proper nouns returned correctly by the model were changed during deterministic cleanup.

### Verification

- 132 backend tests passed.
- Ruff checks passed.
- Fresh database migration reached Alembic head with no schema drift.
- Migration tests verify targeted updates and preservation of unrelated staff rules.
- A live MindRouter smoke test preserved `Elizabeth Bradfield` and `SoFar`.

### Deployment

Use the standard Alembic upgrade during deployment. Migration `c4f8a2d6e9b1` applies these targeted rule updates automatically; do **not** set `SEED_OVERWRITE=1` for this change.
