### PR TITLE
Fix academic dates entry in My UI Builder

### DIFF
--- a/backend/app/api/v1/newsletters.py
+++ b/backend/app/api/v1/newsletters.py
@@ -1,5 +1,8 @@
 """Newsletter CRUD and assembly API endpoints."""
 
+from datetime import datetime, time, timedelta
+import uuid
+
 import sqlalchemy as sa
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
@@ -15,6 +18,7 @@ from app.services import (
     schedule_service,
 )
 from app.schemas.newsletter import (
+    AcademicDateImportRequest,
     CalendarEventCandidateResponse,
     CalendarEventImportRequest,
     JobPostingCandidateResponse,
@@ -33,6 +37,38 @@ from app.schemas.recurring_message import RecurringMessageIssueCandidateResponse
 from app.utils.export import export_newsletter_docx
 
 router = APIRouter(prefix="/newsletters", tags=["newsletters"])
+
+ACADEMIC_DATES_SOURCE_URL = "https://www.uidaho.edu/registrar/dates-deadlines"
+ACADEMIC_DATES_WINDOW_DAYS = 30
+
+
+def _format_academic_date(value) -> str:
+    """Format a date using the AP-style month names required by UCM."""
+    month_names = {
+        1: "Jan.",
+        2: "Feb.",
+        3: "March",
+        4: "April",
+        5: "May",
+        6: "June",
+        7: "July",
+        8: "Aug.",
+        9: "Sept.",
+        10: "Oct.",
+        11: "Nov.",
+        12: "Dec.",
+    }
+    return f"{value.strftime('%A')}, {month_names[value.month]} {value.day}"
+
+
+def _build_academic_date_body(description: str | None) -> str:
+    """Keep pasted details intact and append the authoritative source link."""
+    source_link = (
+        f'<a href="{ACADEMIC_DATES_SOURCE_URL}">View the Registrar academic calendar</a>.'
+    )
+    if not description:
+        return source_link
+    return f"{description} {source_link}"
 
 
 @router.post("", response_model=NewsletterResponse, status_code=201)
@@ -373,6 +409,68 @@ async def add_job_posting(
         final_body=job_posting_service.build_job_body(posting),
     )
     return item
+
+
+@router.post(
+    "/{newsletter_id}/academic-dates",
+    response_model=NewsletterExternalItemResponse,
+    status_code=201,
+)
+async def add_academic_date(
+    newsletter_id: str,
+    data: AcademicDateImportRequest,
+    db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
+):
+    """Add a registrar date to My UI's Academic Dates and Deadlines section."""
+    newsletter = await newsletter_service.get_newsletter(db, newsletter_id)
+    if not newsletter:
+        raise HTTPException(status_code=404, detail="Newsletter not found")
+    if newsletter.Newsletter_Type != "myui":
+        raise HTTPException(
+            status_code=422,
+            detail="Academic dates and deadlines are only supported for My UI.",
+        )
+
+    last_included_date = newsletter.Publish_Date + timedelta(
+        days=ACADEMIC_DATES_WINDOW_DAYS
+    )
+    if not newsletter.Publish_Date <= data.Academic_Date <= last_included_date:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Academic dates must fall between the My UI publication date "
+                f"and the next {ACADEMIC_DATES_WINDOW_DAYS} days."
+            ),
+        )
+
+    section_result = await db.execute(
+        sa.select(NewsletterSection).where(
+            NewsletterSection.Newsletter_Type == "myui",
+            NewsletterSection.Slug == newsletter_service.get_academic_dates_section_slug(),
+            NewsletterSection.Is_Active == True,  # noqa: E712
+        )
+    )
+    section = section_result.scalar_one_or_none()
+    if not section:
+        raise HTTPException(
+            status_code=422,
+            detail="Academic Dates and Deadlines section is not configured",
+        )
+
+    return await newsletter_service.add_external_item(
+        db,
+        newsletter_id=newsletter_id,
+        section_id=section.Id,
+        source_type="academic_date",
+        source_id=f"manual-{uuid.uuid4()}",
+        source_url=ACADEMIC_DATES_SOURCE_URL,
+        event_start=datetime.combine(data.Academic_Date, time.min),
+        event_end=None,
+        location=None,
+        final_headline=f"{_format_academic_date(data.Academic_Date)} — {data.Title}",
+        final_body=_build_academic_date_body(data.Description),
+    )
 
 
 @router.patch("/{newsletter_id}/items/{item_id}", response_model=NewsletterItemResponse)

