### PR TITLE
Show side-by-side manual editing on laptop widths with submitted links

### DIFF
--- a/frontend/src/pages/EditPage.test.tsx
+++ b/frontend/src/pages/EditPage.test.tsx
@@ -375,6 +375,39 @@ describe('EditPage', () => {
     expect(within(finalEdit).getByDisplayValue('AI working body.')).toBeInTheDocument();
   });
 
+  it('lists submitted links in display order inside the original reference panel', async () => {
+    const user = userEvent.setup();
+    getSubmissionMock.mockResolvedValue(makeSubmission({
+      Links: [
+        {
+          Id: 'link-2',
+          Url: 'https://example.com/details',
+          Anchor_Text: null,
+          Display_Order: 1,
+        },
+        {
+          Id: 'link-1',
+          Url: 'https://example.com/register',
+          Anchor_Text: 'Register now',
+          Display_Order: 0,
+        },
+      ],
+    }));
+    listEditVersionsMock.mockResolvedValue([]);
+
+    renderEditPage();
+
+    await screen.findByText('Original campus headline');
+    await user.click(screen.getByRole('button', { name: 'Final Edit' }));
+
+    const original = screen.getByRole('region', { name: 'Original submission' });
+    expect(within(original).getByText('Submitted links')).toBeInTheDocument();
+    const links = within(original).getAllByRole('listitem');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveTextContent('Register now — https://example.com/register');
+    expect(links[1]).toHaveTextContent('https://example.com/details');
+  });
+
   it('shows live CTA links while keeping destination fields separately editable', async () => {
     const user = userEvent.setup();
     getSubmissionMock.mockResolvedValue(makeSubmission({

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -629,10 +629,10 @@ export default function EditPage() {
             )}
 
             {activeTab === 'editor' && (
-              <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+              <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
                 <section
                   aria-label="Original submission"
-                  className="space-y-4 rounded-lg border border-gray-200 bg-gray-50 p-4"
+                  className="space-y-4 rounded-lg border border-gray-200 bg-gray-50 p-4 lg:sticky lg:top-6 lg:self-start"
                 >
                   <div>
                     <h3 className="text-sm font-semibold text-gray-900">Original submission</h3>
@@ -650,6 +650,23 @@ export default function EditPage() {
                       {submission.Original_Body}
                     </p>
                   </div>
+                  {submission.Links.length > 0 && (
+                    <div>
+                      <p className="mb-1 text-xs font-medium text-gray-500">Submitted links</p>
+                      <ul className="space-y-1">
+                        {[...submission.Links]
+                          .sort((a, b) => a.Display_Order - b.Display_Order)
+                          .map((link) => (
+                            <li key={link.Id} className="text-sm text-gray-700">
+                              {link.Anchor_Text?.trim() && (
+                                <span className="font-medium">{link.Anchor_Text} — </span>
+                              )}
+                              <span className="break-all text-gray-500">{link.Url}</span>
+                            </li>
+                          ))}
+                      </ul>
+                    </div>
+                  )}
                 </section>
 
                 <section aria-label="Final edit" className="min-w-0 space-y-4">


### PR DESCRIPTION
## Summary

Issue #63's core side-by-side view already shipped in #231, but two gaps kept it from fully serving the reporter:

- **The side-by-side layout only activated at `xl` (1280px).** The feedback reporter's own window was 1272px wide, so she still saw the original stacked above the editor. The two-column grid now activates at `lg` (1024px), matching the page's main breakpoint.
- **The read-only original panel omitted the submission's links.** It now lists them in display order (anchor text + URL), so the reference panel shows everything the submitter provided. The panel is also sticky on large screens so the original stays visible while scrolling the editor.

## Verification

- `npm test` — 12 EditPage tests pass, including a new test asserting submitted links render in display order inside the original reference panel
- `npm run lint` and `npm run build` — clean
- Verified in the browser at 1272×668 (the reporter's viewport): side-by-side layout active, links listed under the original body, final-edit panel editable alongside

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)