### PR TITLE
Enforce concise AI edits and explicit final-edit source

### DIFF
--- a/backend/alembic/versions/b6e8f0a2c4d1_enforce_short_complete_sentences.py
+++ b/backend/alembic/versions/b6e8f0a2c4d1_enforce_short_complete_sentences.py
@@ -1,0 +1,93 @@
+"""enforce short complete sentences
+
+Revision ID: b6e8f0a2c4d1
+Revises: a5d7e9f1b3c2
+Create Date: 2026-08-05 14:45:00.000000
+
+Promote Joy's recurring short-sentence requirement to a mandatory rule. The
+migration updates only the managed shared rule and preserves unrelated staff
+configuration.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b6e8f0a2c4d1"
+down_revision: str | Sequence[str] | None = "a5d7e9f1b3c2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+SHORT_SENTENCE_RULE_TEXT = (
+    "Use short, complete sentences. Each sentence should communicate one main idea. "
+    "Do not use semicolons. Replace semicolons with periods. Split compound or "
+    "lengthy sentences into separate sentences. Favor clear, direct wording over "
+    "complex sentence structures. Keep sentences concise and easy to read."
+)
+PREVIOUS_RULE_TEXT = (
+    "Write short, clear sentences. Avoid run-on sentences and compound-complex "
+    "structures. Break long sentences into two or more shorter ones for readability. "
+    "Replace semicolons with periods."
+)
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _upsert_short_sentence_rule(connection: sa.Connection) -> None:
+    values = {
+        "Category": "voice",
+        "Rule_Text": SHORT_SENTENCE_RULE_TEXT,
+        "Is_Active": True,
+        "Severity": "error",
+    }
+    result = connection.execute(
+        style_rules.update()
+        .where(
+            style_rules.c.Rule_Set == "shared",
+            style_rules.c.Rule_Key == "short_sentences",
+        )
+        .values(**values)
+    )
+    if result.rowcount == 0:
+        connection.execute(
+            style_rules.insert().values(
+                Id=str(uuid.uuid4()),
+                Rule_Set="shared",
+                Rule_Key="short_sentences",
+                **values,
+            )
+        )
+
+
+def upgrade() -> None:
+    _upsert_short_sentence_rule(op.get_bind())
+
+
+def downgrade() -> None:
+    op.get_bind().execute(
+        style_rules.update()
+        .where(
+            style_rules.c.Rule_Set == "shared",
+            style_rules.c.Rule_Key == "short_sentences",
+            style_rules.c.Rule_Text == SHORT_SENTENCE_RULE_TEXT,
+        )
+        .values(
+            Rule_Text=PREVIOUS_RULE_TEXT,
+            Is_Active=True,
+            Severity="warning",
+        )
+    )

--- a/backend/app/services/ai/editor.py
+++ b/backend/app/services/ai/editor.py
@@ -1,6 +1,7 @@
 """AI Editor orchestrator — coordinates style rules, LLM calls, and post-processing."""
 
 import logging
+import re
 from dataclasses import dataclass, field
 
 import sqlalchemy as sa
@@ -23,6 +24,31 @@ from app.utils.text import (
 from app.utils.hyperlinks import parse_submitter_notes
 
 logger = logging.getLogger(__name__)
+
+_HTML_OR_ENTITY_TOKEN = re.compile(
+    r"(<[^>]*>|&(?:#\d+|#x[0-9a-f]+|[a-z][a-z0-9]+);)",
+    re.IGNORECASE,
+)
+
+
+def enforce_no_semicolons_in_prose(body: str) -> tuple[str, bool]:
+    """Replace prose semicolons while preserving HTML tags, URLs and entities."""
+    parts = _HTML_OR_ENTITY_TOKEN.split(body)
+    changed = False
+
+    for index in range(0, len(parts), 2):
+        prose = parts[index]
+        if ";" not in prose:
+            continue
+        changed = True
+        prose = re.sub(
+            r";\s*([a-z])",
+            lambda match: f". {match.group(1).upper()}",
+            prose,
+        )
+        parts[index] = prose.replace(";", ".")
+
+    return "".join(parts), changed
 
 
 class AIEditError(Exception):
@@ -170,10 +196,25 @@ class AIEditor:
 
         edited_headline = ai_result.get("edited_headline", submission.Original_Headline)
         edited_body = ai_result.get("edited_body", submission.Original_Body)
-        changes_made = ai_result.get("changes_made", [])
+        changes_made = list(ai_result.get("changes_made", []) or [])
         ai_flags = ai_result.get("flags", [])
         embedded_links = ai_result.get("embedded_links", [])
         confidence = ai_result.get("confidence", 0.5)
+
+        short_sentence_rule_active = any(
+            rule["rule_key"] == "short_sentences" for rule in style_rules
+        )
+        edited_body, replaced_semicolons = (
+            enforce_no_semicolons_in_prose(edited_body)
+            if short_sentence_rule_active
+            else (edited_body, False)
+        )
+        if replaced_semicolons:
+            cleanup_description = (
+                "Replaced semicolons with periods to enforce the short-sentence rule"
+            )
+            if cleanup_description not in changes_made:
+                changes_made.append(cleanup_description)
 
         if headline_case == "sentence_case":
             edited_headline = to_sentence_case(edited_headline)

--- a/backend/app/services/ai/prompts.py
+++ b/backend/app/services/ai/prompts.py
@@ -91,6 +91,9 @@ Your task is to edit submissions to comply with the university's editorial style
 
 ### Length and Structure
 - Trim verbose submissions to essential information. Produce exactly one paragraph.
+- REQUIRED: Use short, complete sentences. Each sentence should communicate one main idea.
+- Do not use semicolons. Replace them with periods and split compound or lengthy sentences.
+- Favor clear, direct wording over complex sentence structures.
 - Remove redundant phrasing, lists of minor duties, and excessive detail.
 - For job postings: use only the title and link, not full job descriptions.
 - Collapse bullet lists into flowing prose when possible.

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -254,8 +254,8 @@
   {
     "category": "voice",
     "rule_key": "short_sentences",
-    "rule_text": "Write short, clear sentences. Avoid run-on sentences and compound-complex structures. Break long sentences into two or more shorter ones for readability. Replace semicolons with periods.",
-    "severity": "warning"
+    "rule_text": "Use short, complete sentences. Each sentence should communicate one main idea. Do not use semicolons. Replace semicolons with periods. Split compound or lengthy sentences into separate sentences. Favor clear, direct wording over complex sentence structures. Keep sentences concise and easy to read.",
+    "severity": "error"
   },
   {
     "category": "formatting",

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -71,6 +71,28 @@ class ProperNounProvider:
         }
 
 
+class SemicolonProvider:
+    model = "test-model"
+    last_system_prompt = ""
+
+    async def complete(self, *args, **kwargs):  # pragma: no cover - unused interface method
+        raise NotImplementedError
+
+    async def complete_json(self, *args, **kwargs):
+        SemicolonProvider.last_system_prompt = kwargs.get("system_prompt", "")
+        return {
+            "edited_headline": "Read the update",
+            "edited_body": (
+                "The first idea is complete; the second idea links to "
+                '<a href="https://example.com/path?a=1;b=2">news &amp; features</a>.'
+            ),
+            "changes_made": [],
+            "flags": [],
+            "embedded_links": [],
+            "confidence": 0.95,
+        }
+
+
 async def wait_for_task(
     client: AsyncClient,
     task_id: str,
@@ -237,6 +259,62 @@ class TestAIEditTasks:
         assert "[MUST] Always write 'Vandal Gear' as two capitalized words" in (
             SuccessfulProvider.last_system_prompt
         )
+
+    async def test_staff_ai_edit_enforces_short_sentences_and_safe_semicolon_cleanup(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        SemicolonProvider.last_system_prompt = ""
+        db.add(
+            StyleRule(
+                Rule_Set="shared",
+                Category="voice",
+                Rule_Key="short_sentences",
+                Rule_Text=(
+                    "Use short, complete sentences. Each sentence should communicate "
+                    "one main idea. Do not use semicolons."
+                ),
+                Severity="error",
+            )
+        )
+        await db.commit()
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: SemicolonProvider(),
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Original_Body=(
+                    "The first idea is complete; the second idea includes more detail."
+                ),
+            ),
+        )
+        assert submission_resp.status_code == 201
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_resp.json()['Id']}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+        assert resp.status_code == 202
+        task = await wait_for_task(client, resp.json()["Task_Id"], staff_headers)
+
+        assert task["Status"] == "succeeded"
+        assert "Each sentence should communicate one main idea" in (
+            SemicolonProvider.last_system_prompt
+        )
+        assert "Do not use semicolons" in SemicolonProvider.last_system_prompt
+        assert task["Result"]["Edited_Body"] == (
+            "The first idea is complete. The second idea links to "
+            '<a href="https://example.com/path?a=1;b=2">news &amp; features</a>.'
+        )
+        assert task["Result"]["Changes_Made"] == [
+            "Replaced semicolons with periods to enforce the short-sentence rule"
+        ]
 
     async def test_ai_edit_preserves_proper_nouns_in_sentence_case_headline(
         self,

--- a/backend/tests/test_august_short_sentence_rule_migration.py
+++ b/backend/tests/test_august_short_sentence_rule_migration.py
@@ -1,0 +1,109 @@
+"""Regression coverage for the mandatory short-sentence rule migration."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "b6e8f0a2c4d1_enforce_short_complete_sentences.py"
+)
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("short_sentence_rule", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def style_rules_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+
+
+def test_rule_upsert_is_idempotent_and_preserves_unrelated_rules():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert(),
+            [
+                {
+                    "Id": "short-sentences",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "short_sentences",
+                    "Rule_Text": "Old sentence wording.",
+                    "Is_Active": False,
+                    "Severity": "warning",
+                },
+                {
+                    "Id": "custom",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "staff_custom",
+                    "Rule_Text": "Keep this staff rule.",
+                    "Is_Active": True,
+                    "Severity": "info",
+                },
+            ],
+        )
+
+        migration._upsert_short_sentence_rule(connection)
+        migration._upsert_short_sentence_rule(connection)
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    by_key = {row["Rule_Key"]: row for row in rows}
+    assert by_key["short_sentences"]["Rule_Text"] == migration.SHORT_SENTENCE_RULE_TEXT
+    assert by_key["short_sentences"]["Severity"] == "error"
+    assert by_key["short_sentences"]["Is_Active"] is True
+    assert by_key["staff_custom"]["Rule_Text"] == "Keep this staff rule."
+    assert len(rows) == 2
+
+
+def test_rule_upsert_inserts_once_when_the_seed_row_is_missing():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        migration._upsert_short_sentence_rule(connection)
+        migration._upsert_short_sentence_rule(connection)
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    assert len(rows) == 1
+    assert rows[0]["Id"]
+    assert rows[0]["Rule_Key"] == "short_sentences"
+    assert rows[0]["Severity"] == "error"
+
+
+def test_migration_values_match_shared_style_rule_seed():
+    migration = load_migration()
+    seed_path = Path(__file__).parents[1] / "data" / "style_rules" / "shared_rules.json"
+    seeded = {rule["rule_key"]: rule for rule in json.loads(seed_path.read_text())}
+
+    assert seeded["short_sentences"]["rule_text"] == migration.SHORT_SENTENCE_RULE_TEXT
+    assert seeded["short_sentences"]["severity"] == "error"

