### PR TITLE
Add feedback notification foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,9 @@ CORS_ORIGINS=http://localhost:5173
 # survive redeploys. Set to 1 to deliberately reset style rules, allowed
 # values, and schedule configs to the JSON files in backend/data/.
 SEED_OVERWRITE=
+
+# Feedback notifications
+# Phase one records delivery state and surfaces new reports in the staff UI,
+# but sends no data outside the application. Keep disabled until UCM/OIT
+# approves and the codebase adds a specific outbound adapter.
+FEEDBACK_NOTIFICATION_CHANNEL=disabled

--- a/backend/alembic/versions/e7a1c3f5b9d2_add_feedback_notification_state.py
+++ b/backend/alembic/versions/e7a1c3f5b9d2_add_feedback_notification_state.py
@@ -1,0 +1,67 @@
+"""add feedback notification state
+
+Revision ID: e7a1c3f5b9d2
+Revises: c4f8a2d6e9b1
+Create Date: 2026-07-20 11:00:00.000000
+
+Add operational delivery state for in-app feedback notifications. Existing
+feedback predates notification support and is marked disabled rather than
+pending so the staff queue does not imply an unfinished delivery attempt.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e7a1c3f5b9d2"
+down_revision: str | Sequence[str] | None = "c4f8a2d6e9b1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "product_feedback",
+        sa.Column(
+            "Notification_Status",
+            sa.String(length=30),
+            nullable=False,
+            server_default="disabled",
+        ),
+    )
+    op.add_column(
+        "product_feedback",
+        sa.Column(
+            "Notification_Attempts",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "product_feedback",
+        sa.Column("Notification_Sent_At", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "product_feedback",
+        sa.Column("Notification_Last_Error", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "ix_product_feedback_Notification_Status",
+        "product_feedback",
+        ["Notification_Status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_product_feedback_Notification_Status",
+        table_name="product_feedback",
+    )
+    op.drop_column("product_feedback", "Notification_Last_Error")
+    op.drop_column("product_feedback", "Notification_Sent_At")
+    op.drop_column("product_feedback", "Notification_Attempts")
+    op.drop_column("product_feedback", "Notification_Status")

--- a/backend/app/api/v1/feedback.py
+++ b/backend/app/api/v1/feedback.py
@@ -8,9 +8,11 @@ from app.schemas.feedback import (
     ProductFeedbackCreate,
     ProductFeedbackExportResponse,
     ProductFeedbackResponse,
+    ProductFeedbackSummaryResponse,
     ProductFeedbackUpdate,
 )
 from app.services import feedback_service
+from app.services.feedback_notifications import FeedbackNotifier, get_feedback_notifier
 
 router = APIRouter(prefix="/feedback", tags=["feedback"])
 
@@ -19,9 +21,10 @@ router = APIRouter(prefix="/feedback", tags=["feedback"])
 async def create_feedback(
     data: ProductFeedbackCreate,
     db: AsyncSession = Depends(get_db),
+    notifier: FeedbackNotifier = Depends(get_feedback_notifier),
 ):
     """Capture a user-submitted bug report or product idea."""
-    return await feedback_service.create_feedback(db, data)
+    return await feedback_service.create_feedback(db, data, notifier)
 
 
 @router.get("", response_model=list[ProductFeedbackResponse])
@@ -37,6 +40,29 @@ async def list_feedback(
         status=status,
         feedback_type=feedback_type,
     )
+
+
+@router.get("/summary", response_model=ProductFeedbackSummaryResponse)
+async def get_feedback_summary(
+    db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
+):
+    """Return lightweight feedback and notification counts for staff surfaces."""
+    return await feedback_service.get_feedback_summary(db)
+
+
+@router.post("/{feedback_id}/notification/retry", response_model=ProductFeedbackResponse)
+async def retry_feedback_notification(
+    feedback_id: str,
+    db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
+    notifier: FeedbackNotifier = Depends(get_feedback_notifier),
+):
+    """Retry delivery through the currently configured notification adapter."""
+    feedback = await feedback_service.get_feedback(db, feedback_id)
+    if not feedback:
+        raise HTTPException(status_code=404, detail="Feedback item not found")
+    return await feedback_service.attempt_feedback_notification(db, feedback, notifier)
 
 
 @router.patch("/{feedback_id}", response_model=ProductFeedbackResponse)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Self
+from typing import Any, Literal, Self
 
 from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings
@@ -44,6 +44,7 @@ class Settings(BaseSettings):
     job_postings_request_timeout_seconds: float = 10.0
     job_postings_max_pages: int = 5
     ai_edit_max_concurrency: int = 2
+    feedback_notification_channel: Literal["disabled"] = "disabled"
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 

--- a/backend/app/models/feedback.py
+++ b/backend/app/models/feedback.py
@@ -41,6 +41,16 @@ class ProductFeedback(Base):
     Viewport: Mapped[str] = mapped_column(sa.String(50), nullable=False)
     Status: Mapped[str] = mapped_column(sa.String(30), nullable=False, default="new", index=True)
     GitHub_URL: Mapped[str | None] = mapped_column(sa.String(500), nullable=True)
+    Notification_Status: Mapped[str] = mapped_column(
+        sa.String(30), nullable=False, default="pending", index=True
+    )
+    Notification_Attempts: Mapped[int] = mapped_column(
+        sa.Integer, nullable=False, default=0
+    )
+    Notification_Sent_At: Mapped[datetime | None] = mapped_column(
+        sa.DateTime, nullable=True
+    )
+    Notification_Last_Error: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
     Created_At: Mapped[datetime] = mapped_column(
         sa.DateTime, nullable=False, server_default=sa.func.now(), index=True
     )

--- a/backend/app/schemas/feedback.py
+++ b/backend/app/schemas/feedback.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field, field_validator
 
 FEEDBACK_TYPE_PATTERN = r"^(bug|idea)$"
 FEEDBACK_STATUS_PATTERN = r"^(new|reviewed|exported|closed)$"
+NOTIFICATION_STATUS_PATTERN = r"^(pending|sent|failed|disabled)$"
 ROLE_PATTERN = r"^(public|staff|slc)$"
 
 
@@ -62,6 +63,10 @@ class ProductFeedbackResponse(BaseModel):
     Viewport: str
     Status: str
     GitHub_URL: str | None
+    Notification_Status: str = Field(..., pattern=NOTIFICATION_STATUS_PATTERN)
+    Notification_Attempts: int
+    Notification_Sent_At: datetime | None
+    Notification_Last_Error: str | None
     Created_At: datetime
     Updated_At: datetime
 
@@ -71,3 +76,9 @@ class ProductFeedbackResponse(BaseModel):
 class ProductFeedbackExportResponse(BaseModel):
     Title: str
     Body: str
+
+
+class ProductFeedbackSummaryResponse(BaseModel):
+    New_Count: int
+    Failed_Notification_Count: int
+    Pending_Notification_Count: int

--- a/backend/app/services/feedback_notifications.py
+++ b/backend/app/services/feedback_notifications.py
@@ -1,0 +1,86 @@
+"""Channel-neutral delivery contract for product-feedback notifications.
+
+Phase one intentionally ships without an external transport. The disabled
+implementation gives feedback capture stable delivery semantics and a narrow
+adapter boundary while UCM and OIT decide which outbound channel is approved.
+
+Notification payloads are deliberately smaller than feedback records. They do
+not expose report details, browser strings, host values, submission content or
+editorial notes. A future transport can alert a maintainer with enough context
+to open the staff-only feedback queue without copying the report outside the
+application.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+from app.config import settings
+from app.models.feedback import ProductFeedback
+
+
+@dataclass(frozen=True, slots=True)
+class FeedbackNotificationPayload:
+    """Sanitized context that an approved notification adapter may deliver."""
+
+    Feedback_Id: str
+    Feedback_Type: str
+    Summary: str
+    Route: str
+    App_Environment: str
+    Submitted_At: datetime
+    Contact_Email: str | None
+
+
+class FeedbackNotifier(Protocol):
+    """Transport boundary for an approved feedback-notification channel."""
+
+    name: str
+    enabled: bool
+
+    async def send(self, payload: FeedbackNotificationPayload) -> None:
+        """Deliver one sanitized notification or raise a transport error."""
+
+
+class DisabledFeedbackNotifier:
+    """Safe default used until UCM approves an outbound notification channel."""
+
+    name = "disabled"
+    enabled = False
+
+    async def send(self, payload: FeedbackNotificationPayload) -> None:
+        raise RuntimeError("The disabled feedback notifier cannot send messages")
+
+
+_disabled_notifier = DisabledFeedbackNotifier()
+
+
+def get_feedback_notifier() -> FeedbackNotifier:
+    """Return the configured notifier dependency.
+
+    Phase one supports only the disabled transport. Future adapters should be
+    selected here from validated settings after institutional approval.
+    """
+
+    if settings.feedback_notification_channel == "disabled":
+        return _disabled_notifier
+
+    # Pydantic currently rejects any other configured value. Keeping this
+    # guard makes the boundary fail closed if validation changes later.
+    raise RuntimeError("Unsupported feedback notification channel")
+
+
+def build_feedback_notification_payload(
+    feedback: ProductFeedback,
+) -> FeedbackNotificationPayload:
+    """Build a privacy-limited notification payload from a stored report."""
+
+    return FeedbackNotificationPayload(
+        Feedback_Id=feedback.Id,
+        Feedback_Type=feedback.Feedback_Type,
+        Summary=feedback.Summary,
+        Route=feedback.Route,
+        App_Environment=feedback.App_Environment,
+        Submitted_At=feedback.Created_At,
+        Contact_Email=feedback.Contact_Email,
+    )

