### PR TITLE
Fix Joy feedback workflow issues

### DIFF
--- a/backend/alembic/versions/a5d7e9f1b3c2_apply_august_joy_style_rules.py
+++ b/backend/alembic/versions/a5d7e9f1b3c2_apply_august_joy_style_rules.py
@@ -1,0 +1,119 @@
+"""apply August Joy style rules
+
+Revision ID: a5d7e9f1b3c2
+Revises: f3a6b9c2d5e8
+Create Date: 2026-08-05 14:00:00.000000
+
+Promote the repeatedly requested event-detail order to a mandatory rule and
+add Joy's standing capitalization rule for "Vandal Gear". The migration is
+idempotent and narrowly updates only these two managed rule keys.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "a5d7e9f1b3c2"
+down_revision: str | Sequence[str] | None = "f3a6b9c2d5e8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+EVENT_RULE_TEXT = (
+    "Order event details as: time, day, date, location. Example: '3-4 p.m. "
+    "Wednesday, Feb. 12, in the Pitman Center Vandal Ballroom'. Do not "
+    "reorder or omit these elements. If the event is more than one month "
+    "away, omit the day of the week."
+)
+VANDAL_GEAR_RULE_TEXT = (
+    "Always write 'Vandal Gear' as two capitalized words. Replace "
+    "'VandalGear', 'Vandal gear' or other variants with 'Vandal Gear'."
+)
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _upsert_rule(
+    connection: sa.Connection,
+    *,
+    rule_key: str,
+    category: str,
+    rule_text: str,
+    severity: str,
+) -> None:
+    existing_id = connection.execute(
+        sa.select(style_rules.c.Id).where(
+            style_rules.c.Rule_Set == "shared",
+            style_rules.c.Rule_Key == rule_key,
+        )
+    ).scalar_one_or_none()
+    values = {
+        "Category": category,
+        "Rule_Text": rule_text,
+        "Is_Active": True,
+        "Severity": severity,
+    }
+    if existing_id:
+        connection.execute(
+            style_rules.update().where(style_rules.c.Id == existing_id).values(**values)
+        )
+    else:
+        connection.execute(
+            style_rules.insert().values(
+                Id=str(uuid.uuid4()),
+                Rule_Set="shared",
+                Rule_Key=rule_key,
+                **values,
+            )
+        )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    _upsert_rule(
+        connection,
+        rule_key="event_detail_ordering",
+        category="formatting",
+        rule_text=EVENT_RULE_TEXT,
+        severity="error",
+    )
+    _upsert_rule(
+        connection,
+        rule_key="vandal_gear_capitalization",
+        category="terminology",
+        rule_text=VANDAL_GEAR_RULE_TEXT,
+        severity="error",
+    )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    connection.execute(
+        style_rules.delete().where(
+            style_rules.c.Rule_Set == "shared",
+            style_rules.c.Rule_Key == "vandal_gear_capitalization",
+            style_rules.c.Rule_Text == VANDAL_GEAR_RULE_TEXT,
+        )
+    )
+    connection.execute(
+        style_rules.update()
+        .where(
+            style_rules.c.Rule_Set == "shared",
+            style_rules.c.Rule_Key == "event_detail_ordering",
+            style_rules.c.Rule_Text == EVENT_RULE_TEXT,
+        )
+        .values(Severity="warning")
+    )

--- a/backend/app/services/ai/prompts.py
+++ b/backend/app/services/ai/prompts.py
@@ -79,7 +79,7 @@ Your task is to edit submissions to comply with the university's editorial style
 
 ### Event Details
 - Ensure events include date, time and location. Flag if any are missing.
-- Format event details in a natural reading order: time, day/date, location.
+- REQUIRED ORDER: write event details as time, day, date, then location. Never put the day or date before the time.
 - Example: "3-4 p.m. Wednesday, Feb. 12, in the Bruce M. Pitman Center Vandal Ballroom"
 
 ### Links

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -189,7 +189,13 @@
     "category": "formatting",
     "rule_key": "event_detail_ordering",
     "rule_text": "Order event details as: time, day, date, location. Example: '3-4 p.m. Wednesday, Feb. 12, in the Pitman Center Vandal Ballroom'. Do not reorder or omit these elements. If the event is more than one month away, omit the day of the week.",
-    "severity": "warning"
+    "severity": "error"
+  },
+  {
+    "category": "terminology",
+    "rule_key": "vandal_gear_capitalization",
+    "rule_text": "Always write 'Vandal Gear' as two capitalized words. Replace 'VandalGear', 'Vandal gear' or other variants with 'Vandal Gear'.",
+    "severity": "error"
   },
   {
     "category": "formatting",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -38,6 +38,11 @@ include = ["app*"]
 target-version = "py311"
 line-length = 100
 
+[tool.ruff.lint]
+# Preserve the pre-0.16 default rule contract instead of inheriting Ruff's
+# version-dependent defaults.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -8,6 +8,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.edit_history import EditVersion
+from app.models.style_rule import StyleRule
 from app.models.submission import Submission
 from tests.conftest import TestSession, make_submission_data
 
@@ -25,12 +26,14 @@ def configure_ai_edit_tasks(monkeypatch: pytest.MonkeyPatch):
 class SuccessfulProvider:
     model = "test-model"
     last_user_prompt = ""
+    last_system_prompt = ""
 
     async def complete(self, *args, **kwargs):  # pragma: no cover - unused interface method
         raise NotImplementedError
 
     async def complete_json(self, *args, **kwargs):
         SuccessfulProvider.last_user_prompt = kwargs.get("user_prompt", "")
+        SuccessfulProvider.last_system_prompt = kwargs.get("system_prompt", "")
         return {
             "edited_headline": "Edited headline",
             "edited_body": "Edited body.",
@@ -172,6 +175,68 @@ class TestAIEditTasks:
         ai_version = versions_resp.json()[-1]
         assert ai_version["Version_Type"] == "ai_suggested"
         assert ai_version["Editor_Instructions"] == "Tighten the first sentence."
+
+    async def test_staff_ai_edit_applies_mandatory_event_and_vandal_gear_rules(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        SuccessfulProvider.last_system_prompt = ""
+        db.add_all(
+            [
+                StyleRule(
+                    Rule_Set="shared",
+                    Category="formatting",
+                    Rule_Key="event_detail_ordering",
+                    Rule_Text=(
+                        "Order event details as: time, day, date, location. "
+                        "Do not reorder these elements."
+                    ),
+                    Severity="error",
+                ),
+                StyleRule(
+                    Rule_Set="shared",
+                    Category="terminology",
+                    Rule_Key="vandal_gear_capitalization",
+                    Rule_Text=(
+                        "Always write 'Vandal Gear' as two capitalized words."
+                    ),
+                    Severity="error",
+                ),
+            ]
+        )
+        await db.commit()
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: SuccessfulProvider(),
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Original_Body=(
+                    "The VandalGear reception is Thursday, Aug. 20 at 5 p.m. "
+                    "in the Seed Potato Germplasm Laboratory."
+                ),
+            ),
+        )
+        assert submission_resp.status_code == 201
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_resp.json()['Id']}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+        assert resp.status_code == 202
+        task = await wait_for_task(client, resp.json()["Task_Id"], staff_headers)
+        assert task["Status"] == "succeeded"
+        assert "[MUST] Order event details as: time, day, date, location" in (
+            SuccessfulProvider.last_system_prompt
+        )
+        assert "[MUST] Always write 'Vandal Gear' as two capitalized words" in (
+            SuccessfulProvider.last_system_prompt
+        )
 
     async def test_ai_edit_preserves_proper_nouns_in_sentence_case_headline(
         self,

--- a/backend/tests/test_august_joy_style_rule_migration.py
+++ b/backend/tests/test_august_joy_style_rule_migration.py
@@ -1,0 +1,113 @@
+"""Regression coverage for the August Joy style-rule migration."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "a5d7e9f1b3c2_apply_august_joy_style_rules.py"
+)
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("august_joy_rules", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def style_rules_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+
+
+def test_rule_upserts_are_idempotent_and_preserve_unrelated_rules():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert(),
+            [
+                {
+                    "Id": "event-order",
+                    "Rule_Set": "shared",
+                    "Category": "formatting",
+                    "Rule_Key": "event_detail_ordering",
+                    "Rule_Text": "Old event order wording.",
+                    "Is_Active": False,
+                    "Severity": "warning",
+                },
+                {
+                    "Id": "custom",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "staff_custom",
+                    "Rule_Text": "Keep this staff rule.",
+                    "Is_Active": True,
+                    "Severity": "info",
+                },
+            ],
+        )
+
+        for _ in range(2):
+            migration._upsert_rule(
+                connection,
+                rule_key="event_detail_ordering",
+                category="formatting",
+                rule_text=migration.EVENT_RULE_TEXT,
+                severity="error",
+            )
+            migration._upsert_rule(
+                connection,
+                rule_key="vandal_gear_capitalization",
+                category="terminology",
+                rule_text=migration.VANDAL_GEAR_RULE_TEXT,
+                severity="error",
+            )
+
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    by_key = {row["Rule_Key"]: row for row in rows}
+    assert by_key["event_detail_ordering"]["Rule_Text"] == migration.EVENT_RULE_TEXT
+    assert by_key["event_detail_ordering"]["Severity"] == "error"
+    assert by_key["event_detail_ordering"]["Is_Active"] is True
+    assert by_key["vandal_gear_capitalization"]["Rule_Text"] == (
+        migration.VANDAL_GEAR_RULE_TEXT
+    )
+    assert by_key["vandal_gear_capitalization"]["Severity"] == "error"
+    assert by_key["staff_custom"]["Rule_Text"] == "Keep this staff rule."
+    assert len(rows) == 3
+
+
+def test_migration_values_match_shared_style_rule_seed():
+    migration = load_migration()
+    seed_path = Path(__file__).parents[1] / "data" / "style_rules" / "shared_rules.json"
+    seeded = {rule["rule_key"]: rule for rule in json.loads(seed_path.read_text())}
+
+    assert seeded["event_detail_ordering"]["rule_text"] == migration.EVENT_RULE_TEXT
+    assert seeded["event_detail_ordering"]["severity"] == "error"
+    assert seeded["vandal_gear_capitalization"]["rule_text"] == (
+        migration.VANDAL_GEAR_RULE_TEXT
+    )
+    assert seeded["vandal_gear_capitalization"]["severity"] == "error"