--- a/backend/tests/test_joy_style_rule_migration.py
+++ b/backend/tests/test_joy_style_rule_migration.py
@@ -115,11 +115,15 @@ def test_migration_values_match_the_style_rule_seed_files():
     for rule in migration.STYLE_RULE_UPDATES:
         key = (rule["rule_set"], rule["rule_key"])
         assert seeded[key]["category"] == rule["category"]
-        assert seeded[key]["rule_text"] == rule["rule_text"]
-        # The August follow-up migration promotes the repeatedly missed event
-        # ordering rule from warning to error. Its dedicated regression test
-        # verifies the latest seed value; all other July values remain exact.
-        if key != ("shared", "event_detail_ordering"):
+        # August follow-up migrations supersede the recurring event-order and
+        # short-sentence rules. Dedicated regression tests verify their latest
+        # seed values; all other July values remain exact.
+        if key != ("shared", "short_sentences"):
+            assert seeded[key]["rule_text"] == rule["rule_text"]
+        if key not in {
+            ("shared", "event_detail_ordering"),
+            ("shared", "short_sentences"),
+        }:
             assert seeded[key]["severity"] == rule["severity"]
 
     assert ("myui", "title_case") not in seeded

--- a/frontend/src/components/editor/AIEditControls.test.tsx
+++ b/frontend/src/components/editor/AIEditControls.test.tsx
@@ -15,6 +15,7 @@ describe('AIEditControls', () => {
         loading={false}
         hasAIEdit={false}
         targetNewsletter="both"
+        reviewSource="original"
       />,
     );
 
@@ -23,6 +24,26 @@ describe('AIEditControls', () => {
 
     expect(onTriggerEdit).toHaveBeenNthCalledWith(1, 'tdr');
     expect(onTriggerEdit).toHaveBeenNthCalledWith(2, 'myui');
+  });
+
+  it('offers a direct non-AI path before an AI edit exists', async () => {
+    const user = userEvent.setup();
+    const onReviewFinalEdit = vi.fn();
+
+    render(
+      <AIEditControls
+        onTriggerEdit={vi.fn()}
+        onReviewFinalEdit={onReviewFinalEdit}
+        loading={false}
+        hasAIEdit={false}
+        targetNewsletter="tdr"
+        reviewSource="original"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /continue without ai/i }));
+
+    expect(onReviewFinalEdit).toHaveBeenCalledWith('original');
   });
 
   it('routes an AI suggestion through final review without a separate accept action', async () => {
@@ -37,15 +58,16 @@ describe('AIEditControls', () => {
         hasAIEdit
         targetNewsletter="tdr"
         confidence={0.84}
+        reviewSource="ai"
       />,
     );
 
     expect(screen.getByText('84%')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /accept ai edit/i })).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /continue to final edit/i }));