--- a/backend/app/services/feedback_service.py
+++ b/backend/app/services/feedback_service.py
@@ -1,18 +1,69 @@
 """Business logic for in-app product feedback."""
 
+import logging
+from datetime import datetime, timezone
+
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.feedback import ProductFeedback
 from app.schemas.feedback import ProductFeedbackCreate
+from app.services.feedback_notifications import (
+    FeedbackNotifier,
+    build_feedback_notification_payload,
+)
+
+
+logger = logging.getLogger(__name__)
+MAX_NOTIFICATION_ERROR_LENGTH = 2000
 
 
 async def create_feedback(
     db: AsyncSession,
     data: ProductFeedbackCreate,
+    notifier: FeedbackNotifier,
 ) -> ProductFeedback:
     feedback = ProductFeedback(**data.model_dump())
     db.add(feedback)
+    await db.commit()
+    await db.refresh(feedback)
+    await attempt_feedback_notification(db, feedback, notifier)
+    return feedback
+
+
+async def attempt_feedback_notification(
+    db: AsyncSession,
+    feedback: ProductFeedback,
+    notifier: FeedbackNotifier,
+) -> ProductFeedback:
+    """Attempt delivery after persistence and record the operational outcome."""
+
+    if not notifier.enabled:
+        feedback.Notification_Status = "disabled"
+        feedback.Notification_Last_Error = None
+        await db.commit()
+        await db.refresh(feedback)
+        return feedback
+
+    feedback.Notification_Status = "pending"
+    feedback.Notification_Attempts += 1
+    feedback.Notification_Last_Error = None
+
+    try:
+        payload = build_feedback_notification_payload(feedback)
+        await notifier.send(payload)
+    except Exception as exc:  # transport adapters define their own exception types
+        feedback.Notification_Status = "failed"
+        feedback.Notification_Last_Error = str(exc)[:MAX_NOTIFICATION_ERROR_LENGTH]
+        logger.exception(
+            "Feedback notification failed feedback_id=%s notifier=%s",
+            feedback.Id,
+            notifier.name,
+        )
+    else:
+        feedback.Notification_Status = "sent"
+        feedback.Notification_Sent_At = datetime.now(timezone.utc).replace(tzinfo=None)
+
     await db.commit()
     await db.refresh(feedback)
     return feedback
