### PR TITLE
Forward feedback notification configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       CORS_ORIGINS: '${CORS_ORIGINS:?Set CORS_ORIGINS in .env}'
       TRUSTED_ROLE_HEADER_SECRET: ${TRUSTED_ROLE_HEADER_SECRET:-}
       SEED_OVERWRITE: ${SEED_OVERWRITE:-}
+      FEEDBACK_NOTIFICATION_CHANNEL: ${FEEDBACK_NOTIFICATION_CHANNEL:-disabled}
     volumes:
       - uploads:/app/uploads
     networks:


### PR DESCRIPTION
## Summary

- forward `FEEDBACK_NOTIFICATION_CHANNEL` into the backend container
- preserve the fail-closed `disabled` default when the variable is not set

## Why

The phase-one dev deployment showed that the application setting existed and safely defaulted to `disabled`, but Docker Compose did not pass the environment variable into the backend container. That would prevent environment-specific channel selection when an approved phase-two adapter is added.

## Impact

There is no runtime behavior change for current deployments: notifications remain disabled by default. The deployment configuration now matches the documented environment contract and can carry an explicitly configured value into the backend.

## Validation

- `docker compose config --format json` renders `services.backend.environment.FEEDBACK_NOTIFICATION_CHANNEL` as `disabled`
- `git diff --check` passed

Follow-up to phase 1 of #209.