+    await user.click(screen.getByRole('button', { name: /use ai suggestion in final edit/i }));
 
-    expect(onReviewFinalEdit).toHaveBeenCalledOnce();
+    expect(onReviewFinalEdit).toHaveBeenCalledWith('ai');
   });
 
   it('sends targeted editor feedback when revising an AI edit', async () => {
@@ -59,6 +81,7 @@ describe('AIEditControls', () => {
         loading={false}
         hasAIEdit
         targetNewsletter="tdr"
+        reviewSource="ai"
       />,
     );
 

--- a/frontend/src/components/editor/AIEditControls.tsx
+++ b/frontend/src/components/editor/AIEditControls.tsx
@@ -3,13 +3,14 @@ import { Button } from '../common';
 
 interface AIEditControlsProps {
   onTriggerEdit: (newsletterType: 'tdr' | 'myui', editorInstructions?: string) => void;
-  onReviewFinalEdit: () => void;
+  onReviewFinalEdit: (source: 'original' | 'ai') => void;
   loading: boolean;
   hasAIEdit: boolean;
   // Accepts "none" so SLC-only submissions type-check, though AI editing is never
   // triggered for them — all button branches below gate on 'tdr'/'myui'/'both'.
   targetNewsletter: 'tdr' | 'myui' | 'both' | 'none';
   confidence?: number;
+  reviewSource: 'original' | 'ai' | null;
 }
 
 export default function AIEditControls({
@@ -19,6 +20,7 @@ export default function AIEditControls({
   hasAIEdit,
   targetNewsletter,
   confidence,
+  reviewSource,
 }: AIEditControlsProps) {
   const [editorFeedback, setEditorFeedback] = useState('');
   const confidenceColor =
@@ -32,7 +34,7 @@ export default function AIEditControls({
 
   return (
     <div className="bg-white rounded-lg border p-4">
-      <h3 className="text-sm font-semibold text-gray-900 mb-3">AI Edit Controls</h3>
+      <h3 className="text-sm font-semibold text-gray-900 mb-3">Editing options</h3>
 
       {loading && (
         <div className="mb-3 p-3 bg-ui-gold-50 border border-ui-gold-200 rounded-md">
@@ -69,6 +71,22 @@ export default function AIEditControls({
               </Button>
             )}
           </div>
+          {reviewSource === 'original' && (
+            <div className="border-t border-gray-200 pt-3">
+              <p className="mb-2 text-xs leading-5 text-gray-500">
+                Keep the submitted wording for news releases, feature stories, or other copy
+                that should not be rewritten.
+              </p>
+              <Button
+                onClick={() => onReviewFinalEdit('original')}
+                disabled={loading}
+                variant="secondary"
+                className="w-full"
+              >
+                Continue without AI
+              </Button>
+            </div>
+          )}
         </div>
       )}
 
@@ -84,13 +102,17 @@ export default function AIEditControls({
             </div>
           )}
 
-          <Button
-            onClick={onReviewFinalEdit}
-            variant="secondary"
-            className="w-full"
-          >
-            Continue to Final Edit
-          </Button>
+          {reviewSource && (
+            <Button
+              onClick={() => onReviewFinalEdit(reviewSource)}
+              variant="secondary"
+              className="w-full"
+            >
+              {reviewSource === 'ai'
+                ? 'Use AI Suggestion in Final Edit'
+                : 'Use Original in Final Edit'}
+            </Button>
+          )}
 
           <div className="space-y-2 rounded-md border border-gray-200 bg-gray-50 p-3">
             <label htmlFor="editor-ai-feedback" className="block text-xs font-medium text-gray-600">

--- a/frontend/src/pages/EditPage.test.tsx
+++ b/frontend/src/pages/EditPage.test.tsx
@@ -264,7 +264,7 @@ describe('EditPage', () => {
 
     await screen.findByText('Accepted AI headline');
     expect(screen.queryByRole('button', { name: /accept ai edit/i })).not.toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: /continue to final edit/i }));
+    await user.click(screen.getByRole('button', { name: /use ai suggestion in final edit/i }));
     expect(screen.getByDisplayValue('Accepted AI headline')).toBeInTheDocument();
     expect(screen.getByDisplayValue('Accepted AI body.')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /save and approve/i }));
@@ -284,6 +284,41 @@ describe('EditPage', () => {
       'submission-1',
       expect.objectContaining({ Status: 'approved' }),
     );
+  });
+
+  it('uses the original submission when an editor bypasses an existing AI suggestion', async () => {
+    const user = userEvent.setup();
+    listEditVersionsMock.mockResolvedValue([
+      makeVersion({
+        Headline: 'Unreviewed AI headline',
+        Body: 'Unreviewed AI body.',
+        Headline_Case: 'title_case',
+      }),
+    ]);
+
+    renderEditPage();
+
+    await screen.findByText('Unreviewed AI headline');
+    await user.click(screen.getByRole('button', { name: 'Original' }));
+    await user.click(screen.getByRole('button', { name: /use original in final edit/i }));
+
+    const finalEdit = screen.getByRole('region', { name: 'Final edit' });
+    expect(within(finalEdit).getByText('Starting point: Original submission')).toBeInTheDocument();
+    expect(within(finalEdit).getByDisplayValue('Original campus headline')).toBeInTheDocument();
+    expect(
+      within(finalEdit).getByDisplayValue('Original body copy for the newsletter.'),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /save and approve/i }));
+
+    await waitFor(() => {
+      expect(saveEditorFinalMock).toHaveBeenCalledWith('submission-1', {
+        Headline: 'Original campus headline',
+        Body: 'Original body copy for the newsletter.',
+        Headline_Case: undefined,
+        Approve_For_Newsletter: true,
+      });
+    });
   });
 
   it('saves and approves manual final edits with one action', async () => {
@@ -330,7 +365,7 @@ describe('EditPage', () => {
     renderEditPage();
 
     await screen.findByText('AI working headline');
-    await user.click(screen.getByRole('button', { name: /continue to final edit/i }));
+    await user.click(screen.getByRole('button', { name: /use ai suggestion in final edit/i }));
 
     const original = screen.getByRole('region', { name: 'Original submission' });
     const finalEdit = screen.getByRole('region', { name: 'Final edit' });
@@ -385,7 +420,7 @@ describe('EditPage', () => {
       expect(saveEditorFinalMock).toHaveBeenCalledWith('submission-1', {
         Headline: 'Final event headline',
         Body: 'Reserve a seat. Register now.\n<a href="mailto:events@uidaho.edu">UCM events</a>',
-        Headline_Case: undefined,
+        Headline_Case: 'sentence_case',
         Approve_For_Newsletter: false,
         Links: [
           {

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -31,6 +31,7 @@ import { Button, SegmentedToggle, Toast, useToast } from '../components/common';
 type Tab = 'original' | 'ai_edit' | 'editor';
 type ViewMode = 'diff' | 'side_by_side';
 type FinalizationAction = 'draft' | 'approve' | null;
+type FinalEditSource = 'original' | 'ai' | 'saved' | null;
 
 const STATUS_COLORS: Record<string, string> = {
   new: 'bg-status-info-100 text-status-info-800',
@@ -54,6 +55,7 @@ export default function EditPage() {
   const [loading, setLoading] = useState(true);
   const [aiLoading, setAiLoading] = useState(false);
   const [finalizationAction, setFinalizationAction] = useState<FinalizationAction>(null);
+  const [finalEditSource, setFinalEditSource] = useState<FinalEditSource>(null);
   const [editorialSaving, setEditorialSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { toast, showToast, dismissToast } = useToast();
@@ -91,24 +93,28 @@ export default function EditPage() {
             setEditHeadline(editorVersion.Headline);
             setEditBody(editable.body);
             setEditLinks(editable.links);
+            setFinalEditSource('saved');
             setActiveTab('editor');
           } else if (aiVersion) {
             const editable = prepareBodyForEditing(aiVersion.Body, sub.Links);
             setEditHeadline(aiVersion.Headline);
             setEditBody(editable.body);
             setEditLinks(editable.links);
+            setFinalEditSource(null);
             setActiveTab('ai_edit');
           } else {
             const editable = prepareBodyForEditing(sub.Original_Body, sub.Links);
             setEditHeadline(sub.Original_Headline);
             setEditBody(editable.body);
             setEditLinks(editable.links);
+            setFinalEditSource(null);
           }
         } catch {
           const editable = prepareBodyForEditing(sub.Original_Body, sub.Links);
           setEditHeadline(sub.Original_Headline);
           setEditBody(editable.body);
           setEditLinks(editable.links);
+          setFinalEditSource(null);
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load submission');
@@ -139,18 +145,21 @@ export default function EditPage() {
           setEditHeadline(editorVersion.Headline);
           setEditBody(editable.body);
           setEditLinks(editable.links);
+          setFinalEditSource('saved');
           setActiveTab('editor');
         } else if (aiVersion) {
           const editable = prepareBodyForEditing(aiVersion.Body, sub.Links);
           setEditHeadline(aiVersion.Headline);
           setEditBody(editable.body);
           setEditLinks(editable.links);
+          setFinalEditSource(null);
           setActiveTab('ai_edit');
         } else {
           const editable = prepareBodyForEditing(sub.Original_Body, sub.Links);
           setEditHeadline(sub.Original_Headline);
           setEditBody(editable.body);
           setEditLinks(editable.links);
+          setFinalEditSource(null);
         }
       } catch {
         // No versions yet — that's fine
@@ -158,6 +167,7 @@ export default function EditPage() {
         setEditHeadline(sub.Original_Headline);
         setEditBody(editable.body);
         setEditLinks(editable.links);
+        setFinalEditSource(null);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load submission');
@@ -192,6 +202,7 @@ export default function EditPage() {
       setEditHeadline(result.Edited_Headline);
       setEditBody(editable.body);
       setEditLinks(editable.links);
+      setFinalEditSource(null);
       setActiveTab('ai_edit');
       // Refresh data
       const sub = await getSubmission(id);
@@ -208,7 +219,27 @@ export default function EditPage() {
     }
   };
 
-  const handleReviewFinalEdit = () => {
+  const handleReviewFinalEdit = (source: 'original' | 'ai') => {
+    if (!submission) return;
+    if (source === 'original') {
+      const editable = prepareBodyForEditing(submission.Original_Body, submission.Links);
+      setEditHeadline(submission.Original_Headline);
+      setEditBody(editable.body);
+      setEditLinks(editable.links);
+    } else {
+      const aiVersion = [...versions].reverse().find((v) => v.Version_Type === 'ai_suggested');
+      const headline = aiVersion?.Headline || aiEditResult?.Edited_Headline;
+      const body = aiVersion?.Body || aiEditResult?.Edited_Body;
+      if (!headline || !body) {
+        setError('No AI suggestion is available for final editing.');
+        return;
+      }
+      const editable = prepareBodyForEditing(body, submission.Links);
+      setEditHeadline(headline);
+      setEditBody(editable.body);
+      setEditLinks(editable.links);
+    }
+    setFinalEditSource(source);
     setActiveTab('editor');
   };
 
@@ -218,11 +249,17 @@ export default function EditPage() {
     setError(null);
     try {
       const aiVersion = [...versions].reverse().find((v) => v.Version_Type === 'ai_suggested');
+      const editorVersion = [...versions].reverse().find((v) => v.Version_Type === 'editor_final');
+      const sourceVersion = finalEditSource === 'ai'
+        ? aiVersion
+        : finalEditSource === 'saved'
+          ? editorVersion
+          : undefined;
       const links = normalizedBodyLinks(editLinks);
       await saveEditorFinal(id, {
         Headline: editHeadline,
         Body: buildLinkedBody(editBody, links),
-        Headline_Case: aiVersion?.Headline_Case || undefined,
+        Headline_Case: sourceVersion?.Headline_Case || undefined,
         Approve_For_Newsletter: approveForNewsletter,
         ...((submission?.Links.length ?? 0) > 0 || links.length > 0
           ? { Links: links }
@@ -412,6 +449,25 @@ export default function EditPage() {
     { id: 'ai_edit', label: 'AI Suggested', available: hasAIEdit },
     { id: 'editor', label: 'Final Edit', available: true },
   ];
+  const finalEditSourceLabel = finalEditSource === 'ai'
+    ? 'AI suggestion'
+    : finalEditSource === 'saved'
+      ? 'Saved final version'
+      : 'Original submission';
+
+  const handleTabChange = (tab: Tab) => {
+    const selected = tabs.find((candidate) => candidate.id === tab);
+    if (!selected?.available) return;
+    if (tab !== 'editor' || activeTab === 'editor') {
+      setActiveTab(tab);
+      return;
+    }
+    if (finalEditSource !== null) {
+      setActiveTab('editor');
+      return;
+    }
+    handleReviewFinalEdit(activeTab === 'ai_edit' ? 'ai' : 'original');
+  };
 
   return (
     <div>
@@ -459,7 +515,7 @@ export default function EditPage() {
               {tabs.map((tab) => (
                 <button
                   key={tab.id}
-                  onClick={() => tab.available && setActiveTab(tab.id)}
+                  onClick={() => handleTabChange(tab.id)}
                   disabled={!tab.available}
                   className={`pb-2 text-sm font-medium border-b-2 transition-colors ${
                     activeTab === tab.id
@@ -600,7 +656,7 @@ export default function EditPage() {
                   <div>
                     <h3 className="text-sm font-semibold text-gray-900">Final edit</h3>
                     <p className="mt-1 text-xs text-gray-500">
-                      Edit the working version while keeping the original in view.
+                      Starting point: {finalEditSourceLabel}
                     </p>
                   </div>
                   <HeadlineEditor
@@ -679,6 +735,7 @@ export default function EditPage() {
             hasAIEdit={hasAIEdit}
             targetNewsletter={submission.Target_Newsletter}
             confidence={confidence}
+            reviewSource={activeTab === 'ai_edit' ? 'ai' : activeTab === 'original' ? 'original' : null}
           />
           <SubmissionMeta
             submission={submission}


### PR DESCRIPTION
## Summary

- strengthen the shared short-sentence rule so AI edits use complete, single-idea sentences and avoid semicolons
- add an idempotent migration that updates existing databases to the stronger rule
- apply a prose-only semicolon safeguard while preserving URLs and HTML entities
- require editors to explicitly choose either the original submission or the AI suggestion before entering Final Edit
- label the selected Final Edit starting point and preserve original headline metadata when bypassing AI

## Why

News releases and feature stories may already be approved copy and must be able to bypass AI without the editor accidentally adopting an existing AI version. AI edits also need to consistently follow Joy's concise sentence guidance.

## Root cause

Final Edit fields were initialized from the latest AI version, while the previous Original-to-Final action only changed tabs. The shared short-sentence rule was advisory and the base prompt did not contain the full mandatory guidance.

## Impact

Editors now make a deliberate source choice. Choosing Original preserves the submitted headline and body exactly; choosing AI uses the latest suggestion. AI-generated prose is constrained to short, direct sentences without semicolons.

## Validation

- backend: 159 tests passed
- backend: Ruff passed
- Alembic reports `b6e8f0a2c4d1` as head
- frontend: 57 tests passed
- frontend: ESLint passed
- frontend production build passed
- live browser QA passed for both source-selection paths with no console errors

Closes #232
Closes #233