--- a/backend/app/schemas/newsletter.py
+++ b/backend/app/schemas/newsletter.py
@@ -236,6 +236,16 @@ class CalendarEventImportRequest(BaseModel):
     Event_End: datetime | None = None
 
 
+class AcademicDateImportRequest(BaseModel):
+    """A registrar date copied into a My UI newsletter issue."""
+
+    Academic_Date: date
+    Title: str = Field(..., min_length=1, max_length=500)
+    Description: str | None = Field(default=None, max_length=5000)
+
+    model_config = {"str_strip_whitespace": True}
+
+
 class JobPostingCandidateResponse(BaseModel):
     Source_Id: str
     Source_Type: str

--- a/backend/app/services/newsletter_service.py
+++ b/backend/app/services/newsletter_service.py
@@ -414,6 +414,11 @@ def get_job_postings_section_slug(newsletter_type: str) -> str:
     return "job-opportunities" if newsletter_type == "tdr" else "help-wanted"
 
 
+def get_academic_dates_section_slug() -> str:
+    """Return the My UI section slug used for manually imported registrar dates."""
+    return "academic-dates-and-deadlines"
+
+
 def _get_best_text(submission: Submission) -> tuple[str, str]:
     """Get the best available headline/body from edit versions."""
     if submission.Edit_Versions:

--- a/backend/tests/test_newsletters.py
+++ b/backend/tests/test_newsletters.py
@@ -631,6 +631,94 @@ class TestCalendarEventEndpoints:
 
 
 @pytest.mark.asyncio
+class TestAcademicDateEndpoints:
+    async def test_add_myui_academic_date_from_registrar_copy(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+    ):
+        section = NewsletterSection(
+            Newsletter_Type="myui",
+            Name="Academic Dates and Deadlines",
+            Slug="academic-dates-and-deadlines",
+            Display_Order=5,
+            Is_Active=True,
+        )
+        db.add(section)
+        await db.commit()
+
+        create_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(
+                Newsletter_Type="myui",
+                Publish_Date="2026-08-24",
+            ),
+            headers=staff_headers,
+        )
+        newsletter_id = create_resp.json()["Id"]
+
+        response = await client.post(
+            f"/api/v1/newsletters/{newsletter_id}/academic-dates",
+            json={
+                "Academic_Date": "2026-09-02",
+                "Title": "Register, add or wait list without permission",
+                "Description": "Full-term deadline.",
+            },
+            headers=staff_headers,
+        )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["Section_Id"] == section.Id
+        assert body["Source_Type"] == "academic_date"
+        assert body["Source_Url"] == "https://www.uidaho.edu/registrar/dates-deadlines"
+        assert body["Event_Start"] == "2026-09-02T00:00:00"
+        assert body["Final_Headline"] == (
+            "Wednesday, Sept. 2 — Register, add or wait list without permission"
+        )
+        assert "Full-term deadline." in body["Final_Body"]
+
+    async def test_rejects_academic_date_outside_myui_30_day_window(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+    ):
+        db.add(
+            NewsletterSection(
+                Newsletter_Type="myui",
+                Name="Academic Dates and Deadlines",
+                Slug="academic-dates-and-deadlines",
+                Display_Order=5,
+                Is_Active=True,
+            )
+        )
+        await db.commit()
+        create_resp = await client.post(
+            "/api/v1/newsletters",
+            json=make_newsletter_data(
+                Newsletter_Type="myui",
+                Publish_Date="2026-08-24",
+            ),
+            headers=staff_headers,
+        )
+
+        response = await client.post(
+            f"/api/v1/newsletters/{create_resp.json()['Id']}/academic-dates",
+            json={
+                "Academic_Date": "2026-09-24",
+                "Title": "Outside the newsletter window",
+                "Description": None,
+            },
+            headers=staff_headers,
+        )
+
+        assert response.status_code == 422
+        assert "30 days" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
 class TestJobPostingEndpoints:
     async def test_list_job_posting_candidates(
         self,

--- a/frontend/src/api/newsletters.ts
+++ b/frontend/src/api/newsletters.ts
@@ -167,6 +167,20 @@ export async function addCalendarEvent(
   });
 }
 