@@ -31,6 +82,28 @@ async def list_feedback(
         query = query.where(ProductFeedback.Feedback_Type == feedback_type)
     result = await db.execute(query)
     return list(result.scalars().all())
+
+
+async def get_feedback_summary(db: AsyncSession) -> dict[str, int]:
+    """Return staff dashboard counts without loading feedback report contents."""
+
+    result = await db.execute(
+        sa.select(
+            sa.func.sum(sa.case((ProductFeedback.Status == "new", 1), else_=0)),
+            sa.func.sum(
+                sa.case((ProductFeedback.Notification_Status == "failed", 1), else_=0)
+            ),
+            sa.func.sum(
+                sa.case((ProductFeedback.Notification_Status == "pending", 1), else_=0)
+            ),
+        )
+    )
+    new_count, failed_count, pending_count = result.one()
+    return {
+        "New_Count": int(new_count or 0),
+        "Failed_Notification_Count": int(failed_count or 0),
+        "Pending_Notification_Count": int(pending_count or 0),
+    }
 
 
 async def get_feedback(

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -46,3 +46,10 @@ def test_production_rejects_wildcard_cors_origin(monkeypatch: pytest.MonkeyPatch
 
     with pytest.raises(ValidationError, match="cannot include"):
         Settings(_env_file=None)
+
+
+def test_feedback_notifications_fail_closed(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("FEEDBACK_NOTIFICATION_CHANNEL", "power-automate")
+
+    with pytest.raises(ValidationError, match="feedback_notification_channel"):
+        Settings(_env_file=None)

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -1,7 +1,29 @@
 """Tests for in-app product feedback capture and staff review."""
 
+from dataclasses import asdict
+
 import pytest
 from httpx import AsyncClient
+
+from app.main import app as fastapi_app
+from app.services.feedback_notifications import (
+    FeedbackNotificationPayload,
+    get_feedback_notifier,
+)
+
+
+class RecordingFeedbackNotifier:
+    name = "recording-test"
+    enabled = True
+
+    def __init__(self, *, should_fail: bool = False):
+        self.should_fail = should_fail
+        self.payloads: list[FeedbackNotificationPayload] = []
+
+    async def send(self, payload: FeedbackNotificationPayload) -> None:
+        self.payloads.append(payload)
+        if self.should_fail:
+            raise RuntimeError("Test notification channel unavailable")
 
 
 def make_feedback_payload(**overrides) -> dict:
@@ -35,6 +57,116 @@ class TestProductFeedback:
         assert data["Summary"] == "The dashboard filter is confusing"
         assert data["Status"] == "new"
         assert data["GitHub_URL"] is None
+        assert data["Notification_Status"] == "disabled"
+        assert data["Notification_Attempts"] == 0
+        assert data["Notification_Sent_At"] is None
+        assert data["Notification_Last_Error"] is None
+
+    async def test_enabled_notifier_receives_only_sanitized_context(
+        self,
+        client: AsyncClient,
+    ):
+        notifier = RecordingFeedbackNotifier()
+        fastapi_app.dependency_overrides[get_feedback_notifier] = lambda: notifier
+
+        resp = await client.post("/api/v1/feedback", json=make_feedback_payload())
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["Notification_Status"] == "sent"
+        assert data["Notification_Attempts"] == 1
+        assert data["Notification_Sent_At"] is not None
+        assert data["Notification_Last_Error"] is None
+
+        assert len(notifier.payloads) == 1
+        payload = asdict(notifier.payloads[0])
+        assert payload == {
+            "Feedback_Id": data["Id"],
+            "Feedback_Type": "bug",
+            "Summary": "The dashboard filter is confusing",
+            "Route": "/dashboard",
+            "App_Environment": "test",
+            "Submitted_At": notifier.payloads[0].Submitted_At,
+            "Contact_Email": "editor@uidaho.edu",
+        }
+        assert "Details" not in payload
+        assert "Browser" not in payload
+        assert "Host" not in payload
+        assert "Viewport" not in payload
+
+    async def test_notification_failure_does_not_lose_feedback(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+    ):
+        notifier = RecordingFeedbackNotifier(should_fail=True)
+        fastapi_app.dependency_overrides[get_feedback_notifier] = lambda: notifier
+
+        create_resp = await client.post(
+            "/api/v1/feedback",
+            json=make_feedback_payload(Details="Private details stay in the application."),
+        )
+
+        assert create_resp.status_code == 201
+        created = create_resp.json()
+        assert created["Notification_Status"] == "failed"
+        assert created["Notification_Attempts"] == 1
+        assert created["Notification_Sent_At"] is None
+        assert created["Notification_Last_Error"] == "Test notification channel unavailable"
+        assert "Private details" not in created["Notification_Last_Error"]
+
+        list_resp = await client.get("/api/v1/feedback", headers=staff_headers)
+        assert list_resp.status_code == 200
+        assert [item["Id"] for item in list_resp.json()] == [created["Id"]]
+
+    async def test_staff_can_retry_a_failed_notification(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+    ):
+        notifier = RecordingFeedbackNotifier(should_fail=True)
+        fastapi_app.dependency_overrides[get_feedback_notifier] = lambda: notifier
+        create_resp = await client.post("/api/v1/feedback", json=make_feedback_payload())
+        feedback_id = create_resp.json()["Id"]
+
+        notifier.should_fail = False
+        retry_resp = await client.post(
+            f"/api/v1/feedback/{feedback_id}/notification/retry",
+            headers=staff_headers,
+        )
+
+        assert retry_resp.status_code == 200
+        retried = retry_resp.json()
+        assert retried["Notification_Status"] == "sent"
+        assert retried["Notification_Attempts"] == 2
+        assert retried["Notification_Sent_At"] is not None
+        assert retried["Notification_Last_Error"] is None
+
+    async def test_notification_retry_and_summary_require_staff(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+    ):
+        create_resp = await client.post("/api/v1/feedback", json=make_feedback_payload())
+        feedback_id = create_resp.json()["Id"]
+
+        public_summary_resp = await client.get("/api/v1/feedback/summary")
+        public_retry_resp = await client.post(
+            f"/api/v1/feedback/{feedback_id}/notification/retry"
+        )
+        staff_summary_resp = await client.get(
+            "/api/v1/feedback/summary",
+            headers=staff_headers,
+        )
+
+        assert public_summary_resp.status_code == 403
+        assert public_retry_resp.status_code == 403
+        assert staff_summary_resp.status_code == 200
+        assert staff_summary_resp.json() == {
+            "New_Count": 1,
+            "Failed_Notification_Count": 0,
+            "Pending_Notification_Count": 0,
+        }
 
     async def test_public_user_cannot_list_feedback(
         self,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -86,6 +86,25 @@ MINDROUTER_MODEL=openai/gpt-oss-120b
 CORS_ORIGINS=http://localhost:5173
 ```
 
+### Feedback notifications
+
+Feedback capture is database-first: a report is committed before any delivery
+attempt, and notification failure never discards the report. Staff can see new
+report counts and delivery state in the application.
+
+Phase one does not send feedback outside the application. Keep the notification
+channel explicitly disabled in every environment:
+
+```bash
+FEEDBACK_NOTIFICATION_CHANNEL=disabled
+```
+
+The notification payload boundary is intentionally privacy-limited to feedback
+ID, type, summary, route, environment, submission time, and an optional contact
+email. It excludes report details, browser and host strings, submission content,
+submitter records, and editorial notes. Add and document an outbound adapter only
+after UCM and OIT approve the destination and credential model.
+
 !!! warning "Port Conflict"
     Port 8000 may be in use by another application. This project defaults to **port 8001** for the backend.
 

--- a/frontend/src/api/feedback.ts
+++ b/frontend/src/api/feedback.ts
@@ -5,6 +5,7 @@ import type {
   ProductFeedback,
   ProductFeedbackCreate,
   ProductFeedbackExport,
+  ProductFeedbackSummary,
 } from '../types/feedback';
 
 export async function createFeedback(
@@ -41,4 +42,16 @@ export async function getFeedbackGitHubExport(
   id: string,
 ): Promise<ProductFeedbackExport> {
   return apiFetch<ProductFeedbackExport>(`/feedback/${id}/github-export`);
+}
+
+export async function getFeedbackSummary(): Promise<ProductFeedbackSummary> {
+  return apiFetch<ProductFeedbackSummary>('/feedback/summary');
+}
+
+export async function retryFeedbackNotification(
+  id: string,
+): Promise<ProductFeedback> {
+  return apiFetch<ProductFeedback>(`/feedback/${id}/notification/retry`, {
+    method: 'POST',
+  });
 }

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getValidDates } from '../api/schedule';
 import { listSubmissions } from '../api/submissions';
+import { getFeedbackSummary } from '../api/feedback';
 import type { Submission, SubmissionStatus, TargetNewsletter } from '../types/submission';
 import DashboardPage from './DashboardPage';
 
@@ -15,8 +16,13 @@ vi.mock('../api/schedule', () => ({
   getValidDates: vi.fn(),
 }));
 
+vi.mock('../api/feedback', () => ({
+  getFeedbackSummary: vi.fn(),
+}));
+
 const listSubmissionsMock = vi.mocked(listSubmissions);
 const getValidDatesMock = vi.mocked(getValidDates);
+const getFeedbackSummaryMock = vi.mocked(getFeedbackSummary);
 
 function renderDashboard() {
   return render(
@@ -111,6 +117,11 @@ beforeEach(() => {
     ],
     blackout_dates: [],
   });
+  getFeedbackSummaryMock.mockResolvedValue({
+    New_Count: 0,
+    Failed_Notification_Count: 0,
+    Pending_Notification_Count: 0,
+  });
 });
 
 describe('DashboardPage', () => {
@@ -125,6 +136,34 @@ describe('DashboardPage', () => {
     expect(screen.getByText('Assigned: Alex')).toBeInTheDocument();
     expect(screen.getByText('Has notes')).toBeInTheDocument();
     expect(screen.getByText('Has image')).toBeInTheDocument();
+  });
+
+  it('surfaces new feedback and notification failures', async () => {
+    getFeedbackSummaryMock.mockResolvedValueOnce({
+      New_Count: 3,
+      Failed_Notification_Count: 1,
+      Pending_Notification_Count: 0,
+    });
+
+    renderDashboard();
+
+    expect(await screen.findByRole('button', { name: /3 new feedback items are waiting/i })).toBeInTheDocument();
+    expect(screen.getByText(/1 notification attempt needs attention/i)).toBeInTheDocument();
+    expect(screen.getByText('Review feedback')).toBeInTheDocument();
+  });
+
+  it('uses delivery-focused copy when no reports are new', async () => {
+    getFeedbackSummaryMock.mockResolvedValueOnce({
+      New_Count: 0,
+      Failed_Notification_Count: 2,
+      Pending_Notification_Count: 0,
+    });
+
+    renderDashboard();
+
+    expect(await screen.findByText('Feedback notifications need attention')).toBeInTheDocument();
+    expect(screen.getByText(/2 notification attempts need attention/i)).toBeInTheDocument();
+    expect(screen.queryByText(/0 new feedback items/i)).not.toBeInTheDocument();
   });
 
   it('sends selected filters and search text to the submissions API', async () => {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { listSubmissions } from '../api/submissions';
 import { getValidDates } from '../api/schedule';
+import { getFeedbackSummary } from '../api/feedback';
 import type { Submission, SubmissionStatus } from '../types/submission';
+import type { ProductFeedbackSummary } from '../types/feedback';
 import CalendarView from '../components/dashboard/CalendarView';
 import WeekOverview from '../components/dashboard/WeekOverview';
 import DayDetail from '../components/dashboard/DayDetail';
@@ -65,6 +67,7 @@ export default function DashboardPage() {
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [validDates, setValidDates] = useState<Map<string, string[]>>(new Map());
   const [refreshKey, setRefreshKey] = useState(0);
+  const [feedbackSummary, setFeedbackSummary] = useState<ProductFeedbackSummary | null>(null);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -98,6 +101,14 @@ export default function DashboardPage() {
   useEffect(() => {
     fetchData();
   }, [fetchData, refreshKey]);
+
+  useEffect(() => {
+    void getFeedbackSummary()
+      .then(setFeedbackSummary)
+      .catch(() => {
+        // Feedback visibility is useful but must not block the editorial dashboard.
+      });
+  }, [refreshKey]);
 
   useEffect(() => {
     if (viewMode !== 'calendar') return;
@@ -166,6 +177,45 @@ export default function DashboardPage() {
           />
         </div>
       </div>
+
+      {feedbackSummary && (
+        feedbackSummary.New_Count > 0
+        || feedbackSummary.Failed_Notification_Count > 0
+        || feedbackSummary.Pending_Notification_Count > 0
+      ) && (
+        <button
+          type="button"
+          onClick={() => navigate('/feedback')}
+          className="mb-6 flex w-full items-center gap-4 rounded-lg border border-status-attention-100 bg-status-attention-100/60 px-4 py-3 text-left transition-colors hover:bg-status-attention-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ui-clearwater-700"
+        >
+          <span className="flex h-9 min-w-9 items-center justify-center rounded-full bg-status-attention-800 px-2 text-sm font-semibold text-white">
+            {feedbackSummary.New_Count > 0
+              ? feedbackSummary.New_Count
+              : feedbackSummary.Failed_Notification_Count + feedbackSummary.Pending_Notification_Count}
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-sm font-semibold text-gray-900">
+              {feedbackSummary.New_Count === 0
+                ? feedbackSummary.Failed_Notification_Count > 0
+                  ? 'Feedback notifications need attention'
+                  : 'Feedback notifications are pending'
+                : feedbackSummary.New_Count === 1
+                  ? 'New feedback is waiting'
+                  : `${feedbackSummary.New_Count} new feedback items are waiting`}
+            </span>
+            <span className="mt-0.5 block text-xs text-gray-600">
+              {feedbackSummary.Failed_Notification_Count > 0
+                ? `${feedbackSummary.Failed_Notification_Count} notification ${feedbackSummary.Failed_Notification_Count === 1 ? 'attempt needs' : 'attempts need'} attention.`
+                : feedbackSummary.Pending_Notification_Count > 0
+                  ? `${feedbackSummary.Pending_Notification_Count} notification ${feedbackSummary.Pending_Notification_Count === 1 ? 'attempt is' : 'attempts are'} waiting for delivery.`
+                  : 'Review reports before they are exported to GitHub.'}
+            </span>
+          </span>
+          <span className="shrink-0 text-sm font-medium text-ui-clearwater-800">
+            Review feedback
+          </span>
+        </button>
+      )}
 
       {/* Filters */}
       <Card className="mb-6">

--- a/frontend/src/pages/FeedbackPage.test.tsx
+++ b/frontend/src/pages/FeedbackPage.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getFeedbackGitHubExport,
+  listFeedback,
+  retryFeedbackNotification,
+  updateFeedback,
+} from '../api/feedback';
+import type { ProductFeedback } from '../types/feedback';
+import FeedbackPage from './FeedbackPage';
+
+vi.mock('../api/feedback', () => ({
+  getFeedbackGitHubExport: vi.fn(),
+  listFeedback: vi.fn(),
+  retryFeedbackNotification: vi.fn(),
+  updateFeedback: vi.fn(),
+}));
+
+vi.mock('../utils/submitterRole', () => ({
+  getSubmitterRole: () => 'staff',
+}));
+
+const getFeedbackGitHubExportMock = vi.mocked(getFeedbackGitHubExport);
+const listFeedbackMock = vi.mocked(listFeedback);
+const retryFeedbackNotificationMock = vi.mocked(retryFeedbackNotification);
+const updateFeedbackMock = vi.mocked(updateFeedback);
+
+function makeFeedback(overrides: Partial<ProductFeedback> = {}): ProductFeedback {
+  return {
+    Id: 'feedback-1',
+    Feedback_Type: 'bug',
+    Summary: 'Dashboard filter is confusing',
+    Details: 'I expected the filter to keep my selection.',
+    Contact_Email: 'editor@uidaho.edu',
+    Submitter_Role: 'staff',
+    Route: '/dashboard',
+    App_Environment: 'test',
+    Host: 'localhost:5173',
+    Browser: 'vitest',
+    Viewport: '1280x720',
+    Status: 'new',
+    GitHub_URL: null,
+    Notification_Status: 'disabled',
+    Notification_Attempts: 0,
+    Notification_Sent_At: null,
+    Notification_Last_Error: null,
+    Created_At: '2026-07-20T12:00:00Z',
+    Updated_At: '2026-07-20T12:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderFeedbackPage() {
+  return render(
+    <MemoryRouter>
+      <FeedbackPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listFeedbackMock.mockResolvedValue([makeFeedback()]);
+  retryFeedbackNotificationMock.mockResolvedValue(makeFeedback());
+  updateFeedbackMock.mockResolvedValue(makeFeedback());
+  getFeedbackGitHubExportMock.mockResolvedValue({ Title: 'Bug', Body: 'Details' });
+});
+
+describe('FeedbackPage notification state', () => {
+  it('explains disabled external alerts without offering a retry', async () => {
+    renderFeedbackPage();
+
+    expect(await screen.findAllByText('Alerts off')).not.toHaveLength(0);
+    expect(screen.getByText(/external alerts are disabled while UCM confirms/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /retry notification/i })).not.toBeInTheDocument();
+  });
+
+  it('shows a delivery failure and lets staff retry it', async () => {
+    const user = userEvent.setup();
+    const failed = makeFeedback({
+      Notification_Status: 'failed',
+      Notification_Attempts: 1,
+      Notification_Last_Error: 'Approved channel is temporarily unavailable',
+    });
+    const sent = makeFeedback({
+      Notification_Status: 'sent',
+      Notification_Attempts: 2,
+      Notification_Sent_At: '2026-07-20T12:05:00Z',
+    });
+    listFeedbackMock
+      .mockResolvedValueOnce([failed])
+      .mockResolvedValueOnce([sent]);
+    retryFeedbackNotificationMock.mockResolvedValueOnce(sent);
+
+    renderFeedbackPage();
+
+    expect(await screen.findAllByText('Delivery failed')).not.toHaveLength(0);
+    expect(screen.getByText('Approved channel is temporarily unavailable')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Retry notification' }));
+
+    await waitFor(() => {
+      expect(retryFeedbackNotificationMock).toHaveBeenCalledWith('feedback-1');
+      expect(screen.getAllByText('Alert sent')).not.toHaveLength(0);
+    });
+  });
+});

--- a/frontend/src/pages/FeedbackPage.tsx
+++ b/frontend/src/pages/FeedbackPage.tsx
@@ -2,9 +2,15 @@ import { useCallback, useEffect, useState } from 'react';
 import {
   getFeedbackGitHubExport,
   listFeedback,
+  retryFeedbackNotification,
   updateFeedback,
 } from '../api/feedback';
-import type { FeedbackStatus, FeedbackType, ProductFeedback } from '../types/feedback';
+import type {
+  FeedbackNotificationStatus,
+  FeedbackStatus,
+  FeedbackType,
+  ProductFeedback,
+} from '../types/feedback';
 import { buildGitHubIssueUrl } from '../utils/feedback';
 import { getSubmitterRole } from '../utils/submitterRole';
 import { Button, Card, EmptyState, Toast, useToast } from '../components/common';
@@ -30,6 +36,20 @@ const STATUS_CLASSES: Record<FeedbackStatus, string> = {
   closed: 'bg-status-muted-100 text-status-muted-800',
 };
 
+const NOTIFICATION_LABELS: Record<FeedbackNotificationStatus, string> = {
+  pending: 'Delivery pending',
+  sent: 'Alert sent',
+  failed: 'Delivery failed',
+  disabled: 'Alerts off',
+};
+
+const NOTIFICATION_CLASSES: Record<FeedbackNotificationStatus, string> = {
+  pending: 'bg-status-warning-100 text-status-warning-800',
+  sent: 'bg-status-success-100 text-status-success-800',
+  failed: 'bg-status-error-100 text-status-error-800',
+  disabled: 'bg-status-muted-100 text-status-muted-800',
+};
+
 function formatDate(value: string) {
   return new Date(value).toLocaleString('en-US', {
     month: 'short',
@@ -47,6 +67,7 @@ export default function FeedbackPage() {
   const [typeFilter, setTypeFilter] = useState<FeedbackType | ''>('');
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [retryingId, setRetryingId] = useState<string | null>(null);
   const { toast, showToast, dismissToast } = useToast();
 
   const loadData = useCallback(async () => {
@@ -108,6 +129,29 @@ export default function FeedbackPage() {
       await loadData();
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Failed to save GitHub URL', 'error');
+    }
+  };
+
+  const handleRetryNotification = async (item: ProductFeedback) => {
+    setRetryingId(item.Id);
+    try {
+      const updated = await retryFeedbackNotification(item.Id);
+      setSelected(updated);
+      showToast(
+        updated.Notification_Status === 'sent'
+          ? 'Notification sent'
+          : 'No external notification channel is configured',
+        updated.Notification_Status === 'failed'
+          ? 'error'
+          : updated.Notification_Status === 'sent'
+            ? 'success'
+            : 'info',
+      );
+      await loadData();
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to retry notification', 'error');
+    } finally {
+      setRetryingId(null);
     }
   };
 
@@ -200,6 +244,9 @@ export default function FeedbackPage() {
                   <span className={`rounded px-1.5 py-0.5 text-[11px] font-medium ${STATUS_CLASSES[item.Status]}`}>
                     {item.Status}
                   </span>
+                  <span className={`rounded px-1.5 py-0.5 text-[11px] font-medium ${NOTIFICATION_CLASSES[item.Notification_Status]}`}>
+                    {NOTIFICATION_LABELS[item.Notification_Status]}
+                  </span>
                   <span className="ml-auto text-xs text-gray-400">{formatDate(item.Created_At)}</span>
                 </div>
                 <h3 className="text-sm font-semibold text-gray-900">{item.Summary}</h3>
@@ -271,6 +318,48 @@ export default function FeedbackPage() {
                     </option>
                   ))}
                 </select>
+              </div>
+
+              <div className="mt-5 border-t border-gray-100 pt-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-medium text-gray-500">Maintainer notification</p>
+                    <div className="mt-1.5 flex flex-wrap items-center gap-2">
+                      <span className={`rounded px-2 py-0.5 text-xs font-medium ${NOTIFICATION_CLASSES[selected.Notification_Status]}`}>
+                        {NOTIFICATION_LABELS[selected.Notification_Status]}
+                      </span>
+                      <span className="text-xs text-gray-500">
+                        {selected.Notification_Attempts} {selected.Notification_Attempts === 1 ? 'attempt' : 'attempts'}
+                      </span>
+                      {selected.Notification_Sent_At && (
+                        <span className="text-xs text-gray-500">
+                          Sent {formatDate(selected.Notification_Sent_At)}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  {(selected.Notification_Status === 'failed' || selected.Notification_Status === 'pending') && (
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      disabled={retryingId === selected.Id}
+                      onClick={() => void handleRetryNotification(selected)}
+                    >
+                      {retryingId === selected.Id ? 'Retrying...' : 'Retry notification'}
+                    </Button>
+                  )}
+                </div>
+                {selected.Notification_Status === 'disabled' && (
+                  <p className="mt-2 max-w-[70ch] text-xs text-gray-500">
+                    External alerts are disabled while UCM confirms an approved delivery channel.
+                    The report is safely stored in this queue.
+                  </p>
+                )}
+                {selected.Notification_Last_Error && (
+                  <p className="mt-2 rounded-md border border-status-error-100 bg-status-error-100/60 px-3 py-2 text-xs text-status-error-800">
+                    {selected.Notification_Last_Error}
+                  </p>
+                )}
               </div>
 
               <div className="mt-4">

--- a/frontend/src/types/feedback.ts
+++ b/frontend/src/types/feedback.ts
@@ -1,5 +1,6 @@
 export type FeedbackType = 'bug' | 'idea';
 export type FeedbackStatus = 'new' | 'reviewed' | 'exported' | 'closed';
+export type FeedbackNotificationStatus = 'pending' | 'sent' | 'failed' | 'disabled';
 
 export interface ProductFeedback {
   Id: string;
@@ -15,6 +16,10 @@ export interface ProductFeedback {
   Viewport: string;
   Status: FeedbackStatus;
   GitHub_URL: string | null;
+  Notification_Status: FeedbackNotificationStatus;
+  Notification_Attempts: number;
+  Notification_Sent_At: string | null;
+  Notification_Last_Error: string | null;
   Created_At: string;
   Updated_At: string;
 }
@@ -35,4 +40,10 @@ export interface ProductFeedbackCreate {
 export interface ProductFeedbackExport {
   Title: string;
   Body: string;
+}
+
+export interface ProductFeedbackSummary {
+  New_Count: number;
+  Failed_Notification_Count: number;
+  Pending_Notification_Count: number;
 }


### PR DESCRIPTION
## Summary

- persist notification status, delivery attempts, sent timestamps, and failures after feedback is safely stored
- add a fail-closed, channel-neutral notifier boundary with a privacy-limited payload
- add staff-only summary and retry endpoints
- surface new feedback and delivery state on the dashboard and feedback queue
- document the disabled-by-default configuration and institutional approval requirement

## Why

Issue #209 calls for notifying maintainers when feedback arrives, but authorization for Power Automate or another outbound channel has not been confirmed. This phase establishes the internal delivery model and staff visibility without transmitting feedback outside the application.

## User and developer impact

Feedback submission remains database-first, so notification failure cannot discard a report. Staff can see new reports and delivery problems in the app. A future approved transport can implement the notifier contract without changing feedback capture or the staff workflow.

The only accepted configuration in this phase is `FEEDBACK_NOTIFICATION_CHANNEL=disabled`. No external notification adapter is included.

## Privacy

The future notification payload is limited to feedback ID, type, summary, route, application environment, submission time, and optional contact email. It excludes report details, browser and host strings, submission content, submitter records, and editorial notes.

## Validation

- Backend: 137 tests passed
- Backend: Ruff passed
- Frontend: 39 tests passed
- Frontend: ESLint passed
- Frontend: production build passed
- Alembic: fresh upgrade to head and schema check passed

Addresses phase 1 of #209.
