### PR TITLE
Add student reminders Builder section

### DIFF
--- a/backend/data/sections/tdr_sections.json
+++ b/backend/data/sections/tdr_sections.json
@@ -61,5 +61,12 @@
     "display_order": 9,
     "description": "Recurring notices and reminders: tobacco-free, spirit days, sabbatical/tenure, risk control, recycling, etc.",
     "requires_image": false
+  },
+  {
+    "name": "Reminders for your students",
+    "slug": "reminders-for-your-students",
+    "display_order": 10,
+    "description": "Staff-curated reminders for employees to share with students. Items are added or moved here by UCM editors and are not a submitter category.",
+    "requires_image": false
   }
 ]

--- a/backend/tests/test_sections.py
+++ b/backend/tests/test_sections.py
@@ -1,0 +1,29 @@
+"""Tests for the data-driven newsletter section catalog."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import seed
+
+
+@pytest.mark.asyncio
+async def test_tdr_student_reminders_follow_employee_announcements(
+    client: AsyncClient,
+    db: AsyncSession,
+):
+    await seed.seed_sections(db)
+
+    response = await client.get(
+        "/api/v1/sections",
+        params={"newsletter_type": "tdr"},
+    )
+
+    assert response.status_code == 200
+    sections = response.json()
+    assert [section["Name"] for section in sections[-2:]] == [
+        "Employee Announcements",
+        "Reminders for your students",
+    ]
+    assert sections[-1]["Slug"] == "reminders-for-your-students"
+    assert sections[-1]["Display_Order"] == 10

--- a/frontend/src/components/submission/SubmissionForm.test.tsx
+++ b/frontend/src/components/submission/SubmissionForm.test.tsx
@@ -136,6 +136,15 @@ afterEach(() => {
 });
 
 describe('SubmissionForm', () => {
+  it('does not expose staff-only Builder sections as announcement types', async () => {
+    render(<SubmissionForm />);
+
+    await screen.findByRole('option', { name: 'Faculty or Staff Announcement' });
+    expect(
+      screen.queryByRole('option', { name: 'Reminders for your students' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('submits a standard announcement with links and scheduling notes', async () => {
     const user = userEvent.setup();
     render(<SubmissionForm />);

--- a/frontend/src/pages/BuilderPage.test.tsx
+++ b/frontend/src/pages/BuilderPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import BuilderPage from './BuilderPage';
@@ -55,6 +55,31 @@ const myUiSections = [
   },
 ];
 
+const tdrSections = [
+  {
+    Id: 'section-employee-announcements',
+    Newsletter_Type: 'tdr' as const,
+    Name: 'Employee Announcements',
+    Slug: 'employee-announcements',
+    Display_Order: 9,
+    Description: null,
+    Requires_Image: false,
+    Image_Dimensions: null,
+    Is_Active: true,
+  },
+  {
+    Id: 'section-student-reminders',
+    Newsletter_Type: 'tdr' as const,
+    Name: 'Reminders for your students',
+    Slug: 'reminders-for-your-students',
+    Display_Order: 10,
+    Description: null,
+    Requires_Image: false,
+    Image_Dimensions: null,
+    Is_Active: true,
+  },
+];
+
 const newsletter = {
   Id: 'newsletter-1',
   Newsletter_Type: 'myui' as const,
@@ -64,6 +89,25 @@ const newsletter = {
   Updated_At: '2026-08-01T12:00:00Z',
   Items: [],
   External_Items: [],
+};
+
+const tdrNewsletter = {
+  ...newsletter,
+  Id: 'tdr-newsletter-1',
+  Newsletter_Type: 'tdr' as const,
+  Publish_Date: '2026-08-25',
+  Items: [
+    {
+      Id: 'newsletter-item-1',
+      Newsletter_Id: 'tdr-newsletter-1',
+      Submission_Id: 'submission-1',
+      Section_Id: 'section-employee-announcements',
+      Position: 0,
+      Final_Headline: 'Registration reminder',
+      Final_Body: 'Please remind students to register.',
+      Run_Number: 1,
+    },
+  ],
 };
 
 const academicDateItem = {
@@ -84,16 +128,42 @@ const academicDateItem = {
 beforeEach(() => {
   vi.clearAllMocks();
   newsletterApiMocks.listSections.mockImplementation(async (newsletterType?: string) => (
-    newsletterType === 'myui' ? myUiSections : []
+    newsletterType === 'myui' ? myUiSections : tdrSections
   ));
   newsletterApiMocks.listNewsletters.mockResolvedValue([]);
   newsletterApiMocks.listCalendarEvents.mockResolvedValue([]);
   newsletterApiMocks.listJobPostings.mockResolvedValue([]);
-  newsletterApiMocks.assembleNewsletter.mockResolvedValue(newsletter);
+  newsletterApiMocks.assembleNewsletter.mockImplementation(async (request) => (
+    request.Newsletter_Type === 'tdr' ? tdrNewsletter : newsletter
+  ));
   newsletterApiMocks.addAcademicDate.mockResolvedValue(academicDateItem);
   newsletterApiMocks.getNewsletter.mockResolvedValue({
     ...newsletter,
     External_Items: [academicDateItem],
+  });
+});
+
+describe('BuilderPage staff-only sections', () => {
+  it('shows student reminders after employee announcements and in the move menu', async () => {
+    const user = userEvent.setup();
+    render(<BuilderPage />);
+
+    const publishDateInput = document.querySelector<HTMLInputElement>('input[type="date"]');
+    expect(publishDateInput).not.toBeNull();
+    await user.clear(publishDateInput!);
+    await user.type(publishDateInput!, '2026-08-25');
+    await user.click(screen.getAllByRole('button', { name: 'Assemble Newsletter' })[0]);
+
+    const sectionHeadings = await screen.findAllByRole('heading', { level: 4 });
+    expect(sectionHeadings.map((heading) => heading.textContent)).toEqual([
+      'Employee Announcements',
+      'Reminders for your students',
+    ]);
+
+    const moveMenu = screen.getByTitle('Move to section');
+    expect(
+      within(moveMenu).getByRole('option', { name: 'Reminders for your students' }),
+    ).toHaveValue('section-student-reminders');
   });
 });
 


### PR DESCRIPTION
## Summary

- add the TDR “Reminders for your students” section directly after Employee Announcements
- expose the section automatically in the staff Builder and item move menu
- keep the submitter announcement-type list unchanged
- add backend ordering and frontend visibility regression coverage

## Why

Editors need a dedicated place for reminders that employees should pass along to students. This is a staff-curated newsletter destination, not a new submission category.

## Impact

The normal idempotent section seeder adds the new section to existing deployments. Editors can move items into it in the Builder, while submitters see no new announcement type. No hard-coded category mapping is introduced.

## Validation

- backend: 146 tests passed
- frontend: 43 tests passed
- Ruff passed
- ESLint passed
- production TypeScript/Vite build passed

Closes #200
