### PR TITLE
Add contact-line format style rule (hyperlink contacts, never duplicate names)

### DIFF
--- a/backend/alembic/versions/d8f2a6c4e9b3_add_contact_line_format_rule.py
+++ b/backend/alembic/versions/d8f2a6c4e9b3_add_contact_line_format_rule.py
@@ -1,0 +1,106 @@
+"""add contact line format rule
+
+Revision ID: d8f2a6c4e9b3
+Revises: b6e8f0a2c4d1
+Create Date: 2026-08-07 14:00:00.000000
+
+Add Joy's standing contact-line rule: hyperlink contact names with provided
+email addresses, retain phone numbers, and never repeat a contact's name in
+place of contact information. The migration is idempotent and narrowly
+updates only this managed rule key.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "d8f2a6c4e9b3"
+down_revision: str | Sequence[str] | None = "b6e8f0a2c4d1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+CONTACT_LINE_RULE_TEXT = (
+    "When the original submission provides an email address for a contact "
+    "person or unit, hyperlink the person's or unit's name with that email "
+    "address instead of displaying the address as plain text. Keep phone "
+    "numbers from the original submission. Never repeat the contact's name "
+    "in place of contact information: write 'contact Paul Rowley' (name "
+    "linked) or 'contact Paul Rowley at 208-885-1234', never 'contact Paul "
+    "Rowley at Paul Rowley' or 'contact Paul Rowley at prowley@uidaho.edu'. "
+    "In a contact line, 'at' must be followed by meaningful information such "
+    "as a phone number or location. If no email address or phone number is "
+    "provided, use the name alone."
+)
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _upsert_rule(
+    connection: sa.Connection,
+    *,
+    rule_key: str,
+    category: str,
+    rule_text: str,
+    severity: str,
+) -> None:
+    existing_id = connection.execute(
+        sa.select(style_rules.c.Id).where(
+            style_rules.c.Rule_Set == "shared",
+            style_rules.c.Rule_Key == rule_key,
+        )
+    ).scalar_one_or_none()
+    values = {
+        "Category": category,
+        "Rule_Text": rule_text,
+        "Is_Active": True,
+        "Severity": severity,
+    }
+    if existing_id:
+        connection.execute(
+            style_rules.update().where(style_rules.c.Id == existing_id).values(**values)
+        )
+    else:
+        connection.execute(
+            style_rules.insert().values(
+                Id=str(uuid.uuid4()),
+                Rule_Set="shared",
+                Rule_Key=rule_key,
+                **values,
+            )
+        )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    _upsert_rule(
+        connection,
+        rule_key="contact_line_format",
+        category="formatting",
+        rule_text=CONTACT_LINE_RULE_TEXT,
+        severity="error",
+    )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    connection.execute(
+        style_rules.delete().where(
+            style_rules.c.Rule_Set == "shared",
+            style_rules.c.Rule_Key == "contact_line_format",
+            style_rules.c.Rule_Text == CONTACT_LINE_RULE_TEXT,
+        )
+    )

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -304,5 +304,11 @@
     "rule_key": "cta_structure",
     "rule_text": "Structure announcements around a clear call to action: open with the action the reader should take, follow with context, dates and incentives, and close with an explicit final call to action such as 'Learn more and register'. Replace vague instructions with explicit actions. Do not introduce audience qualifiers that are not in the original submission. When the submission provides a contact's full name, use it rather than a bare email address.",
     "severity": "warning"
+  },
+  {
+    "category": "formatting",
+    "rule_key": "contact_line_format",
+    "rule_text": "When the original submission provides an email address for a contact person or unit, hyperlink the person's or unit's name with that email address instead of displaying the address as plain text. Keep phone numbers from the original submission. Never repeat the contact's name in place of contact information: write 'contact Paul Rowley' (name linked) or 'contact Paul Rowley at 208-885-1234', never 'contact Paul Rowley at Paul Rowley' or 'contact Paul Rowley at prowley@uidaho.edu'. In a contact line, 'at' must be followed by meaningful information such as a phone number or location. If no email address or phone number is provided, use the name alone.",
+    "severity": "error"
   }
 ]

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -260,6 +260,56 @@ class TestAIEditTasks:
             SuccessfulProvider.last_system_prompt
         )
 
+    async def test_staff_ai_edit_receives_contact_line_format_rule(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        SuccessfulProvider.last_system_prompt = ""
+        db.add(
+            StyleRule(
+                Rule_Set="shared",
+                Category="formatting",
+                Rule_Key="contact_line_format",
+                Rule_Text=(
+                    "Never repeat the contact's name in place of contact "
+                    "information. Hyperlink the contact's name with a provided "
+                    "email address instead of displaying the address."
+                ),
+                Severity="error",
+            )
+        )
+        await db.commit()
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: SuccessfulProvider(),
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Original_Body=(
+                    "The safety fair runs 9-11 a.m. Friday, Aug. 21, in the "
+                    "Pitman Center. For questions, please contact Paul Rowley "
+                    "(prowley@uidaho.edu)."
+                ),
+            ),
+        )
+        assert submission_resp.status_code == 201
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_resp.json()['Id']}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+        assert resp.status_code == 202
+        task = await wait_for_task(client, resp.json()["Task_Id"], staff_headers)
+        assert task["Status"] == "succeeded"
+        assert "[MUST] Never repeat the contact's name in place of contact" in (
+            SuccessfulProvider.last_system_prompt
+        )
+
     async def test_staff_ai_edit_enforces_short_sentences_and_safe_semicolon_cleanup(
         self,
         client: AsyncClient,

--- a/backend/tests/test_contact_line_rule_migration.py
+++ b/backend/tests/test_contact_line_rule_migration.py
@@ -1,0 +1,104 @@
+"""Regression coverage for the contact-line format style-rule migration."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "d8f2a6c4e9b3_add_contact_line_format_rule.py"
+)
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("contact_line_rule", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def style_rules_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+
+
+def test_rule_upsert_is_idempotent_and_preserves_unrelated_rules():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert(),
+            [
+                {
+                    "Id": "stale-contact",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "contact_line_format",
+                    "Rule_Text": "Old contact wording.",
+                    "Is_Active": False,
+                    "Severity": "warning",
+                },
+                {
+                    "Id": "custom",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "staff_custom",
+                    "Rule_Text": "Keep this staff rule.",
+                    "Is_Active": True,
+                    "Severity": "info",
+                },
+            ],
+        )
+
+        for _ in range(2):
+            migration._upsert_rule(
+                connection,
+                rule_key="contact_line_format",
+                category="formatting",
+                rule_text=migration.CONTACT_LINE_RULE_TEXT,
+                severity="error",
+            )
+
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    by_key = {row["Rule_Key"]: row for row in rows}
+    assert by_key["contact_line_format"]["Rule_Text"] == (
+        migration.CONTACT_LINE_RULE_TEXT
+    )
+    assert by_key["contact_line_format"]["Category"] == "formatting"
+    assert by_key["contact_line_format"]["Severity"] == "error"
+    assert by_key["contact_line_format"]["Is_Active"] is True
+    assert by_key["staff_custom"]["Rule_Text"] == "Keep this staff rule."
+    assert len(rows) == 2
+
+
+def test_migration_values_match_shared_style_rule_seed():
+    migration = load_migration()
+    seed_path = Path(__file__).parents[1] / "data" / "style_rules" / "shared_rules.json"
+    seeded = {rule["rule_key"]: rule for rule in json.loads(seed_path.read_text())}
+
+    assert seeded["contact_line_format"]["rule_text"] == (
+        migration.CONTACT_LINE_RULE_TEXT
+    )
+    assert seeded["contact_line_format"]["severity"] == "error"
+    assert seeded["contact_line_format"]["category"] == "formatting"


### PR DESCRIPTION
Closes #272

## Problem

The AI editor sometimes repeats a contact's name in place of contact information ("contact Paul Rowley at Paul Rowley"), displays raw email addresses instead of embedding them, or drops phone numbers. Triage confirmed `link_embedding` and `no_duplicate_link_text` are active on dev but no rule governs contact lines.

## Fix

New mandatory (`error`) shared rule `contact_line_format`: hyperlink the contact's or unit's name with a provided email address, retain phone numbers, never repeat the name, and require "at" to be followed by meaningful information.

- Seed data (`shared_rules.json`) for fresh databases
- Idempotent alembic upsert migration `d8f2a6c4e9b3` (revises `b6e8f0a2c4d1`) for deployed databases, with delete-on-downgrade guarded by exact text match
- Migration regression tests mirroring the prior Joy-rule pattern (idempotent upsert, unrelated rules preserved, migration text matches seed text)
- Prompt-delivery test asserting the `[MUST]` rule reaches the assembled system prompt for a staff TDR edit

## Testing

- `pytest` — 162 passed (full backend suite)
- `ruff check .` — clean
- `alembic heads` — single head `d8f2a6c4e9b3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)