### PR TITLE
Simplify editor finalization

### DIFF
--- a/backend/app/api/v1/ai_edits.py
+++ b/backend/app/api/v1/ai_edits.py
@@ -290,7 +290,8 @@ async def save_editor_final(
 ):
     """Save the editor's final version of a submission.
 
-    This creates an 'editor_final' EditVersion and updates the submission status.
+    This creates an 'editor_final' EditVersion and updates the submission status
+    to either in review or approved in the same transaction.
     The submitted Original_Headline/Original_Body are never modified — the
     edited text lives in the version history, and newsletter assembly prefers
     the 'editor_final' version via _get_best_text.
@@ -331,7 +332,7 @@ async def save_editor_final(
     )
     session.add(version)
 
-    submission.Status = "in_review"
+    submission.Status = "approved" if data.Approve_For_Newsletter else "in_review"
     await session.commit()
     await session.refresh(version)
     return version

--- a/backend/app/schemas/ai_edit.py
+++ b/backend/app/schemas/ai_edit.py
@@ -83,9 +83,11 @@ class EditVersionResponse(BaseModel):
 
 class EditorFinalCreate(BaseModel):
     """Request to save the editor's final version."""
+
     Headline: str = Field(..., min_length=1)
     Body: str = Field(..., min_length=1)
     Headline_Case: str | None = Field(None, pattern=r"^(sentence_case|title_case)$")
+    Approve_For_Newsletter: bool = False
 
 
 # --- Style rules schemas ---

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -379,3 +379,48 @@ class TestFinalizePreservesOriginal:
         version_types = [v["Version_Type"] for v in versions_resp.json()]
         assert version_types.count("original") == 1
         assert version_types.count("editor_final") == 2
+
+    async def test_finalize_and_approve_is_atomic_and_preserves_original(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+    ):
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(),
+        )
+        assert submission_resp.status_code == 201
+        created = submission_resp.json()
+        submission_id = created["Id"]
+
+        finalize_resp = await client.post(
+            f"/api/v1/ai-edits/{submission_id}/finalize",
+            json={
+                "Headline": "Approved editor headline",
+                "Body": "Approved editor body.",
+                "Approve_For_Newsletter": True,
+            },
+            headers=staff_headers,
+        )
+
+        assert finalize_resp.status_code == 200
+        assert finalize_resp.json()["Version_Type"] == "editor_final"
+
+        detail_resp = await client.get(
+            f"/api/v1/submissions/{submission_id}",
+            headers=staff_headers,
+        )
+        assert detail_resp.status_code == 200
+        detail = detail_resp.json()
+        assert detail["Status"] == "approved"
+        assert detail["Original_Headline"] == created["Original_Headline"]
+        assert detail["Original_Body"] == created["Original_Body"]
+
+        versions_resp = await client.get(
+            f"/api/v1/ai-edits/{submission_id}/versions",
+            headers=staff_headers,
+        )
+        assert [version["Version_Type"] for version in versions_resp.json()] == [
+            "original",
+            "editor_final",
+        ]

