### PR TITLE
Reset announcement type to the top option after a successful submission

### DIFF
--- a/frontend/src/components/submission/SubmissionForm.test.tsx
+++ b/frontend/src/components/submission/SubmissionForm.test.tsx
@@ -187,6 +187,24 @@ describe('SubmissionForm', () => {
     expect(await screen.findByText(/submission received/i)).toBeInTheDocument();
   });
 
+  it('resets the announcement type to the top option after a successful submission', async () => {
+    const user = userEvent.setup();
+    render(<SubmissionForm />);
+
+    await screen.findByRole('option', { name: 'Faculty or Staff Announcement' });
+    await user.selectOptions(screen.getByLabelText('Announcement Type'), 'survey');
+    await user.type(screen.getByLabelText(/survey \/ event end date/i), '2026-05-30');
+    await fillStandardAnnouncement(user);
+    await user.click(screen.getByRole('button', { name: /submit announcement/i }));
+
+    await waitFor(() => {
+      expect(createSubmissionMock).toHaveBeenCalled();
+    });
+    expect(screen.getByLabelText('Announcement Type')).toHaveValue('faculty_staff');
+    // Submitter identity is intentionally retained for convenience.
+    expect(screen.getByLabelText('Your Name')).toHaveValue('Jane Submitter');
+  });
+
   it('submits separate TDR and My UI run dates when both newsletters are selected', async () => {
     const user = userEvent.setup();
     render(<SubmissionForm />);

--- a/frontend/src/components/submission/SubmissionForm.tsx
+++ b/frontend/src/components/submission/SubmissionForm.tsx
@@ -404,6 +404,7 @@ export default function SubmissionForm() {
       setJobLocation('');
       setJobRemoveDate('');
       setLinks([]);
+      setCategory((filteredCategories[0]?.Code ?? 'faculty_staff') as SubmissionCategory);
       setSchedule({
         Requested_Date: '',
         Second_Requested_Date: '',


### PR DESCRIPTION
Closes #282

## Problem

The submission form's post-submit reset cleared headline, body, notes, job fields, links, and the schedule block — but not the announcement type. Submitting another announcement from the same mounted page therefore started from the previously chosen type instead of Faculty/Staff Announcement.

## Fix

Reset the category to the first entry of the rendered (target-filtered) category list in the post-submit reset, matching the fresh-page-load default. Submitter name and email retention (intentional convenience) is unchanged.

## Testing

- New regression test: submit with a non-default type (Survey), assert the select returns to `faculty_staff` and submitter identity is retained.
- `npx vitest run src/components/submission/SubmissionForm.test.tsx` — 6 passed.
- `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)