### PR TITLE
Improve editor links and Builder editing

### DIFF
--- a/backend/app/api/v1/ai_edits.py
+++ b/backend/app/api/v1/ai_edits.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import selectinload
 from app.config import settings
 from app.api.deps import get_db, require_staff
 from app.db.engine import async_session_factory
-from app.models.submission import Submission
+from app.models.submission import Submission, SubmissionLink
 from app.models.edit_history import EditVersion
 from app.services.ai.factory import get_llm_provider
 from app.services.ai.editor import AIEditor, AIEditError, EditResult
@@ -331,6 +331,22 @@ async def save_editor_final(
         Headline_Case=data.Headline_Case,
     )
     session.add(version)
+
+    if data.Links is not None:
+        await session.execute(
+            sa.delete(SubmissionLink).where(
+                SubmissionLink.Submission_Id == submission_id,
+            )
+        )
+        for index, link_data in enumerate(data.Links):
+            session.add(
+                SubmissionLink(
+                    Submission_Id=submission_id,
+                    Url=link_data.Url,
+                    Anchor_Text=link_data.Anchor_Text,
+                    Display_Order=link_data.Display_Order or index,
+                )
+            )
 
     submission.Status = "approved" if data.Approve_For_Newsletter else "in_review"
     await session.commit()