--- a/frontend/src/api/aiEdits.ts
+++ b/frontend/src/api/aiEdits.ts
@@ -56,7 +56,12 @@ export async function getEditVersion(
 
 export async function saveEditorFinal(
   submissionId: string,
-  data: { Headline: string; Body: string; Headline_Case?: string },
+  data: {
+    Headline: string;
+    Body: string;
+    Headline_Case?: string;
+    Approve_For_Newsletter?: boolean;
+  },
 ): Promise<EditVersion> {
   return apiFetch<EditVersion>(`/ai-edits/${submissionId}/finalize`, {
     method: 'POST',

--- a/frontend/src/components/editor/AIEditControls.test.tsx
+++ b/frontend/src/components/editor/AIEditControls.test.tsx
@@ -11,8 +11,7 @@ describe('AIEditControls', () => {
     render(
       <AIEditControls
         onTriggerEdit={onTriggerEdit}
-        onAcceptEdit={vi.fn()}
-        onRejectEdit={vi.fn()}
+        onReviewFinalEdit={vi.fn()}
         loading={false}
         hasAIEdit={false}
         targetNewsletter="both"
@@ -26,16 +25,14 @@ describe('AIEditControls', () => {
     expect(onTriggerEdit).toHaveBeenNthCalledWith(2, 'myui');
   });
 
-  it('shows review actions and confidence after an AI edit exists', async () => {
+  it('routes an AI suggestion through final review without a separate accept action', async () => {
     const user = userEvent.setup();
-    const onAcceptEdit = vi.fn();
-    const onRejectEdit = vi.fn();
+    const onReviewFinalEdit = vi.fn();
 
     render(
       <AIEditControls
         onTriggerEdit={vi.fn()}
-        onAcceptEdit={onAcceptEdit}
-        onRejectEdit={onRejectEdit}
+        onReviewFinalEdit={onReviewFinalEdit}
         loading={false}
         hasAIEdit
         targetNewsletter="tdr"
@@ -44,12 +41,11 @@ describe('AIEditControls', () => {
     );
 
     expect(screen.getByText('84%')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /accept ai edit/i })).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /accept ai edit/i }));
-    await user.click(screen.getByRole('button', { name: /edit manually/i }));
+    await user.click(screen.getByRole('button', { name: /continue to final edit/i }));
 
-    expect(onAcceptEdit).toHaveBeenCalledOnce();
-    expect(onRejectEdit).toHaveBeenCalledOnce();
+    expect(onReviewFinalEdit).toHaveBeenCalledOnce();
   });
 
   it('sends targeted editor feedback when revising an AI edit', async () => {
@@ -59,8 +55,7 @@ describe('AIEditControls', () => {
     render(
       <AIEditControls
         onTriggerEdit={onTriggerEdit}
-        onAcceptEdit={vi.fn()}
-        onRejectEdit={vi.fn()}
+        onReviewFinalEdit={vi.fn()}
         loading={false}
         hasAIEdit
         targetNewsletter="tdr"

--- a/frontend/src/components/editor/AIEditControls.tsx
+++ b/frontend/src/components/editor/AIEditControls.tsx
@@ -3,8 +3,7 @@ import { Button } from '../common';
 
 interface AIEditControlsProps {
   onTriggerEdit: (newsletterType: 'tdr' | 'myui', editorInstructions?: string) => void;
-  onAcceptEdit: () => void;
-  onRejectEdit: () => void;
+  onReviewFinalEdit: () => void;
   loading: boolean;
   hasAIEdit: boolean;
   // Accepts "none" so SLC-only submissions type-check, though AI editing is never
@@ -15,8 +14,7 @@ interface AIEditControlsProps {
 
 export default function AIEditControls({
   onTriggerEdit,
-  onAcceptEdit,
-  onRejectEdit,
+  onReviewFinalEdit,
   loading,
   hasAIEdit,
   targetNewsletter,
@@ -86,23 +84,13 @@ export default function AIEditControls({
             </div>
           )}
 
-          <div className="flex gap-2">
-            <Button
-              onClick={onAcceptEdit}
-              variant="success"
-              className="flex-1"
-              title="Accept the AI-suggested edit as the final version"
-            >
-              Accept AI Edit
-            </Button>
-            <Button
-              onClick={onRejectEdit}
-              variant="secondary"
-              className="flex-1"
-            >
-              Edit Manually
-            </Button>
-          </div>
+          <Button
+            onClick={onReviewFinalEdit}
+            variant="secondary"
+            className="w-full"
+          >
+            Continue to Final Edit
+          </Button>
 
           <div className="space-y-2 rounded-md border border-gray-200 bg-gray-50 p-3">
             <label htmlFor="editor-ai-feedback" className="block text-xs font-medium text-gray-600">

--- a/frontend/src/pages/EditPage.test.tsx
+++ b/frontend/src/pages/EditPage.test.tsx
@@ -251,7 +251,7 @@ describe('EditPage', () => {
     expect(screen.getByText('AI edit complete')).toBeInTheDocument();
   });
 
-  it('accepts the latest AI version as the final edit', async () => {
+  it('reviews and approves the latest AI version through Final Edit', async () => {
     const user = userEvent.setup();
     const aiVersion = makeVersion({
       Headline: 'Accepted AI headline',
@@ -263,19 +263,30 @@ describe('EditPage', () => {
     renderEditPage();
 
     await screen.findByText('Accepted AI headline');
-    await user.click(screen.getByRole('button', { name: /accept ai edit/i }));
+    expect(screen.queryByRole('button', { name: /accept ai edit/i })).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /continue to final edit/i }));
+    expect(screen.getByDisplayValue('Accepted AI headline')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Accepted AI body.')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /save and approve/i }));
 
     await waitFor(() => {
       expect(saveEditorFinalMock).toHaveBeenCalledWith('submission-1', {
         Headline: 'Accepted AI headline',
         Body: 'Accepted AI body.',
         Headline_Case: 'title_case',
+        Approve_For_Newsletter: true,
       });
     });
-    expect(await screen.findByText('Edit accepted and finalized')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Final version saved and approved for newsletter'),
+    ).toBeInTheDocument();
+    expect(updateSubmissionMock).not.toHaveBeenCalledWith(
+      'submission-1',
+      expect.objectContaining({ Status: 'approved' }),
+    );
   });
 
-  it('saves manual final edits from the editor tab', async () => {
+  it('saves and approves manual final edits with one action', async () => {
     const user = userEvent.setup();
 
     renderEditPage();
@@ -292,16 +303,41 @@ describe('EditPage', () => {
     await user.clear(body);
     await user.type(body, 'Manual final body.');
     await user.tab();
-    await user.click(screen.getByRole('button', { name: /save final version/i }));
+    await user.click(screen.getByRole('button', { name: /save and approve/i }));
 
     await waitFor(() => {
       expect(saveEditorFinalMock).toHaveBeenCalledWith('submission-1', {
         Headline: 'Manual final headline',
         Body: 'Manual final body.',
         Headline_Case: undefined,
+        Approve_For_Newsletter: true,
       });
     });
-    expect(await screen.findByText('Final version saved')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Final version saved and approved for newsletter'),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the explicit draft action distinct from approval', async () => {
+    const user = userEvent.setup();
+
+    renderEditPage();
+
+    await screen.findByText('Original campus headline');
+    await user.click(screen.getByRole('button', { name: /final edit/i }));
+    await user.click(screen.getByRole('button', { name: /save draft/i }));
+
+    await waitFor(() => {
+      expect(saveEditorFinalMock).toHaveBeenCalledWith('submission-1', {
+        Headline: 'Original campus headline',
+        Body: 'Original body copy for the newsletter.',
+        Headline_Case: undefined,
+        Approve_For_Newsletter: false,
+      });
+    });
+    expect(
+      await screen.findByText('Draft saved. Submission remains in review'),
+    ).toBeInTheDocument();
   });
 
   it('shows load errors and lets staff return to the dashboard', async () => {

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -24,6 +24,7 @@ import { Button, SegmentedToggle, Toast, useToast } from '../components/common';
 
 type Tab = 'original' | 'ai_edit' | 'editor';
 type ViewMode = 'diff' | 'side_by_side';
+type FinalizationAction = 'draft' | 'approve' | null;
 
 const STATUS_COLORS: Record<string, string> = {
   new: 'bg-status-info-100 text-status-info-800',
@@ -46,7 +47,7 @@ export default function EditPage() {
   const [activeTab, setActiveTab] = useState<Tab>('original');
   const [loading, setLoading] = useState(true);
   const [aiLoading, setAiLoading] = useState(false);
-  const [saveLoading, setSaveLoading] = useState(false);
+  const [finalizationAction, setFinalizationAction] = useState<FinalizationAction>(null);
   const [editorialSaving, setEditorialSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { toast, showToast, dismissToast } = useToast();
@@ -172,46 +173,38 @@ export default function EditPage() {
     }
   };
 
-  const handleAcceptEdit = async () => {
-    if (!id) return;
-    setSaveLoading(true);
-    try {
-      const aiVersion = [...versions].reverse().find((v) => v.Version_Type === 'ai_suggested');
-      await saveEditorFinal(id, {
-        Headline: aiVersion?.Headline || editHeadline,
-        Body: aiVersion?.Body || editBody,
-        Headline_Case: aiVersion?.Headline_Case || undefined,
-      });
-      showToast('Edit accepted and finalized');
-      await loadData();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save');
-    } finally {
-      setSaveLoading(false);
-    }
-  };
-
-  const handleRejectEdit = () => {
-    // Switch to editor tab for manual editing
+  const handleReviewFinalEdit = () => {
     setActiveTab('editor');
   };
 
-  const handleSaveFinal = async () => {
+  const handleFinalize = async (approveForNewsletter: boolean) => {
     if (!id) return;
-    setSaveLoading(true);
+    setFinalizationAction(approveForNewsletter ? 'approve' : 'draft');
+    setError(null);
     try {
       const aiVersion = [...versions].reverse().find((v) => v.Version_Type === 'ai_suggested');
       await saveEditorFinal(id, {
         Headline: editHeadline,
         Body: editBody,
         Headline_Case: aiVersion?.Headline_Case || undefined,
+        Approve_For_Newsletter: approveForNewsletter,
       });
-      showToast('Final version saved');
+      showToast(
+        approveForNewsletter
+          ? 'Final version saved and approved for newsletter'
+          : 'Draft saved. Submission remains in review',
+      );
       await loadData();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save');
+      const message = err instanceof Error
+        ? err.message
+        : approveForNewsletter
+          ? 'Failed to save and approve'
+          : 'Failed to save draft';
+      setError(message);
+      showToast(message, 'error');
     } finally {
-      setSaveLoading(false);
+      setFinalizationAction(null);
     }
   };
 
@@ -233,25 +226,6 @@ export default function EditPage() {
       showToast(msg, 'error');
     } finally {
       setEditorialSaving(false);
-    }
-  };
-
-  const handleApprove = async () => {
-    if (!id) return;
-    try {
-      // Save current edits first so they persist
-      const aiVersion = [...versions].reverse().find((v) => v.Version_Type === 'ai_suggested');
-      await saveEditorFinal(id, {
-        Headline: editHeadline,
-        Body: editBody,
-        Headline_Case: aiVersion?.Headline_Case || undefined,
-      });
-      // Then approve
-      await updateSubmission(id, { Status: 'approved' } as Partial<Submission>);
-      showToast('Submission approved');
-      await loadData();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to approve');
     }
   };
 
@@ -390,6 +364,9 @@ export default function EditPage() {
   const flags: AIFlag[] = aiEditResult?.Flags || aiVersion?.Flags || [];
   const changesMade: string[] = aiEditResult?.Changes_Made || aiVersion?.Changes_Made || [];
   const confidence = aiEditResult?.Confidence;
+  const canApproveFinal = ['new', 'ai_edited', 'in_review', 'approved'].includes(
+    submission.Status,
+  );
 
   const tabs: { id: Tab; label: string; available: boolean }[] = [
     { id: 'original', label: 'Original', available: true },
@@ -564,24 +541,40 @@ export default function EditPage() {
                   headlineCase={aiVersion?.Headline_Case || null}
                 />
                 <BodyEditor value={editBody} onChange={setEditBody} />
-                <div className="flex justify-end gap-3 pt-2">
-                  <Button
-                    onClick={handleSaveFinal}
-                    disabled={saveLoading}
-                    variant="primary"
-                    title="Save your manual edits without changing the submission status"
-                  >
-                    {saveLoading ? 'Saving...' : 'Save Final Version'}
-                  </Button>
-                  {submission.Status === 'in_review' && (
+                <div className="flex flex-col gap-3 border-t border-gray-200 pt-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-900">
+                      {canApproveFinal
+                        ? 'Ready for newsletter assembly?'
+                        : 'Save your work before leaving'}
+                    </p>
+                    <p className="mt-0.5 max-w-[65ch] text-xs text-gray-500">
+                      {canApproveFinal
+                        ? 'Save a draft for continued review, or approve the current text for the newsletter.'
+                        : 'This submission cannot be approved in its current status, but you can keep your edits as a draft.'}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 flex-wrap justify-end gap-2">
                     <Button
-                      onClick={handleApprove}
-                      variant="success"
-                      title="Mark this submission as approved and ready for the newsletter"
+                      onClick={() => void handleFinalize(false)}
+                      disabled={finalizationAction !== null}
+                      variant="secondary"
                     >
-                      Approve for Newsletter
+                      {finalizationAction === 'draft' ? 'Saving draft...' : 'Save Draft'}
                     </Button>
-                  )}
+                    {canApproveFinal && (
+                      <Button
+                        onClick={() => void handleFinalize(true)}
+                        disabled={finalizationAction !== null}
+                        variant="success"
+                        title="Save this final version and approve it for newsletter assembly"
+                      >
+                        {finalizationAction === 'approve'
+                          ? 'Saving and approving...'
+                          : 'Save and Approve'}
+                      </Button>
+                    )}
+                  </div>
                 </div>
               </div>
             )}
@@ -592,8 +585,7 @@ export default function EditPage() {
         <div className="space-y-4">
           <AIEditControls
             onTriggerEdit={handleTriggerEdit}
-            onAcceptEdit={handleAcceptEdit}
-            onRejectEdit={handleRejectEdit}
+            onReviewFinalEdit={handleReviewFinalEdit}
             loading={aiLoading}
             hasAIEdit={hasAIEdit}
             targetNewsletter={submission.Target_Newsletter}


### PR DESCRIPTION
## Summary

- remove the redundant `Accept AI Edit` action from the AI controls
- route AI suggestions into Final Edit for confirmation or manual adjustment
- present `Save Draft` as the secondary action and `Save and Approve` as the single primary finalization action
- save the editor-final version and approval status atomically in one backend transaction
- preserve the immutable original and complete edit-version history
- add focused backend and frontend regression coverage for AI suggestions, manual edits, draft saving, approval, and original preservation

## Why

The editor previously had to interpret and sequence three overlapping actions: `Accept AI Edit`, `Save Final Version`, and `Approve for Newsletter`. Saving and approval were also separate API calls, leaving a failure gap where the final version could persist without the status transition.

This change makes Final Edit the single confirmation surface. Editors can keep work in review with an explicitly labeled draft action or save and approve the current text in one operation.

## User and developer impact

Joy and other editors get one clear primary path into newsletter assembly, with confirmation messaging that distinguishes draft from approved state. The backend remains backward-compatible because finalization defaults to in-review unless approval is explicitly requested.

Related manual side-by-side editing (#63) and CTA/link editing (#202) remain separately scoped.

## Validation

- Backend: 138 tests passed
- Backend: Ruff passed
- Frontend: 40 tests passed
- Frontend: ESLint passed
- Frontend: production build passed

Closes #210.