--- a/backend/tests/test_joy_style_rule_migration.py
+++ b/backend/tests/test_joy_style_rule_migration.py
@@ -116,6 +116,10 @@ def test_migration_values_match_the_style_rule_seed_files():
         key = (rule["rule_set"], rule["rule_key"])
         assert seeded[key]["category"] == rule["category"]
         assert seeded[key]["rule_text"] == rule["rule_text"]
-        assert seeded[key]["severity"] == rule["severity"]
+        # The August follow-up migration promotes the repeatedly missed event
+        # ordering rule from warning to error. Its dedicated regression test
+        # verifies the latest seed value; all other July values remain exact.
+        if key != ("shared", "event_detail_ordering"):
+            assert seeded[key]["severity"] == rule["severity"]
 
     assert ("myui", "title_case") not in seeded

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,16 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { apiFetch } from './client';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('apiFetch network failures', () => {
+  it('turns an unreachable API into an actionable retry message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+
+    await expect(apiFetch('/submissions')).rejects.toThrow(
+      'Unable to reach the UCM service. Check your connection and retry.',
+    );
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -43,14 +43,24 @@ export async function apiFetch<T>(
   path: string,
   options?: RequestInit,
 ): Promise<T> {
-  const res = await fetch(`${BASE_URL}${path}`, {
-    headers: {
-      'Content-Type': 'application/json',
-      ...getSubmitterRoleHeaders(),
-      ...options?.headers,
-    },
-    ...options,
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${BASE_URL}${path}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...getSubmitterRoleHeaders(),
+        ...options?.headers,
+      },
+      ...options,
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') throw error;
+    throw new Error(
+      'Unable to reach the UCM service. Check your connection and retry. '
+      + 'If the problem continues, report it to the application maintainers.',
+      { cause: error },
+    );
+  }
   if (!res.ok) {
     const error = await res.json().catch(() => ({ detail: res.statusText }));
     throw new Error(formatApiError(error.detail ?? error));

--- a/frontend/src/components/editor/SubmissionMeta.tsx
+++ b/frontend/src/components/editor/SubmissionMeta.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { Submission, TargetNewsletter } from '../../types/submission';
 import { getValidDates } from '../../api/schedule';
-import { parseISODate, addDaysISO } from '../../utils/date';
+import { parseAPIDateTime, parseISODate, addDaysISO } from '../../utils/date';
 
 interface SubmissionMetaProps {
   submission: Submission;
@@ -399,7 +399,7 @@ export default function SubmissionMeta({
         <div>
           <dt className="text-xs text-gray-500">Submitted</dt>
           <dd className="text-gray-900">
-            {new Date(submission.Created_At.endsWith('Z') ? submission.Created_At : submission.Created_At + 'Z').toLocaleString()}
+            {parseAPIDateTime(submission.Created_At).toLocaleString()}
           </dd>
         </div>
         {submission.Links.length > 0 && (

--- a/frontend/src/pages/BuilderPage.test.tsx
+++ b/frontend/src/pages/BuilderPage.test.tsx
@@ -145,6 +145,21 @@ beforeEach(() => {
 });
 
 describe('BuilderPage staff-only sections', () => {
+  it('shows an actionable retry when builder metadata cannot be reached', async () => {
+    const user = userEvent.setup();
+    newsletterApiMocks.listSections.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    render(<BuilderPage />);
+
+    expect(await screen.findByText(/Builder data could not be loaded.*Failed to fetch/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => {
+      expect(newsletterApiMocks.listSections).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.queryByText(/Builder data could not be loaded/i)).not.toBeInTheDocument();
+  });
+
   it('shows student reminders after employee announcements and in the move menu', async () => {
     const user = userEvent.setup();
     render(<BuilderPage />);

--- a/frontend/src/pages/BuilderPage.tsx
+++ b/frontend/src/pages/BuilderPage.tsx
@@ -206,6 +206,7 @@ export default function BuilderPage() {
   const [sectionOpen, setSectionOpen] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [metadataError, setMetadataError] = useState<string | null>(null);
   const { toast, showToast, dismissToast } = useToast();
   const [dragState, setDragState] = useState<SubmissionDragState | null>(null);
   const [itemEditDraft, setItemEditDraft] = useState<NewsletterItemEditDraft | null>(null);
@@ -213,20 +214,24 @@ export default function BuilderPage() {
   const dragStateRef = useRef<SubmissionDragState | null>(null);
   const newsletterId = newsletter?.Id;
 
-  useEffect(() => {
-    void (async () => {
-      try {
-        const [secs, list] = await Promise.all([
-          listSections(newsletterType),
-          listNewsletters({ newsletter_type: newsletterType }),
-        ]);
-        setSections(secs);
-        setNewsletters(list as NewsletterDetailResponse[]);
-      } catch (err) {
-        console.error('Failed to load builder metadata:', err);
-      }
-    })();
+  const loadBuilderMetadata = useCallback(async () => {
+    setMetadataError(null);
+    try {
+      const [secs, list] = await Promise.all([
+        listSections(newsletterType),
+        listNewsletters({ newsletter_type: newsletterType }),
+      ]);
+      setSections(secs);
+      setNewsletters(list as NewsletterDetailResponse[]);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : 'Unknown loading error';
+      setMetadataError(`Builder data could not be loaded. ${detail}`);
+    }
   }, [newsletterType]);
+
+  useEffect(() => {
+    void loadBuilderMetadata();
+  }, [loadBuilderMetadata]);
 
   useEffect(() => {
     if (!newsletterId) {
@@ -878,6 +883,19 @@ export default function BuilderPage() {
       {error && (
         <div className="bg-red-50 border border-red-200 text-red-700 text-sm p-3 rounded-lg mb-4">
           {error}
+        </div>
+      )}
+
+      {metadataError && (
+        <div className="mb-4 flex items-center justify-between gap-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <span>{metadataError}</span>
+          <button
+            type="button"
+            onClick={() => void loadBuilderMetadata()}
+            className="shrink-0 rounded-md border border-red-300 bg-white px-3 py-1.5 font-medium text-red-700 hover:bg-red-100"
+          >
+            Retry
+          </button>
         </div>
       )}
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -10,7 +10,7 @@ import WeekOverview from '../components/dashboard/WeekOverview';
 import DayDetail from '../components/dashboard/DayDetail';
 import { getPrimaryOccurrenceDate } from '../utils/submissionOccurrences';
 import { Button, Card, EmptyState, SegmentedToggle } from '../components/common';
-import { toISODate } from '../utils/date';
+import { parseAPIDateTime, toISODate } from '../utils/date';
 
 const STATUS_COLORS: Record<string, string> = {
   new: 'bg-status-info-100 text-status-info-800',
@@ -287,9 +287,25 @@ export default function DashboardPage() {
       </Card>
 
       {error && (
-        <div className="bg-red-50 border border-red-200 text-red-700 text-sm p-3 rounded-lg mb-4 flex items-center justify-between">
+        <div className="bg-red-50 border border-red-200 text-red-700 text-sm p-3 rounded-lg mb-4 flex items-center justify-between gap-4">
           <span>{error}</span>
-          <button onClick={() => setError(null)} className="ml-4 text-red-400 hover:text-red-600">&times;</button>
+          <div className="flex shrink-0 items-center gap-3">
+            <button
+              type="button"
+              onClick={() => void fetchData()}
+              className="rounded-md border border-red-300 bg-white px-3 py-1.5 font-medium text-red-700 hover:bg-red-100"
+            >
+              Retry
+            </button>
+            <button
+              type="button"
+              aria-label="Dismiss error"
+              onClick={() => setError(null)}
+              className="text-red-400 hover:text-red-600"
+            >
+              &times;
+            </button>
+          </div>
         </div>
       )}
 
@@ -377,9 +393,7 @@ export default function DashboardPage() {
                     <span>{sub.Submitter_Name}</span>
                     <span aria-hidden="true" className="text-gray-300">·</span>
                     <span>
-                      {new Date(
-                        sub.Created_At.endsWith('Z') ? sub.Created_At : sub.Created_At + 'Z',
-                      ).toLocaleDateString()}
+                      {parseAPIDateTime(sub.Created_At).toLocaleDateString()}
                     </span>
                     {sub.Schedule_Requests.length > 0 && (
                       <>

--- a/frontend/src/pages/EditPage.test.tsx
+++ b/frontend/src/pages/EditPage.test.tsx
@@ -318,6 +318,28 @@ describe('EditPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('keeps the immutable original beside the editable final version', async () => {
+    const user = userEvent.setup();
+    listEditVersionsMock.mockResolvedValue([
+      makeVersion({
+        Headline: 'AI working headline',
+        Body: 'AI working body.',
+      }),
+    ]);
+
+    renderEditPage();
+
+    await screen.findByText('AI working headline');
+    await user.click(screen.getByRole('button', { name: /continue to final edit/i }));
+
+    const original = screen.getByRole('region', { name: 'Original submission' });
+    const finalEdit = screen.getByRole('region', { name: 'Final edit' });
+    expect(within(original).getByText('Original campus headline')).toBeInTheDocument();
+    expect(within(original).getByText('Original body copy for the newsletter.')).toBeInTheDocument();
+    expect(within(finalEdit).getByDisplayValue('AI working headline')).toBeInTheDocument();
+    expect(within(finalEdit).getByDisplayValue('AI working body.')).toBeInTheDocument();
+  });
+
   it('shows live CTA links while keeping destination fields separately editable', async () => {
     const user = userEvent.setup();
     getSubmissionMock.mockResolvedValue(makeSubmission({

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -573,68 +573,98 @@ export default function EditPage() {
             )}
 
             {activeTab === 'editor' && (
-              <div className="space-y-4">
-                <HeadlineEditor
-                  value={editHeadline}
-                  onChange={setEditHeadline}
-                  headlineCase={aiVersion?.Headline_Case || null}
-                />
-                <BodyEditor value={editBody} onChange={setEditBody} />
-                <div className="border-t border-gray-100 pt-4">
-                  <LinkEditor
-                    links={editLinks}
-                    onChange={setEditLinks}
-                    label="Links and CTA text"
-                    description="Link text stays readable in the body while its destination is edited here. Add a secure web URL or an email address."
-                  />
-                </div>
-                {editLinks.some((link) => link.Url.trim()) && (
-                  <section
-                    aria-label="Newsletter body preview"
-                    className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3"
-                  >
-                    <p className="mb-2 text-xs font-medium text-gray-500">Live preview</p>
-                    <RichBody
-                      text={buildLinkedBody(editBody, editLinks)}
-                      className="text-sm leading-6 text-gray-800"
-                    />
-                  </section>
-                )}
-                <div className="flex flex-col gap-3 border-t border-gray-200 pt-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+                <section
+                  aria-label="Original submission"
+                  className="space-y-4 rounded-lg border border-gray-200 bg-gray-50 p-4"
+                >
                   <div>
+                    <h3 className="text-sm font-semibold text-gray-900">Original submission</h3>
+                    <p className="mt-1 text-xs text-gray-500">Read-only reference</p>
+                  </div>
+                  <div>
+                    <p className="mb-1 text-xs font-medium text-gray-500">Headline</p>
                     <p className="text-sm font-medium text-gray-900">
-                      {canApproveFinal
-                        ? 'Ready for newsletter assembly?'
-                        : 'Save your work before leaving'}
-                    </p>
-                    <p className="mt-0.5 max-w-[65ch] text-xs text-gray-500">
-                      {canApproveFinal
-                        ? 'Save a draft for continued review, or approve the current text for the newsletter.'
-                        : 'This submission cannot be approved in its current status, but you can keep your edits as a draft.'}
+                      {submission.Original_Headline}
                     </p>
                   </div>
-                  <div className="flex shrink-0 flex-wrap justify-end gap-2">
-                    <Button
-                      onClick={() => void handleFinalize(false)}
-                      disabled={finalizationAction !== null}
-                      variant="secondary"
+                  <div>
+                    <p className="mb-1 text-xs font-medium text-gray-500">Body</p>
+                    <p className="whitespace-pre-wrap text-sm leading-6 text-gray-700">
+                      {submission.Original_Body}
+                    </p>
+                  </div>
+                </section>
+
+                <section aria-label="Final edit" className="min-w-0 space-y-4">
+                  <div>
+                    <h3 className="text-sm font-semibold text-gray-900">Final edit</h3>
+                    <p className="mt-1 text-xs text-gray-500">
+                      Edit the working version while keeping the original in view.
+                    </p>
+                  </div>
+                  <HeadlineEditor
+                    value={editHeadline}
+                    onChange={setEditHeadline}
+                    headlineCase={aiVersion?.Headline_Case || null}
+                  />
+                  <BodyEditor value={editBody} onChange={setEditBody} />
+                  <div className="border-t border-gray-100 pt-4">
+                    <LinkEditor
+                      links={editLinks}
+                      onChange={setEditLinks}
+                      label="Links and CTA text"
+                      description="Link text stays readable in the body while its destination is edited here. Add a secure web URL or an email address."
+                    />
+                  </div>
+                  {editLinks.some((link) => link.Url.trim()) && (
+                    <section
+                      aria-label="Newsletter body preview"
+                      className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3"
                     >
-                      {finalizationAction === 'draft' ? 'Saving draft...' : 'Save Draft'}
-                    </Button>
-                    {canApproveFinal && (
+                      <p className="mb-2 text-xs font-medium text-gray-500">Live preview</p>
+                      <RichBody
+                        text={buildLinkedBody(editBody, editLinks)}
+                        className="text-sm leading-6 text-gray-800"
+                      />
+                    </section>
+                  )}
+                  <div className="flex flex-col gap-3 border-t border-gray-200 pt-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <p className="text-sm font-medium text-gray-900">
+                        {canApproveFinal
+                          ? 'Ready for newsletter assembly?'
+                          : 'Save your work before leaving'}
+                      </p>
+                      <p className="mt-0.5 max-w-[65ch] text-xs text-gray-500">
+                        {canApproveFinal
+                          ? 'Save a draft for continued review, or approve the current text for the newsletter.'
+                          : 'This submission cannot be approved in its current status, but you can keep your edits as a draft.'}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 flex-wrap justify-end gap-2">
                       <Button
-                        onClick={() => void handleFinalize(true)}
+                        onClick={() => void handleFinalize(false)}
                         disabled={finalizationAction !== null}
-                        variant="success"
-                        title="Save this final version and approve it for newsletter assembly"
+                        variant="secondary"
                       >
-                        {finalizationAction === 'approve'
-                          ? 'Saving and approving...'
-                          : 'Save and Approve'}
+                        {finalizationAction === 'draft' ? 'Saving draft...' : 'Save Draft'}
                       </Button>
-                    )}
+                      {canApproveFinal && (
+                        <Button
+                          onClick={() => void handleFinalize(true)}
+                          disabled={finalizationAction !== null}
+                          variant="success"
+                          title="Save this final version and approve it for newsletter assembly"
+                        >
+                          {finalizationAction === 'approve'
+                            ? 'Saving and approving...'
+                            : 'Save and Approve'}
+                        </Button>
+                      )}
+                    </div>
                   </div>
-                </div>
+                </section>
               </div>
             )}
           </div>

--- a/frontend/src/pages/FeedbackPage.test.tsx
+++ b/frontend/src/pages/FeedbackPage.test.tsx
@@ -69,6 +69,21 @@ beforeEach(() => {
 });
 
 describe('FeedbackPage notification state', () => {
+  it('treats timezone-naive API timestamps as UTC', async () => {
+    const createdAt = '2026-08-05T16:20:28.935505';
+    listFeedbackMock.mockResolvedValueOnce([makeFeedback({ Created_At: createdAt })]);
+
+    renderFeedbackPage();
+
+    const expected = new Date(`${createdAt}Z`).toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    expect(await screen.findByText(expected)).toBeInTheDocument();
+  });
+
   it('explains disabled external alerts without offering a retry', async () => {
     renderFeedbackPage();
 

--- a/frontend/src/pages/FeedbackPage.tsx
+++ b/frontend/src/pages/FeedbackPage.tsx
@@ -12,6 +12,7 @@ import type {
   ProductFeedback,
 } from '../types/feedback';
 import { buildGitHubIssueUrl } from '../utils/feedback';
+import { parseAPIDateTime } from '../utils/date';
 import { getSubmitterRole } from '../utils/submitterRole';
 import { Button, Card, EmptyState, Toast, useToast } from '../components/common';
 
@@ -51,7 +52,7 @@ const NOTIFICATION_CLASSES: Record<FeedbackNotificationStatus, string> = {
 };
 
 function formatDate(value: string) {
-  return new Date(value).toLocaleString('en-US', {
+  return parseAPIDateTime(value).toLocaleString('en-US', {
     month: 'short',
     day: 'numeric',
     hour: 'numeric',

--- a/frontend/src/utils/bodyLinks.test.ts
+++ b/frontend/src/utils/bodyLinks.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { buildLinkedBody, prepareBodyForEditing } from './bodyLinks';
+
+describe('body link editing', () => {
+  it('repairs the duplicated anchor pattern from Joy\'s dev submission', () => {
+    const editable = prepareBodyForEditing(
+      'Participants receive a book. Sign up, or email '
+        + '<a href="mailto:nikkihodge@uidaho.edu">Nikki Hodge</a>.\n'
+        + '<a href="https://example.com/study">sign up</a>',
+      [
+        {
+          Url: 'https://example.com/study',
+          Anchor_Text: 'sign up',
+          Display_Order: 1,
+        },
+      ],
+    );
+
+    expect(editable.body).toBe('Participants receive a book. Sign up, or email Nikki Hodge.');
+    expect(editable.links).toEqual([
+      {
+        Url: 'mailto:nikkihodge@uidaho.edu',
+        Anchor_Text: 'Nikki Hodge',
+        Display_Order: 0,
+      },
+      {
+        Url: 'https://example.com/study',
+        Anchor_Text: 'sign up',
+        Display_Order: 1,
+      },
+    ]);
+
+    const rebuilt = buildLinkedBody(editable.body, editable.links);
+    expect(rebuilt).toContain('<a href="https://example.com/study">Sign up</a>');
+    expect(rebuilt.match(/sign up/gi)).toHaveLength(1);
+    expect(rebuilt).not.toMatch(/\n<a href="https:\/\/example\.com\/study">/);
+  });
+
+  it('deduplicates embedded and stored links by normalized destination', () => {
+    const editable = prepareBodyForEditing(
+      'Read <a href="https://example.com/details">event details</a>.',
+      [
+        {
+          Url: 'https://example.com/details',
+          Anchor_Text: 'Learn more',
+          Display_Order: 0,
+        },
+      ],
+    );
+
+    expect(editable.links).toHaveLength(1);
+    expect(editable.links[0].Anchor_Text).toBe('event details');
+  });
+});

--- a/frontend/src/utils/bodyLinks.ts
+++ b/frontend/src/utils/bodyLinks.ts
@@ -34,16 +34,51 @@ export function prepareBodyForEditing(
   storedLinks: Array<{ Url: string; Anchor_Text: string | null; Display_Order?: number }> = [],
 ): { body: string; links: EditableBodyLink[] } {
   const bodyLinks: EditableBodyLink[] = [];
-  const plainBody = body.replace(ANCHOR_PATTERN, (_match, href: string, anchorText: string) => {
+  const standaloneAnchorLabels = new Set<string>();
+  let plainBody = body.replace(ANCHOR_PATTERN, (
+    match,
+    href: string,
+    anchorText: string,
+    offset: number,
+    source: string,
+  ) => {
     if (isSafeLinkDestination(href)) {
-      bodyLinks.push({
-        Url: normalizeEditableLinkUrl(href),
-        Anchor_Text: anchorText,
-        Display_Order: bodyLinks.length,
-      });
+      const normalizedUrl = normalizeEditableLinkUrl(href);
+      if (!bodyLinks.some((candidate) => candidate.Url === normalizedUrl)) {
+        bodyLinks.push({
+          Url: normalizedUrl,
+          Anchor_Text: anchorText,
+          Display_Order: bodyLinks.length,
+        });
+      }
+
+      const lineStart = source.lastIndexOf('\n', Math.max(0, offset - 1)) + 1;
+      const nextLineBreak = source.indexOf('\n', offset + match.length);
+      const lineEnd = nextLineBreak === -1 ? source.length : nextLineBreak;
+      if (
+        source.slice(lineStart, offset).trim() === ''
+        && source.slice(offset + match.length, lineEnd).trim() === ''
+      ) {
+        standaloneAnchorLabels.add(anchorText.trim().toLocaleLowerCase());
+      }
     }
     return anchorText;
   });
+
+  // Older editor builds appended unmatched anchors on their own line. Remove
+  // only those generated duplicates when the same label already exists in the
+  // prose; retain their link metadata so it can be reattached there.
+  const lowerBody = plainBody.toLocaleLowerCase();
+  plainBody = plainBody
+    .split('\n')
+    .filter((line) => {
+      const label = line.trim().toLocaleLowerCase();
+      if (!standaloneAnchorLabels.has(label)) return true;
+      const first = lowerBody.indexOf(label);
+      return first === lowerBody.lastIndexOf(label);
+    })
+    .join('\n')
+    .trimEnd();
 
   const links = [...bodyLinks];
   for (const link of [...storedLinks].sort(
@@ -52,9 +87,7 @@ export function prepareBodyForEditing(
     const normalizedUrl = normalizeEditableLinkUrl(link.Url);
     const anchorText = link.Anchor_Text?.trim() || '';
     if (!isSafeLinkDestination(normalizedUrl)) continue;
-    if (links.some(
-      (candidate) => candidate.Url === normalizedUrl && candidate.Anchor_Text === anchorText,
-    )) continue;
+    if (links.some((candidate) => candidate.Url === normalizedUrl)) continue;
     links.push({
       Url: normalizedUrl,
       Anchor_Text: anchorText,
@@ -95,18 +128,21 @@ export function buildLinkedBody(body: string, links: EditableBodyLink[]): string
     const label = linkLabel(link);
     if (!label) continue;
 
-    let matchIndex = body.indexOf(label);
+    const searchableBody = body.toLocaleLowerCase();
+    const searchableLabel = label.toLocaleLowerCase();
+    let matchIndex = searchableBody.indexOf(searchableLabel);
     while (
       matchIndex >= 0
       && occupiedRanges.some(
         (range) => matchIndex < range.end && matchIndex + label.length > range.start,
       )
     ) {
-      matchIndex = body.indexOf(label, matchIndex + label.length);
+      matchIndex = searchableBody.indexOf(searchableLabel, matchIndex + label.length);
     }
 
-    const markup = `<a href="${safeAttributeValue(link.Url)}">${label}</a>`;
     if (matchIndex >= 0) {
+      const matchedLabel = body.slice(matchIndex, matchIndex + label.length);
+      const markup = `<a href="${safeAttributeValue(link.Url)}">${matchedLabel}</a>`;
       occupiedRanges.push({ start: matchIndex, end: matchIndex + label.length });
       replacements.push({
         start: matchIndex,
@@ -114,6 +150,7 @@ export function buildLinkedBody(body: string, links: EditableBodyLink[]): string
         markup,
       });
     } else {
+      const markup = `<a href="${safeAttributeValue(link.Url)}">${label}</a>`;
       appendedLinks.push(markup);
     }
   }

--- a/frontend/src/utils/date.test.ts
+++ b/frontend/src/utils/date.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { parseISODate, toISODate, todayISO, addDaysISO, addMonthsISO } from './date';
+import {
+  parseAPIDateTime,
+  parseISODate,
+  toISODate,
+  todayISO,
+  addDaysISO,
+  addMonthsISO,
+} from './date';
 
 afterEach(() => {
   vi.useRealTimers();
@@ -41,5 +48,19 @@ describe('today/offset helpers', () => {
     expect(addDaysISO(1)).toBe('2026-07-18');
     expect(addDaysISO(90)).toBe('2026-10-15');
     expect(addMonthsISO(3)).toBe('2026-10-17');
+  });
+});
+
+describe('parseAPIDateTime', () => {
+  it('treats a timezone-naive server timestamp as UTC', () => {
+    expect(parseAPIDateTime('2026-08-05T16:20:28.935505').toISOString()).toBe(
+      '2026-08-05T16:20:28.935Z',
+    );
+  });
+
+  it('preserves an explicit timezone offset', () => {
+    expect(parseAPIDateTime('2026-08-05T09:20:28.935-07:00').toISOString()).toBe(
+      '2026-08-05T16:20:28.935Z',
+    );
   });
 });

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -38,3 +38,9 @@ export function addMonthsISO(months: number): string {
   d.setMonth(d.getMonth() + months);
   return toISODate(d);
 }
+
+/** Parse an API datetime, treating legacy timezone-naive values as UTC. */
+export function parseAPIDateTime(value: string): Date {
+  const hasTimezone = /(?:Z|[+-]\d{2}:\d{2})$/i.test(value);
+  return new Date(hasTimezone ? value : `${value}Z`);
+}


### PR DESCRIPTION
## Summary

Fix the latest feedback items reported by Joy across link handling, AI style enforcement, timestamps, final editing, and transient API failures.

Closes #227.
Closes #228.
Closes #229.
Advances #63.
Improves #230.

## What changed

- Deduplicate embedded and stored links by normalized destination, match anchors case-insensitively, and repair legacy standalone duplicate anchors.
- Require AI event details in time/day/date/location order and enforce the exact term “Vandal Gear.”
- Add an idempotent Alembic migration so deployed style rules match the updated seed data.
- Interpret legacy timezone-naive API timestamps as UTC.
- Show the original submission beside the editable final version.
- Surface actionable network errors and retry controls on Dashboard and Builder.

## Root causes

- Link identity previously included both URL and label, allowing the same destination to be emitted twice; anchor matching was also case-sensitive.
- The event-order rule was only a warning and Vandal Gear had no standing rule.
- Browsers interpreted timezone-naive API timestamps as local time.
- Final Edit did not retain the original submission in view.
- Transient fetch failures were either generic or only written to the console.

The historical #230 event could not be tied to a backend outage: server logs showed healthy responses at the reported time. This PR improves recovery and diagnostics for that failure mode.

## Validation

- Backend: 155 tests passed.
- Frontend: 55 tests passed.
- Backend Ruff passed.
- Frontend lint passed.
- Frontend production build passed.
- Alembic reports a single head.
- Visual QA completed at desktop and tablet widths.
- `git diff --check` passed.