--- a/backend/app/api/v1/submissions.py
+++ b/backend/app/api/v1/submissions.py
@@ -227,7 +227,10 @@ async def delete_submission(
 
 @router.post("/{submission_id}/links", response_model=LinkResponse, status_code=201)
 async def add_link(
-    submission_id: str, data: LinkCreate, db: AsyncSession = Depends(get_db)
+    submission_id: str,
+    data: LinkCreate,
+    db: AsyncSession = Depends(get_db),
+    _staff: None = Depends(require_staff),
 ):
     link = await submission_service.add_link(
         db, submission_id, url=data.Url, anchor_text=data.Anchor_Text, display_order=data.Display_Order,

--- a/backend/app/schemas/ai_edit.py
+++ b/backend/app/schemas/ai_edit.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from app.schemas.submission import LinkCreate
+
 
 class AIEditRequest(BaseModel):
     """Request to trigger AI editing on a submission."""
@@ -88,6 +90,7 @@ class EditorFinalCreate(BaseModel):
     Body: str = Field(..., min_length=1)
     Headline_Case: str | None = Field(None, pattern=r"^(sentence_case|title_case)$")
     Approve_For_Newsletter: bool = False
+    Links: list[LinkCreate] | None = Field(None, max_length=3)
 
 
 # --- Style rules schemas ---

--- a/backend/app/schemas/submission.py
+++ b/backend/app/schemas/submission.py
@@ -1,15 +1,49 @@
+import re
 from datetime import date, datetime
+from urllib.parse import urlsplit
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 # --- Link schemas ---
 
+EMAIL_ADDRESS_PATTERN = re.compile(
+    r"^[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@"
+    r"[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?"
+    r"(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)+$",
+    re.IGNORECASE,
+)
+
 
 class LinkCreate(BaseModel):
-    Url: str
-    Anchor_Text: str | None = None
+    Url: str = Field(..., min_length=1, max_length=2048)
+    Anchor_Text: str | None = Field(None, max_length=500)
     Display_Order: int = 0
+
+    @field_validator("Url", mode="before")
+    @classmethod
+    def validate_and_normalize_url(cls, value: object) -> str:
+        if not isinstance(value, str):
+            raise ValueError("Link destination must be a URL or email address")
+
+        normalized = value.strip()
+        if EMAIL_ADDRESS_PATTERN.fullmatch(normalized):
+            return f"mailto:{normalized}"
+
+        parsed = urlsplit(normalized)
+        if parsed.scheme == "https" and parsed.netloc and not (
+            parsed.username or parsed.password
+        ):
+            return normalized
+        if (
+            parsed.scheme == "mailto"
+            and EMAIL_ADDRESS_PATTERN.fullmatch(parsed.path)
+            and not parsed.query
+            and not parsed.fragment
+        ):
+            return f"mailto:{parsed.path}"
+
+        raise ValueError("Link destination must use https:// or be an email address")
 
 
 class LinkResponse(BaseModel):
@@ -86,7 +120,7 @@ class SubmissionCreate(BaseModel):
     Survey_End_Date: date | None = None
     Show_In_SLC_Calendar: bool = False
     Event_Classification: str | None = Field(None, pattern=r"^(strategic|signature)$")
-    Links: list[LinkCreate] = []
+    Links: list[LinkCreate] = Field(default_factory=list, max_length=3)
     Schedule_Requests: list[ScheduleRequestCreate] = Field(..., min_length=1)
 
 

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -285,6 +285,49 @@ class TestAIEditTasks:
 
 @pytest.mark.asyncio
 class TestFinalizePreservesOriginal:
+    async def test_finalize_replaces_links_with_validated_editor_links(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+    ):
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Links=[{"Url": "https://old.example.com", "Anchor_Text": "Old link"}],
+            ),
+        )
+        submission_id = submission_resp.json()["Id"]
+
+        finalize_resp = await client.post(
+            f"/api/v1/ai-edits/{submission_id}/finalize",
+            json={
+                "Headline": "Editor headline",
+                "Body": 'Contact <a href="mailto:questions@uidaho.edu">UCM</a>.',
+                "Links": [
+                    {
+                        "Url": "questions@uidaho.edu",
+                        "Anchor_Text": "UCM",
+                    }
+                ],
+            },
+            headers=staff_headers,
+        )
+
+        assert finalize_resp.status_code == 200
+        detail_resp = await client.get(
+            f"/api/v1/submissions/{submission_id}",
+            headers=staff_headers,
+        )
+        assert detail_resp.status_code == 200
+        assert detail_resp.json()["Links"] == [
+            {
+                "Id": detail_resp.json()["Links"][0]["Id"],
+                "Url": "mailto:questions@uidaho.edu",
+                "Anchor_Text": "UCM",
+                "Display_Order": 0,
+            }
+        ]
+
     async def test_finalize_without_prior_ai_edit_keeps_original_and_snapshots_it(
         self,
         client: AsyncClient,

--- a/backend/tests/test_submissions.py
+++ b/backend/tests/test_submissions.py
@@ -38,6 +38,33 @@ class TestSubmissionCRUD:
         assert len(body["Links"]) == 1
         assert body["Links"][0]["Url"] == "https://example.com"
 
+    async def test_create_submission_normalizes_email_link(self, client: AsyncClient):
+        data = make_submission_data(
+            Links=[{"Url": "contact@uidaho.edu", "Anchor_Text": "UCM contact"}]
+        )
+
+        resp = await client.post("/api/v1/submissions/", json=data)
+
+        assert resp.status_code == 201
+        assert resp.json()["Links"][0]["Url"] == "mailto:contact@uidaho.edu"
+
+    @pytest.mark.parametrize(
+        "unsafe_url",
+        ["http://example.com", "javascript:alert(1)", "ftp://example.com/file"],
+    )
+    async def test_create_submission_rejects_unsafe_link_schemes(
+        self,
+        client: AsyncClient,
+        unsafe_url: str,
+    ):
+        data = make_submission_data(
+            Links=[{"Url": unsafe_url, "Anchor_Text": "Unsafe link"}]
+        )
+
+        resp = await client.post("/api/v1/submissions/", json=data)
+
+        assert resp.status_code == 422
+
     async def test_create_submission_with_schedule(self, client: AsyncClient):
         data = make_submission_data(
             Schedule_Requests=[{"Requested_Date": "2026-03-15", "Repeat_Count": 2}]
@@ -316,7 +343,19 @@ class TestSubmissionCRUD:
 @pytest.mark.asyncio
 @freeze_time(FROZEN_TODAY)
 class TestSubmissionLinks:
-    async def test_add_link(self, client: AsyncClient):
+    async def test_add_link(self, client: AsyncClient, staff_headers: dict[str, str]):
+        create_resp = await client.post("/api/v1/submissions/", json=make_submission_data())
+        sub_id = create_resp.json()["Id"]
+
+        resp = await client.post(
+            f"/api/v1/submissions/{sub_id}/links",
+            json={"Url": "https://test.com", "Anchor_Text": "Test"},
+            headers=staff_headers,
+        )
+        assert resp.status_code == 201
+        assert resp.json()["Url"] == "https://test.com"
+
+    async def test_public_cannot_add_link_to_existing_submission(self, client: AsyncClient):
         create_resp = await client.post("/api/v1/submissions/", json=make_submission_data())
         sub_id = create_resp.json()["Id"]
 
@@ -324,8 +363,8 @@ class TestSubmissionLinks:
             f"/api/v1/submissions/{sub_id}/links",
             json={"Url": "https://test.com", "Anchor_Text": "Test"},
         )
-        assert resp.status_code == 201
-        assert resp.json()["Url"] == "https://test.com"
+
+        assert resp.status_code == 403
 
     async def test_delete_link(self, client: AsyncClient, staff_headers: dict[str, str]):
         data = make_submission_data(

--- a/frontend/src/api/aiEdits.ts
+++ b/frontend/src/api/aiEdits.ts
@@ -61,6 +61,11 @@ export async function saveEditorFinal(
     Body: string;
     Headline_Case?: string;
     Approve_For_Newsletter?: boolean;
+    Links?: Array<{
+      Url: string;
+      Anchor_Text?: string;
+      Display_Order?: number;
+    }>;
   },
 ): Promise<EditVersion> {
   return apiFetch<EditVersion>(`/ai-edits/${submissionId}/finalize`, {

--- a/frontend/src/components/editor/RichBody.test.tsx
+++ b/frontend/src/components/editor/RichBody.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import RichBody from './RichBody';
+
+describe('RichBody', () => {
+  it('renders https and email anchors as live links', () => {
+    render(
+      <RichBody text={'Read <a href="https://example.com">the guide</a> or <a href="mailto:help@uidaho.edu">email UCM</a>.'} />,
+    );
+
+    expect(screen.getByRole('link', { name: 'the guide' })).toHaveAttribute(
+      'href',
+      'https://example.com',
+    );
+    expect(screen.getByRole('link', { name: 'email UCM' })).toHaveAttribute(
+      'href',
+      'mailto:help@uidaho.edu',
+    );
+  });
+
+  it('renders unsafe anchors as plain text', () => {
+    render(<RichBody text={'Do not <a href="javascript:alert(1)">open this</a>.'} />);
+
+    expect(screen.queryByRole('link', { name: 'open this' })).not.toBeInTheDocument();
+    expect(screen.getByText(/open this/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/editor/RichBody.tsx
+++ b/frontend/src/components/editor/RichBody.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { isSafeLinkDestination } from '../../utils/bodyLinks';
 
 interface RichBodyProps {
   text: string;
@@ -20,7 +21,11 @@ export default function RichBody({ text, className = '' }: RichBodyProps) {
       if (match.index > lastIndex) {
         result.push({ type: 'text', text: text.slice(lastIndex, match.index) });
       }
-      result.push({ type: 'link', text: match[2], href: match[1] });
+      result.push(
+        isSafeLinkDestination(match[1])
+          ? { type: 'link', text: match[2], href: match[1] }
+          : { type: 'text', text: match[2] },
+      );
       lastIndex = match.index + match[0].length;
     }
 
@@ -38,9 +43,9 @@ export default function RichBody({ text, className = '' }: RichBodyProps) {
           <a
             key={i}
             href={part.href}
-            target="_blank"
+            target={part.href?.startsWith('mailto:') ? undefined : '_blank'}
             rel="noopener noreferrer"
-            className="text-blue-600 hover:underline"
+            className="text-ui-clearwater-700 underline decoration-ui-clearwater-300 underline-offset-2 hover:text-ui-clearwater-900"
           >
             {part.text}
           </a>

--- a/frontend/src/components/submission/LinkEditor.tsx
+++ b/frontend/src/components/submission/LinkEditor.tsx
@@ -1,4 +1,4 @@
-interface LinkEntry {
+export interface LinkEntry {
   Url: string;
   Anchor_Text: string;
 }
@@ -6,6 +6,8 @@ interface LinkEntry {
 interface Props {
   links: LinkEntry[];
   onChange: (links: LinkEntry[]) => void;
+  label?: string;
+  description?: string;
 }
 
 const MAX_LINKS = 3;
@@ -18,7 +20,12 @@ function ensureSlots(links: LinkEntry[]): LinkEntry[] {
   return slots.slice(0, MAX_LINKS);
 }
 
-export default function LinkEditor({ links, onChange }: Props) {
+export default function LinkEditor({
+  links,
+  onChange,
+  label = 'Links to Embed',
+  description = `Add up to ${MAX_LINKS} web URLs or email addresses to embed in your announcement.`,
+}: Props) {
   const slots = ensureSlots(links);
 
   const updateLink = (index: number, field: keyof LinkEntry, value: string) => {
@@ -51,10 +58,10 @@ export default function LinkEditor({ links, onChange }: Props) {
   return (
     <div>
       <label className="block text-sm font-medium text-gray-700 mb-2">
-        Links to Embed
+        {label}
       </label>
       <p className="text-xs text-gray-500 mb-3">
-        Add up to {MAX_LINKS} web URLs or email addresses to embed in your announcement.
+        {description}
       </p>
       <div className="space-y-3">
         {slots.map((link, index) => {

--- a/frontend/src/pages/BuilderPage.test.tsx
+++ b/frontend/src/pages/BuilderPage.test.tsx
@@ -16,6 +16,7 @@ const newsletterApiMocks = vi.hoisted(() => ({
   removeNewsletterExternalItem: vi.fn(),
   removeNewsletterItem: vi.fn(),
   reorderNewsletterItems: vi.fn(),
+  updateNewsletterItem: vi.fn(),
   updateNewsletterStatus: vi.fn(),
 }));
 
@@ -104,7 +105,7 @@ const tdrNewsletter = {
       Section_Id: 'section-employee-announcements',
       Position: 0,
       Final_Headline: 'Registration reminder',
-      Final_Body: 'Please remind students to register.',
+      Final_Body: 'Please remind students to register. This is the complete approved entry. <a href="https://example.com/register">Review registration details</a>.',
       Run_Number: 1,
     },
   ],
@@ -164,6 +165,54 @@ describe('BuilderPage staff-only sections', () => {
     expect(
       within(moveMenu).getByRole('option', { name: 'Reminders for your students' }),
     ).toHaveValue('section-student-reminders');
+  });
+
+  it('shows the full approved entry and saves manual edits in place', async () => {
+    const user = userEvent.setup();
+    newsletterApiMocks.getNewsletter.mockResolvedValue(tdrNewsletter);
+    newsletterApiMocks.updateNewsletterItem.mockResolvedValue({
+      ...tdrNewsletter.Items[0],
+      Final_Headline: 'Updated registration reminder',
+      Final_Body: 'Updated approved copy. <a href="https://example.com/register">Review registration details</a>.',
+    });
+    render(<BuilderPage />);
+
+    const publishDateInput = document.querySelector<HTMLInputElement>('input[type="date"]');
+    expect(publishDateInput).not.toBeNull();
+    await user.clear(publishDateInput!);
+    await user.type(publishDateInput!, '2026-08-25');
+    await user.click(screen.getAllByRole('button', { name: 'Assemble Newsletter' })[0]);
+
+    expect(await screen.findByText(/This is the complete approved entry/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Review registration details' })).toHaveAttribute(
+      'href',
+      'https://example.com/register',
+    );
+
+    await user.click(screen.getByRole('button', { name: /edit registration reminder/i }));
+    const headline = screen.getByLabelText('Newsletter headline');
+    const body = screen.getByLabelText('Newsletter body');
+    expect(body).toHaveValue(
+      'Please remind students to register. This is the complete approved entry. Review registration details.',
+    );
+    expect(body).not.toHaveValue(expect.stringContaining('<a'));
+
+    await user.clear(headline);
+    await user.type(headline, 'Updated registration reminder');
+    await user.clear(body);
+    await user.type(body, 'Updated approved copy. Review registration details.');
+    await user.click(screen.getByRole('button', { name: 'Save newsletter text' }));
+
+    await waitFor(() => {
+      expect(newsletterApiMocks.updateNewsletterItem).toHaveBeenCalledWith(
+        'tdr-newsletter-1',
+        'newsletter-item-1',
+        {
+          Final_Headline: 'Updated registration reminder',
+          Final_Body: 'Updated approved copy. <a href="https://example.com/register">Review registration details</a>.',
+        },
+      );
+    });
   });
 });
 

--- a/frontend/src/pages/BuilderPage.tsx
+++ b/frontend/src/pages/BuilderPage.tsx
@@ -14,6 +14,7 @@ import {
   reorderNewsletterItems,
   getExportUrl,
   listSections,
+  updateNewsletterItem,
 } from '../api/newsletters';
 import {
   addRecurringMessageToNewsletter,
@@ -28,6 +29,12 @@ import type {
 import type { NewsletterSection } from '../types/newsletter';
 import type { RecurringMessageIssueCandidate } from '../types/recurringMessage';
 import { EmptyState, Toast, useToast } from '../components/common';
+import RichBody from '../components/editor/RichBody';
+import {
+  buildLinkedBody,
+  prepareBodyForEditing,
+  type EditableBodyLink,
+} from '../utils/bodyLinks';
 import { parseISODate, todayISO, toISODate } from '../utils/date';
 
 const ACADEMIC_DATES_SOURCE_URL = 'https://www.uidaho.edu/registrar/dates-deadlines';
@@ -53,6 +60,13 @@ interface SubmissionDragState {
   width: number;
   height: number;
   title: string;
+}
+
+interface NewsletterItemEditDraft {
+  Item_Id: string;
+  Headline: string;
+  Body: string;
+  Links: EditableBodyLink[];
 }
 
 type BuilderSectionItem =
@@ -194,6 +208,8 @@ export default function BuilderPage() {
   const [error, setError] = useState<string | null>(null);
   const { toast, showToast, dismissToast } = useToast();
   const [dragState, setDragState] = useState<SubmissionDragState | null>(null);
+  const [itemEditDraft, setItemEditDraft] = useState<NewsletterItemEditDraft | null>(null);
+  const [itemEditSaving, setItemEditSaving] = useState(false);
   const dragStateRef = useRef<SubmissionDragState | null>(null);
   const newsletterId = newsletter?.Id;
 
@@ -554,6 +570,47 @@ export default function BuilderPage() {
       showToast(`Status updated to ${status.replace('_', ' ')}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update status');
+    }
+  };
+
+  const beginNewsletterItemEdit = (
+    item: Extract<BuilderSectionItem, { Kind: 'submission' }>,
+  ) => {
+    const editable = prepareBodyForEditing(item.Final_Body);
+    setItemEditDraft({
+      Item_Id: item.Id,
+      Headline: item.Final_Headline,
+      Body: editable.body,
+      Links: editable.links,
+    });
+  };
+
+  const handleSaveNewsletterItem = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!newsletter || !itemEditDraft) return;
+
+    const headline = itemEditDraft.Headline.trim();
+    const body = itemEditDraft.Body.trim();
+    if (!headline || !body) {
+      setError('Newsletter headline and body are required');
+      return;
+    }
+
+    setItemEditSaving(true);
+    setError(null);
+    try {
+      await updateNewsletterItem(newsletter.Id, itemEditDraft.Item_Id, {
+        Final_Headline: headline,
+        Final_Body: buildLinkedBody(body, itemEditDraft.Links),
+      });
+      const refreshed = await getNewsletter(newsletter.Id);
+      setNewsletter(refreshed);
+      setItemEditDraft(null);
+      showToast('Newsletter text updated');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update newsletter text');
+    } finally {
+      setItemEditSaving(false);
     }
   };
 
@@ -1354,9 +1411,10 @@ export default function BuilderPage() {
                                             </span>
                                           )}
                                         </div>
-                                        <p className="text-xs text-gray-600 mt-1 line-clamp-2">
-                                          {item.Final_Body.replace(/<[^>]+>/g, '')}
-                                        </p>
+                                        <RichBody
+                                          text={item.Final_Body}
+                                          className="mt-2 max-w-[75ch] text-xs leading-5 text-gray-600"
+                                        />
                                         {item.Kind === 'submission' && item.Run_Number > 1 && (
                                           <span className="text-xs text-ui-gold-600 mt-1 inline-block">
                                             Run #{item.Run_Number}
@@ -1388,9 +1446,17 @@ export default function BuilderPage() {
                                           </a>
                                         )}
                                       </div>
-                                      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity ml-2">
+                                      <div className="ml-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
                                         {item.Kind === 'submission' && (
                                           <>
+                                            <button
+                                              type="button"
+                                              onClick={() => beginNewsletterItemEdit(item)}
+                                              className="rounded px-2 py-1 text-xs font-medium text-ui-clearwater-700 hover:bg-ui-clearwater-50 hover:text-ui-clearwater-900"
+                                              aria-label={`Edit ${item.Final_Headline}`}
+                                            >
+                                              Edit
+                                            </button>
                                             <button
                                               type="button"
                                               onPointerDown={(event) => startSubmissionDrag(item, event)}
@@ -1442,6 +1508,75 @@ export default function BuilderPage() {
                                         </button>
                                       </div>
                                     </div>
+                                    {item.Kind === 'submission' && itemEditDraft?.Item_Id === item.Id && (
+                                      <form
+                                        onSubmit={(event) => void handleSaveNewsletterItem(event)}
+                                        className="mt-4 space-y-3 border-t border-gray-200 pt-4"
+                                      >
+                                        <div>
+                                          <label
+                                            htmlFor={`builder-item-${item.Id}-headline`}
+                                            className="mb-1 block text-xs font-medium text-gray-600"
+                                          >
+                                            Newsletter headline
+                                          </label>
+                                          <input
+                                            id={`builder-item-${item.Id}-headline`}
+                                            type="text"
+                                            value={itemEditDraft.Headline}
+                                            onChange={(event) => setItemEditDraft((current) => (
+                                              current ? { ...current, Headline: event.target.value } : current
+                                            ))}
+                                            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
+                                          />
+                                        </div>
+                                        <div>
+                                          <label
+                                            htmlFor={`builder-item-${item.Id}-body`}
+                                            className="mb-1 block text-xs font-medium text-gray-600"
+                                          >
+                                            Newsletter body
+                                          </label>
+                                          <textarea
+                                            id={`builder-item-${item.Id}-body`}
+                                            value={itemEditDraft.Body}
+                                            onChange={(event) => setItemEditDraft((current) => (
+                                              current ? { ...current, Body: event.target.value } : current
+                                            ))}
+                                            rows={6}
+                                            className="w-full resize-y rounded-md border border-gray-300 px-3 py-2 text-sm leading-6 focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
+                                          />
+                                        </div>
+                                        {itemEditDraft.Links.length > 0 && (
+                                          <div className="rounded-md border border-gray-200 bg-gray-50 px-3 py-2">
+                                            <p className="mb-1 text-[11px] font-medium text-gray-500">
+                                              Live link preview
+                                            </p>
+                                            <RichBody
+                                              text={buildLinkedBody(itemEditDraft.Body, itemEditDraft.Links)}
+                                              className="text-xs leading-5 text-gray-700"
+                                            />
+                                          </div>
+                                        )}
+                                        <div className="flex justify-end gap-2">
+                                          <button
+                                            type="button"
+                                            onClick={() => setItemEditDraft(null)}
+                                            disabled={itemEditSaving}
+                                            className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                                          >
+                                            Cancel
+                                          </button>
+                                          <button
+                                            type="submit"
+                                            disabled={itemEditSaving}
+                                            className="rounded-md bg-ui-clearwater-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-ui-clearwater-800 disabled:opacity-50"
+                                          >
+                                            {itemEditSaving ? 'Saving...' : 'Save newsletter text'}
+                                          </button>
+                                        </div>
+                                      </form>
+                                    )}
                                   </div>
                                   {showIndicatorAfter && (
                                     <div className="px-4 pb-1">

--- a/frontend/src/pages/EditPage.test.tsx
+++ b/frontend/src/pages/EditPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -316,6 +316,64 @@ describe('EditPage', () => {
     expect(
       await screen.findByText('Final version saved and approved for newsletter'),
     ).toBeInTheDocument();
+  });
+
+  it('shows live CTA links while keeping destination fields separately editable', async () => {
+    const user = userEvent.setup();
+    getSubmissionMock.mockResolvedValue(makeSubmission({
+      Links: [
+        {
+          Id: 'link-1',
+          Url: 'https://example.com/register',
+          Anchor_Text: 'Register now',
+          Display_Order: 0,
+        },
+      ],
+    }));
+    listEditVersionsMock.mockResolvedValue([
+      makeVersion({
+        Version_Type: 'editor_final',
+        Headline: 'Final event headline',
+        Body: 'Reserve a seat. <a href="https://example.com/register">Register now</a>.',
+      }),
+    ]);
+
+    renderEditPage();
+
+    const preview = await screen.findByRole('region', { name: 'Newsletter body preview' });
+    expect(within(preview).getByRole('link', { name: 'Register now' })).toHaveAttribute(
+      'href',
+      'https://example.com/register',
+    );
+    expect(screen.getByPlaceholderText('Enter body text...')).toHaveValue(
+      'Reserve a seat. Register now.',
+    );
+    expect(screen.getByPlaceholderText('Enter body text...')).not.toHaveValue(
+      expect.stringContaining('<a'),
+    );
+
+    await user.click(screen.getAllByRole('button', { name: 'Switch to email link' })[0]);
+    await user.type(screen.getByLabelText('Email address'), 'events@uidaho.edu');
+    const linkText = screen.getByLabelText("Link text (person's name or email address)");
+    await user.clear(linkText);
+    await user.type(linkText, 'UCM events');
+    await user.click(screen.getByRole('button', { name: /save draft/i }));
+
+    await waitFor(() => {
+      expect(saveEditorFinalMock).toHaveBeenCalledWith('submission-1', {
+        Headline: 'Final event headline',
+        Body: 'Reserve a seat. Register now.\n<a href="mailto:events@uidaho.edu">UCM events</a>',
+        Headline_Case: undefined,
+        Approve_For_Newsletter: false,
+        Links: [
+          {
+            Url: 'mailto:events@uidaho.edu',
+            Anchor_Text: 'UCM events',
+            Display_Order: 0,
+          },
+        ],
+      });
+    });
   });
 
   it('keeps the explicit draft action distinct from approval', async () => {

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -19,7 +19,13 @@ import ChangesList from '../components/editor/ChangesList';
 import SideBySideView from '../components/editor/SideBySideView';
 import SubmissionMeta from '../components/editor/SubmissionMeta';
 import RichBody from '../components/editor/RichBody';
+import LinkEditor, { type LinkEntry } from '../components/submission/LinkEditor';
 import { getSubmitterRole } from '../utils/submitterRole';
+import {
+  buildLinkedBody,
+  normalizedBodyLinks,
+  prepareBodyForEditing,
+} from '../utils/bodyLinks';
 import { Button, SegmentedToggle, Toast, useToast } from '../components/common';
 
 type Tab = 'original' | 'ai_edit' | 'editor';
@@ -58,6 +64,7 @@ export default function EditPage() {
   // Editor state
   const [editHeadline, setEditHeadline] = useState('');
   const [editBody, setEditBody] = useState('');
+  const [editLinks, setEditLinks] = useState<LinkEntry[]>([]);
   const [assignedEditor, setAssignedEditor] = useState('');
   const [editorialNotes, setEditorialNotes] = useState('');
   const isStaff = getSubmitterRole() === 'staff';
@@ -80,20 +87,28 @@ export default function EditPage() {
           const aiVersion = [...vers].reverse().find((v) => v.Version_Type === 'ai_suggested');
           const editorVersion = [...vers].reverse().find((v) => v.Version_Type === 'editor_final');
           if (editorVersion) {
+            const editable = prepareBodyForEditing(editorVersion.Body, sub.Links);
             setEditHeadline(editorVersion.Headline);
-            setEditBody(editorVersion.Body);
+            setEditBody(editable.body);
+            setEditLinks(editable.links);
             setActiveTab('editor');
           } else if (aiVersion) {
+            const editable = prepareBodyForEditing(aiVersion.Body, sub.Links);
             setEditHeadline(aiVersion.Headline);
-            setEditBody(aiVersion.Body);
+            setEditBody(editable.body);
+            setEditLinks(editable.links);
             setActiveTab('ai_edit');
           } else {
+            const editable = prepareBodyForEditing(sub.Original_Body, sub.Links);
             setEditHeadline(sub.Original_Headline);
-            setEditBody(sub.Original_Body);
+            setEditBody(editable.body);
+            setEditLinks(editable.links);
           }
         } catch {
+          const editable = prepareBodyForEditing(sub.Original_Body, sub.Links);
           setEditHeadline(sub.Original_Headline);
-          setEditBody(sub.Original_Body);
+          setEditBody(editable.body);
+          setEditLinks(editable.links);
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load submission');
@@ -120,21 +135,29 @@ export default function EditPage() {
         const aiVersion = [...vers].reverse().find((v) => v.Version_Type === 'ai_suggested');
         const editorVersion = [...vers].reverse().find((v) => v.Version_Type === 'editor_final');
         if (editorVersion) {
+          const editable = prepareBodyForEditing(editorVersion.Body, sub.Links);
           setEditHeadline(editorVersion.Headline);
-          setEditBody(editorVersion.Body);
+          setEditBody(editable.body);
+          setEditLinks(editable.links);
           setActiveTab('editor');
         } else if (aiVersion) {
+          const editable = prepareBodyForEditing(aiVersion.Body, sub.Links);
           setEditHeadline(aiVersion.Headline);
-          setEditBody(aiVersion.Body);
+          setEditBody(editable.body);
+          setEditLinks(editable.links);
           setActiveTab('ai_edit');
         } else {
+          const editable = prepareBodyForEditing(sub.Original_Body, sub.Links);
           setEditHeadline(sub.Original_Headline);
-          setEditBody(sub.Original_Body);
+          setEditBody(editable.body);
+          setEditLinks(editable.links);
         }
       } catch {
         // No versions yet — that's fine
+        const editable = prepareBodyForEditing(sub.Original_Body, sub.Links);
         setEditHeadline(sub.Original_Headline);
-        setEditBody(sub.Original_Body);
+        setEditBody(editable.body);
+        setEditLinks(editable.links);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load submission');
@@ -154,9 +177,21 @@ export default function EditPage() {
       const result = editorInstructions === undefined
         ? await triggerAIEdit(id, newsletterType)
         : await triggerAIEdit(id, newsletterType, editorInstructions);
+      const editable = prepareBodyForEditing(
+        result.Edited_Body,
+        [
+          ...result.Embedded_Links.map((link, index) => ({
+            Url: link.url,
+            Anchor_Text: link.anchor_text,
+            Display_Order: index,
+          })),
+          ...(submission?.Links ?? []),
+        ],
+      );
       setAiEditResult(result);
       setEditHeadline(result.Edited_Headline);
-      setEditBody(result.Edited_Body);
+      setEditBody(editable.body);
+      setEditLinks(editable.links);
       setActiveTab('ai_edit');
       // Refresh data
       const sub = await getSubmission(id);
@@ -183,11 +218,15 @@ export default function EditPage() {
     setError(null);
     try {
       const aiVersion = [...versions].reverse().find((v) => v.Version_Type === 'ai_suggested');
+      const links = normalizedBodyLinks(editLinks);
       await saveEditorFinal(id, {
         Headline: editHeadline,
-        Body: editBody,
+        Body: buildLinkedBody(editBody, links),
         Headline_Case: aiVersion?.Headline_Case || undefined,
         Approve_For_Newsletter: approveForNewsletter,
+        ...((submission?.Links.length ?? 0) > 0 || links.length > 0
+          ? { Links: links }
+          : {}),
       });
       showToast(
         approveForNewsletter
@@ -541,6 +580,26 @@ export default function EditPage() {
                   headlineCase={aiVersion?.Headline_Case || null}
                 />
                 <BodyEditor value={editBody} onChange={setEditBody} />
+                <div className="border-t border-gray-100 pt-4">
+                  <LinkEditor
+                    links={editLinks}
+                    onChange={setEditLinks}
+                    label="Links and CTA text"
+                    description="Link text stays readable in the body while its destination is edited here. Add a secure web URL or an email address."
+                  />
+                </div>
+                {editLinks.some((link) => link.Url.trim()) && (
+                  <section
+                    aria-label="Newsletter body preview"
+                    className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3"
+                  >
+                    <p className="mb-2 text-xs font-medium text-gray-500">Live preview</p>
+                    <RichBody
+                      text={buildLinkedBody(editBody, editLinks)}
+                      className="text-sm leading-6 text-gray-800"
+                    />
+                  </section>
+                )}
                 <div className="flex flex-col gap-3 border-t border-gray-200 pt-4 sm:flex-row sm:items-center sm:justify-between">
                   <div>
                     <p className="text-sm font-medium text-gray-900">

--- a/frontend/src/utils/bodyLinks.ts
+++ b/frontend/src/utils/bodyLinks.ts
@@ -1,0 +1,137 @@
+export interface EditableBodyLink {
+  Url: string;
+  Anchor_Text: string;
+  Display_Order?: number;
+}
+
+const EMAIL_ADDRESS_PATTERN = /^[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)+$/i;
+const ANCHOR_PATTERN = /<a\s+href=["']([^"']+)["'][^>]*>([^<]+)<\/a>/gi;
+
+export function normalizeEditableLinkUrl(value: string): string {
+  const trimmed = value.trim();
+  if (EMAIL_ADDRESS_PATTERN.test(trimmed)) return `mailto:${trimmed}`;
+  return trimmed;
+}
+
+export function isSafeLinkDestination(value: string): boolean {
+  const normalized = normalizeEditableLinkUrl(value);
+  try {
+    const parsed = new URL(normalized);
+    if (parsed.protocol === 'https:') {
+      return Boolean(parsed.hostname) && !parsed.username && !parsed.password;
+    }
+    if (parsed.protocol === 'mailto:') {
+      return EMAIL_ADDRESS_PATTERN.test(parsed.pathname) && !parsed.search && !parsed.hash;
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+export function prepareBodyForEditing(
+  body: string,
+  storedLinks: Array<{ Url: string; Anchor_Text: string | null; Display_Order?: number }> = [],
+): { body: string; links: EditableBodyLink[] } {
+  const bodyLinks: EditableBodyLink[] = [];
+  const plainBody = body.replace(ANCHOR_PATTERN, (_match, href: string, anchorText: string) => {
+    if (isSafeLinkDestination(href)) {
+      bodyLinks.push({
+        Url: normalizeEditableLinkUrl(href),
+        Anchor_Text: anchorText,
+        Display_Order: bodyLinks.length,
+      });
+    }
+    return anchorText;
+  });
+
+  const links = [...bodyLinks];
+  for (const link of [...storedLinks].sort(
+    (left, right) => (left.Display_Order ?? 0) - (right.Display_Order ?? 0),
+  )) {
+    const normalizedUrl = normalizeEditableLinkUrl(link.Url);
+    const anchorText = link.Anchor_Text?.trim() || '';
+    if (!isSafeLinkDestination(normalizedUrl)) continue;
+    if (links.some(
+      (candidate) => candidate.Url === normalizedUrl && candidate.Anchor_Text === anchorText,
+    )) continue;
+    links.push({
+      Url: normalizedUrl,
+      Anchor_Text: anchorText,
+      Display_Order: links.length,
+    });
+  }
+
+  return { body: plainBody, links: links.slice(0, 3) };
+}
+
+function linkLabel(link: EditableBodyLink): string {
+  const explicitLabel = link.Anchor_Text.trim();
+  if (explicitLabel) return explicitLabel.replace(/[<>]/g, '');
+  const normalizedUrl = normalizeEditableLinkUrl(link.Url);
+  return normalizedUrl.startsWith('mailto:')
+    ? normalizedUrl.slice('mailto:'.length)
+    : normalizedUrl;
+}
+
+function safeAttributeValue(value: string): string {
+  return value.replace(/["'<>]/g, (character) => encodeURIComponent(character));
+}
+
+export function buildLinkedBody(body: string, links: EditableBodyLink[]): string {
+  const validLinks = links
+    .map((link, index) => ({
+      ...link,
+      Url: normalizeEditableLinkUrl(link.Url),
+      Display_Order: index,
+    }))
+    .filter((link) => link.Url && isSafeLinkDestination(link.Url));
+
+  const occupiedRanges: Array<{ start: number; end: number }> = [];
+  const replacements: Array<{ start: number; end: number; markup: string }> = [];
+  const appendedLinks: string[] = [];
+
+  for (const link of validLinks) {
+    const label = linkLabel(link);
+    if (!label) continue;
+
+    let matchIndex = body.indexOf(label);
+    while (
+      matchIndex >= 0
+      && occupiedRanges.some(
+        (range) => matchIndex < range.end && matchIndex + label.length > range.start,
+      )
+    ) {
+      matchIndex = body.indexOf(label, matchIndex + label.length);
+    }
+
+    const markup = `<a href="${safeAttributeValue(link.Url)}">${label}</a>`;
+    if (matchIndex >= 0) {
+      occupiedRanges.push({ start: matchIndex, end: matchIndex + label.length });
+      replacements.push({
+        start: matchIndex,
+        end: matchIndex + label.length,
+        markup,
+      });
+    } else {
+      appendedLinks.push(markup);
+    }
+  }
+
+  let linkedBody = body;
+  for (const replacement of replacements.sort((left, right) => right.start - left.start)) {
+    linkedBody = `${linkedBody.slice(0, replacement.start)}${replacement.markup}${linkedBody.slice(replacement.end)}`;
+  }
+
+  return [linkedBody.trimEnd(), ...appendedLinks].filter(Boolean).join('\n');
+}
+
+export function normalizedBodyLinks(links: EditableBodyLink[]): EditableBodyLink[] {
+  return links
+    .map((link, index) => ({
+      Url: normalizeEditableLinkUrl(link.Url),
+      Anchor_Text: link.Anchor_Text.trim(),
+      Display_Order: index,
+    }))
+    .filter((link) => link.Url && isSafeLinkDestination(link.Url));
+}


### PR DESCRIPTION
## Summary

- render CTA and email links as live, safe links while keeping destinations separately editable in Final Edit
- let editors add or replace link text, HTTPS URLs, and email addresses as part of the normal immutable final-version save
- show complete approved copy in the Builder and add inline headline/body editing for assembled submissions
- preserve embedded links when Builder copy is edited and add focused security and workflow regression coverage

## Why

Editor link markup was stored inside body text, so the manual editor exposed raw anchor code while normalized submission links were only manageable during intake. The Builder also deliberately clamped each item to two lines and did not expose its existing item-update API.

This change separates readable copy from link destinations in the editing UI, validates link schemes at the API boundary, and surfaces the existing newsletter-item edit path directly in the Builder.

## Impact

Editors can review links as readers will see them, update CTA destinations or use email links, and make last-mile newsletter changes without leaving the Builder. Plain email addresses normalize to `mailto:`; unsafe schemes are rejected by the backend and rendered as plain text by the frontend.

## Validation

- backend: 152 tests passed
- frontend: 47 tests passed
- Ruff passed
- ESLint passed
- production TypeScript/Vite build passed

Closes #202
Closes #198