+export async function addAcademicDate(
+  newsletterId: string,
+  data: {
+    Academic_Date: string;
+    Title: string;
+    Description?: string | null;
+  },
+): Promise<NewsletterExternalItemResponse> {
+  return apiFetch<NewsletterExternalItemResponse>(`/newsletters/${newsletterId}/academic-dates`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
 export async function listJobPostings(
   newsletterId: string,
 ): Promise<JobPostingCandidate[]> {

--- a/frontend/src/pages/BuilderPage.test.tsx
+++ b/frontend/src/pages/BuilderPage.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BuilderPage from './BuilderPage';
+
+const newsletterApiMocks = vi.hoisted(() => ({
+  addAcademicDate: vi.fn(),
+  addCalendarEvent: vi.fn(),
+  addJobPosting: vi.fn(),
+  assembleNewsletter: vi.fn(),
+  getNewsletter: vi.fn(),
+  listCalendarEvents: vi.fn(),
+  listJobPostings: vi.fn(),
+  listNewsletters: vi.fn(),
+  listSections: vi.fn(),
+  removeNewsletterExternalItem: vi.fn(),
+  removeNewsletterItem: vi.fn(),
+  reorderNewsletterItems: vi.fn(),
+  updateNewsletterStatus: vi.fn(),
+}));
+
+vi.mock('../api/newsletters', () => ({
+  ...newsletterApiMocks,
+  getExportUrl: (newsletterId: string) => `/api/v1/newsletters/${newsletterId}/export`,
+}));
+
+vi.mock('../api/recurringMessages', () => ({
+  addRecurringMessageToNewsletter: vi.fn(),
+  listRecurringMessageCandidates: vi.fn().mockResolvedValue([]),
+  skipRecurringMessageForNewsletter: vi.fn(),
+}));
+
+const myUiSections = [
+  {
+    Id: 'section-news',
+    Newsletter_Type: 'myui' as const,
+    Name: 'News and Updates',
+    Slug: 'news-and-updates',
+    Display_Order: 1,
+    Description: null,
+    Requires_Image: false,
+    Image_Dimensions: null,
+    Is_Active: true,
+  },
+  {
+    Id: 'section-academic',
+    Newsletter_Type: 'myui' as const,
+    Name: 'Academic Dates and Deadlines',
+    Slug: 'academic-dates-and-deadlines',
+    Display_Order: 5,
+    Description: 'Include 30 days of upcoming information.',
+    Requires_Image: false,
+    Image_Dimensions: null,
+    Is_Active: true,
+  },
+];
+
+const newsletter = {
+  Id: 'newsletter-1',
+  Newsletter_Type: 'myui' as const,
+  Publish_Date: '2026-08-24',
+  Status: 'draft',
+  Created_At: '2026-08-01T12:00:00Z',
+  Updated_At: '2026-08-01T12:00:00Z',
+  Items: [],
+  External_Items: [],
+};
+
+const academicDateItem = {
+  Id: 'academic-date-1',
+  Newsletter_Id: newsletter.Id,
+  Section_Id: 'section-academic',
+  Source_Type: 'academic_date',
+  Source_Id: 'manual-academic-date-1',
+  Source_Url: 'https://www.uidaho.edu/registrar/dates-deadlines',
+  Event_Start: '2026-09-02T00:00:00',
+  Event_End: null,
+  Location: null,
+  Position: 0,
+  Final_Headline: 'Wednesday, Sept. 2 — Register, add or wait list without permission',
+  Final_Body: 'Full-term deadline.',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  newsletterApiMocks.listSections.mockImplementation(async (newsletterType?: string) => (
+    newsletterType === 'myui' ? myUiSections : []
+  ));
+  newsletterApiMocks.listNewsletters.mockResolvedValue([]);
+  newsletterApiMocks.listCalendarEvents.mockResolvedValue([]);
+  newsletterApiMocks.listJobPostings.mockResolvedValue([]);
+  newsletterApiMocks.assembleNewsletter.mockResolvedValue(newsletter);
+  newsletterApiMocks.addAcademicDate.mockResolvedValue(academicDateItem);
+  newsletterApiMocks.getNewsletter.mockResolvedValue({
+    ...newsletter,
+    External_Items: [academicDateItem],
+  });
+});
+
+describe('BuilderPage academic dates', () => {
+  it('lets a My UI editor paste and add a registrar deadline', async () => {
+    const user = userEvent.setup();
+    render(<BuilderPage />);
+
+    await user.selectOptions(screen.getAllByRole('combobox')[0], 'myui');
+    const publishDateInput = document.querySelector<HTMLInputElement>('input[type="date"]');
+    expect(publishDateInput).not.toBeNull();
+    await user.clear(publishDateInput!);
+    await user.type(publishDateInput!, '2026-08-24');
+    await user.click(screen.getAllByRole('button', { name: 'Assemble Newsletter' })[0]);
+
+    expect(await screen.findByRole('link', { name: /open registrar calendar/i })).toHaveAttribute(
+      'href',
+      'https://www.uidaho.edu/registrar/dates-deadlines',
+    );
+
+    const deadlineDate = screen.getByLabelText('Deadline date');
+    expect(deadlineDate).toHaveAttribute('min', '2026-08-24');
+    expect(deadlineDate).toHaveAttribute('max', '2026-09-23');
+    await user.type(deadlineDate, '2026-09-02');
+    await user.type(
+      screen.getByLabelText('Academic date or deadline'),
+      'Register, add or wait list without permission',
+    );
+    await user.type(screen.getByLabelText('Details (optional)'), 'Full-term deadline.');
+    await user.click(screen.getByRole('button', { name: 'Add academic date' }));
+
+    await waitFor(() => {
+      expect(newsletterApiMocks.addAcademicDate).toHaveBeenCalledWith('newsletter-1', {
+        Academic_Date: '2026-09-02',
+        Title: 'Register, add or wait list without permission',
+        Description: 'Full-term deadline.',
+      });
+    });
+  });
+});

--- a/frontend/src/pages/BuilderPage.tsx
+++ b/frontend/src/pages/BuilderPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import {
+  addAcademicDate,
   addJobPosting,
   addCalendarEvent,
   listNewsletters,
@@ -27,7 +28,10 @@ import type {
 import type { NewsletterSection } from '../types/newsletter';
 import type { RecurringMessageIssueCandidate } from '../types/recurringMessage';
 import { EmptyState, Toast, useToast } from '../components/common';
-import { parseISODate, todayISO } from '../utils/date';
+import { parseISODate, todayISO, toISODate } from '../utils/date';
+
+const ACADEMIC_DATES_SOURCE_URL = 'https://www.uidaho.edu/registrar/dates-deadlines';
+const ACADEMIC_DATES_WINDOW_DAYS = 30;
 
 interface BuilderSectionItemBase {
   Id: string;
@@ -72,6 +76,13 @@ type BuilderSectionItem =
   | (BuilderSectionItemBase & {
     Kind: 'recurring_message';
     Source_Id: string;
+    Source_Type: string;
+  })
+  | (BuilderSectionItemBase & {
+    Kind: 'academic_date';
+    Source_Id: string;
+    Source_Url: string | null;
+    Event_Start: string | null;
     Source_Type: string;
   });
 
@@ -169,6 +180,10 @@ export default function BuilderPage() {
   const [calendarError, setCalendarError] = useState<string | null>(null);
   const [jobLoading, setJobLoading] = useState(false);
   const [jobError, setJobError] = useState<string | null>(null);
+  const [academicDate, setAcademicDate] = useState('');
+  const [academicTitle, setAcademicTitle] = useState('');
+  const [academicDescription, setAcademicDescription] = useState('');
+  const [academicSaving, setAcademicSaving] = useState(false);
   const [panelOpen, setPanelOpen] = useState({
     recurringMessages: false,
     calendarEvents: false,
@@ -396,6 +411,31 @@ export default function BuilderPage() {
       showToast('Job posting added');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to add job posting');
+    }
+  };
+
+  const handleAddAcademicDate = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!newsletter || !academicDate || !academicTitle.trim()) return;
+
+    setAcademicSaving(true);
+    setError(null);
+    try {
+      await addAcademicDate(newsletter.Id, {
+        Academic_Date: academicDate,
+        Title: academicTitle.trim(),
+        Description: academicDescription.trim() || null,
+      });
+      const nl = await getNewsletter(newsletter.Id);
+      setNewsletter(nl);
+      setAcademicDate('');
+      setAcademicTitle('');
+      setAcademicDescription('');
+      showToast('Academic date added');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add academic date');
+    } finally {
+      setAcademicSaving(false);
     }
   };
 
@@ -647,7 +687,9 @@ export default function BuilderPage() {
         ? 'job_posting'
         : item.Source_Type === 'recurring_message'
           ? 'recurring_message'
-          : 'calendar_event',
+          : item.Source_Type === 'academic_date'
+            ? 'academic_date'
+            : 'calendar_event',
       Source_Url: item.Source_Url,
       Location: item.Location,
       Event_Start: item.Event_Start,
@@ -673,6 +715,13 @@ export default function BuilderPage() {
   );
 
   const sectionNameById = new Map(sections.map((section) => [section.Id, section.Name]));
+  const academicDateMax = newsletter
+    ? (() => {
+        const maxDate = parseISODate(newsletter.Publish_Date);
+        maxDate.setDate(maxDate.getDate() + ACADEMIC_DATES_WINDOW_DAYS);
+        return toISODate(maxDate);
+      })()
+    : '';
 
   const STATUS_COLORS: Record<string, string> = {
     draft: 'bg-status-muted-100 text-status-muted-800',
@@ -709,8 +758,11 @@ export default function BuilderPage() {
       <div className="bg-white rounded-lg shadow p-4 mb-6">
         <div className="flex gap-4 items-end flex-wrap">
           <div>
-            <label className="block text-xs text-gray-500 mb-1">Newsletter</label>
+            <label htmlFor="builder-newsletter-type" className="block text-xs text-gray-500 mb-1">
+              Newsletter
+            </label>
             <select
+              id="builder-newsletter-type"
               value={newsletterType}
               onChange={(e) => {
                 setNewsletterType(e.target.value as 'tdr' | 'myui');
@@ -723,8 +775,11 @@ export default function BuilderPage() {
             </select>
           </div>
           <div>
-            <label className="block text-xs text-gray-500 mb-1">Publish Date</label>
+            <label htmlFor="builder-publish-date" className="block text-xs text-gray-500 mb-1">
+              Publish Date
+            </label>
             <input
+              id="builder-publish-date"
               type="date"
               value={publishDate}
               onChange={(e) => setPublishDate(e.target.value)}
@@ -1108,6 +1163,8 @@ export default function BuilderPage() {
                 const submissionItems = submissionItemsBySection.get(section.Id) || [];
                 const isOpen = sectionOpen[section.Id] ?? true;
                 const isDropSection = dragState?.overSectionId === section.Id;
+                const isAcademicDatesSection = newsletterType === 'myui'
+                  && section.Slug === 'academic-dates-and-deadlines';
                 return (
                   <div key={section.Id} className="bg-white rounded-lg shadow">
                     <button
@@ -1134,15 +1191,109 @@ export default function BuilderPage() {
                           isDropSection ? 'bg-ui-gold-50/70 ring-2 ring-inset ring-ui-gold-300' : ''
                         }`}
                       >
+                        {isAcademicDatesSection && (
+                          <div className="border-b border-gray-100 bg-ui-clearwater-50/50 p-4">
+                            <div className="flex flex-wrap items-start justify-between gap-3">
+                              <div>
+                                <h5 className="text-sm font-semibold text-gray-900">
+                                  Add from the Registrar calendar
+                                </h5>
+                                <p className="mt-1 max-w-2xl text-xs text-gray-600">
+                                  Copy the date and wording from the official calendar. My UI includes
+                                  deadlines from the publication date through the next 30 days.
+                                </p>
+                              </div>
+                              <a
+                                href={ACADEMIC_DATES_SOURCE_URL}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-xs font-medium text-ui-clearwater-700 hover:text-ui-clearwater-900"
+                              >
+                                Open Registrar calendar ↗
+                              </a>
+                            </div>
+                            <form
+                              className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-6"
+                              onSubmit={handleAddAcademicDate}
+                            >
+                              <div className="md:col-span-2">
+                                <label
+                                  htmlFor="academic-deadline-date"
+                                  className="block text-xs font-medium text-gray-700"
+                                >
+                                  Deadline date
+                                </label>
+                                <input
+                                  id="academic-deadline-date"
+                                  type="date"
+                                  min={newsletter.Publish_Date}
+                                  max={academicDateMax}
+                                  value={academicDate}
+                                  onChange={(event) => setAcademicDate(event.target.value)}
+                                  required
+                                  className="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+                                />
+                              </div>
+                              <div className="md:col-span-4">
+                                <label
+                                  htmlFor="academic-deadline-title"
+                                  className="block text-xs font-medium text-gray-700"
+                                >
+                                  Academic date or deadline
+                                </label>
+                                <input
+                                  id="academic-deadline-title"
+                                  type="text"
+                                  value={academicTitle}
+                                  onChange={(event) => setAcademicTitle(event.target.value)}
+                                  placeholder="Paste the deadline wording"
+                                  required
+                                  className="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+                                />
+                              </div>
+                              <div className="md:col-span-4">
+                                <label
+                                  htmlFor="academic-deadline-details"
+                                  className="block text-xs font-medium text-gray-700"
+                                >
+                                  Details (optional)
+                                </label>
+                                <textarea
+                                  id="academic-deadline-details"
+                                  rows={2}
+                                  value={academicDescription}
+                                  onChange={(event) => setAcademicDescription(event.target.value)}
+                                  placeholder="Paste any audience or term details that should appear in My UI"
+                                  className="mt-1 w-full resize-y rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+                                />
+                              </div>
+                              <div className="flex items-end md:col-span-2">
+                                <button
+                                  type="submit"
+                                  disabled={academicSaving || !academicDate || !academicTitle.trim()}
+                                  className="w-full rounded-md bg-ui-gold-600 px-3 py-2 text-sm font-medium text-white hover:bg-ui-gold-700 disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                  {academicSaving ? 'Adding...' : 'Add academic date'}
+                                </button>
+                              </div>
+                            </form>
+                          </div>
+                        )}
                         {items.length === 0 ? (
                           <div className="px-4 py-6">
                             {isDropIndicatorVisible(section.Id, 0) && (
                               <div className="mb-3 rounded-full bg-ui-gold-500 h-1.5 w-full" />
                             )}
                             <div className="rounded-md border border-dashed border-gray-200 px-4 py-4 text-center">
-                              <p className="text-xs font-medium text-gray-500">No items in this section</p>
+                              <p className="text-xs font-medium text-gray-500">
+                                {isAcademicDatesSection
+                                  ? 'No academic dates added'
+                                  : 'No items in this section'}
+                              </p>
                               <p className="mt-1 text-xs text-gray-400">
-                                Approved submissions and imports can be moved here before export.
+                                {isAcademicDatesSection
+                                  ? 'Use the form above to add a Registrar deadline, or move an approved submission here.'
+                                  : 'Approved submissions can be moved here before export.'}
                               </p>
                             </div>
                           </div>
@@ -1197,6 +1348,11 @@ export default function BuilderPage() {
                                               Recurring
                                             </span>
                                           )}
+                                          {item.Kind === 'academic_date' && (
+                                            <span className="inline-flex items-center rounded-full bg-ui-clearwater-100 px-2 py-0.5 text-[11px] font-medium text-ui-clearwater-800">
+                                              Academic date
+                                            </span>
+                                          )}
                                         </div>
                                         <p className="text-xs text-gray-600 mt-1 line-clamp-2">
                                           {item.Final_Body.replace(/<[^>]+>/g, '')}
@@ -1220,6 +1376,16 @@ export default function BuilderPage() {
                                         )}
                                         {item.Kind === 'job_posting' && item.Location && (
                                           <p className="text-xs text-gray-400 mt-1">{item.Location}</p>
+                                        )}
+                                        {item.Kind === 'academic_date' && item.Source_Url && (
+                                          <a
+                                            href={item.Source_Url}
+                                            target="_blank"
+                                            rel="noreferrer"
+                                            className="mt-1 inline-block text-xs text-ui-clearwater-700 hover:text-ui-clearwater-900"
+                                          >
+                                            View Registrar source
+                                          </a>
                                         )}
                                       </div>
                                       <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity ml-2">


### PR DESCRIPTION
## Summary

- replace the misleading Academic Dates empty drop affordance with a paste-first form linked to the official Registrar calendar
- add a staff-only API path that creates source-linked academic-date items in the My UI section
- enforce the My UI publication-date-through-30-days window on both the form and server
- format imported deadlines using UCM/AP date style and identify them clearly in the Builder
- add frontend and backend regression coverage

## Root cause

The Builder rendered every empty section as a drop target, but its pointer-drag implementation only started from existing submission cards. Content dragged or pasted from the Registrar page therefore had no supported input path, and My UI calendar imports were routed to Weekly Events rather than Academic Dates and Deadlines.

## Impact

Editors can now copy a deadline from the Registrar calendar, enter its date and optional details, and add it directly to the correct My UI section. The official source remains attached to the newsletter item, and out-of-window dates are rejected consistently.

## Validation

- backend: 140 tests passed
- backend: Ruff checks passed
- frontend: 41 tests passed
- frontend: ESLint passed
- frontend: production TypeScript/Vite build passed
- local browser visual verification passed with no console warnings or errors

Closes #199
