### PR TITLE
Require commas after month-day dates when the sentence continues (AP style)

### DIFF
--- a/backend/alembic/versions/e4b7c9d2a1f8_require_date_continuation_commas.py
+++ b/backend/alembic/versions/e4b7c9d2a1f8_require_date_continuation_commas.py
@@ -1,0 +1,101 @@
+"""require date continuation commas
+
+Revision ID: e4b7c9d2a1f8
+Revises: d8f2a6c4e9b3
+Create Date: 2026-08-07 14:00:00.000000
+
+Extend the AP date style rule with the continuation-comma requirement:
+a comma must follow a month-and-day date when the sentence continues,
+including within ranges and sequences. Idempotent; touches only the
+managed ap_style_dates rule key.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "e4b7c9d2a1f8"
+down_revision: str | Sequence[str] | None = "d8f2a6c4e9b3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+AP_DATES_RULE_TEXT = (
+    "Use AP style for dates: abbreviate months with 6+ letters (Jan., "
+    "Feb., Aug., Sept., Oct., Nov., Dec.). Spell out March, April, May, "
+    "June, July. Use numerals for dates (Jan. 5, not January fifth). When "
+    "a month-and-day date appears mid-sentence, place a comma after the "
+    "date if the sentence continues: 'The conference runs Monday, Oct. "
+    "31, and Tuesday, Nov. 1.' 'The workshop is Wednesday, Sept. 16, in "
+    "the Pitman Center.' Apply the comma to every date in a range or "
+    "sequence."
+)
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _upsert_rule(
+    connection: sa.Connection,
+    *,
+    rule_set: str,
+    rule_key: str,
+    category: str,
+    rule_text: str,
+    severity: str,
+) -> None:
+    existing_id = connection.execute(
+        sa.select(style_rules.c.Id).where(
+            style_rules.c.Rule_Set == rule_set,
+            style_rules.c.Rule_Key == rule_key,
+        )
+    ).scalar_one_or_none()
+    values = {
+        "Category": category,
+        "Rule_Text": rule_text,
+        "Is_Active": True,
+        "Severity": severity,
+    }
+    if existing_id:
+        connection.execute(
+            style_rules.update().where(style_rules.c.Id == existing_id).values(**values)
+        )
+    else:
+        connection.execute(
+            style_rules.insert().values(
+                Id=str(uuid.uuid4()),
+                Rule_Set=rule_set,
+                Rule_Key=rule_key,
+                **values,
+            )
+        )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    _upsert_rule(
+        connection,
+        rule_set="shared",
+        rule_key="ap_style_dates",
+        category="formatting",
+        rule_text=AP_DATES_RULE_TEXT,
+        severity="warning",
+    )
+
+
+def downgrade() -> None:
+    # Text-only revision of managed rules; the prior wording is not
+    # restored on downgrade.
+    pass

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -38,7 +38,7 @@
   {
     "category": "formatting",
     "rule_key": "ap_style_dates",
-    "rule_text": "Use AP style for dates: abbreviate months with 6+ letters (Jan., Feb., Aug., Sept., Oct., Nov., Dec.). Spell out March, April, May, June, July. Use numerals for dates (Jan. 5, not January fifth).",
+    "rule_text": "Use AP style for dates: abbreviate months with 6+ letters (Jan., Feb., Aug., Sept., Oct., Nov., Dec.). Spell out March, April, May, June, July. Use numerals for dates (Jan. 5, not January fifth). When a month-and-day date appears mid-sentence, place a comma after the date if the sentence continues: 'The conference runs Monday, Oct. 31, and Tuesday, Nov. 1.' 'The workshop is Wednesday, Sept. 16, in the Pitman Center.' Apply the comma to every date in a range or sequence.",
     "severity": "warning"
   },
   {

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -310,6 +310,56 @@ class TestAIEditTasks:
             SuccessfulProvider.last_system_prompt
         )
 
+    async def test_staff_ai_edit_receives_date_continuation_comma_rule(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        SuccessfulProvider.last_system_prompt = ""
+        db.add(
+            StyleRule(
+                Rule_Set="shared",
+                Category="formatting",
+                Rule_Key="ap_style_dates",
+                Rule_Text=(
+                    "Use AP style for dates. When a month-and-day date appears "
+                    "mid-sentence, place a comma after the date if the sentence "
+                    "continues."
+                ),
+                Severity="warning",
+            )
+        )
+        await db.commit()
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: SuccessfulProvider(),
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Original_Body=(
+                    "The conference will take place on Monday, Oct. 31 and "
+                    "Tuesday, Nov. 1 in the Pitman Center."
+                ),
+            ),
+        )
+        assert submission_resp.status_code == 201
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_resp.json()['Id']}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+        assert resp.status_code == 202
+        task = await wait_for_task(client, resp.json()["Task_Id"], staff_headers)
+        assert task["Status"] == "succeeded"
+        assert (
+            "[SHOULD] Use AP style for dates. When a month-and-day date appears"
+            in SuccessfulProvider.last_system_prompt
+        )
+
     async def test_staff_ai_edit_enforces_short_sentences_and_safe_semicolon_cleanup(
         self,
         client: AsyncClient,

--- a/backend/tests/test_date_continuation_comma_migration.py
+++ b/backend/tests/test_date_continuation_comma_migration.py
@@ -1,0 +1,104 @@
+"""Regression coverage for the require date continuation commas migration."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "e4b7c9d2a1f8_require_date_continuation_commas.py"
+)
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("date_continuation_comma", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def style_rules_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+
+
+def test_rule_upserts_are_idempotent_and_preserve_unrelated_rules():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert(),
+            [
+                {
+                    "Id": "stale",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "ap_style_dates",
+                    "Rule_Text": "Old wording.",
+                    "Is_Active": False,
+                    "Severity": "info",
+                },
+                {
+                    "Id": "custom",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "staff_custom",
+                    "Rule_Text": "Keep this staff rule.",
+                    "Is_Active": True,
+                    "Severity": "info",
+                },
+            ],
+        )
+
+        for _ in range(2):
+            migration._upsert_rule(
+                connection,
+                rule_set="shared",
+                rule_key="ap_style_dates",
+                category="formatting",
+                rule_text=migration.AP_DATES_RULE_TEXT,
+                severity="warning",
+            )
+
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    by_key = {row["Rule_Key"]: row for row in rows}
+    assert by_key["ap_style_dates"]["Rule_Text"] == migration.AP_DATES_RULE_TEXT
+    assert by_key["ap_style_dates"]["Category"] == "formatting"
+    assert by_key["ap_style_dates"]["Severity"] == "warning"
+    assert by_key["ap_style_dates"]["Is_Active"] is True
+    assert by_key["staff_custom"]["Rule_Text"] == "Keep this staff rule."
+    assert len(rows) == 2
+
+
+def test_migration_values_match_style_rule_seeds():
+    migration = load_migration()
+    seed_dir = Path(__file__).parents[1] / "data" / "style_rules"
+    seeded_shared = {
+        rule["rule_key"]: rule
+        for rule in json.loads((seed_dir / "shared_rules.json").read_text())
+    }
+
+    assert seeded_shared["ap_style_dates"]["rule_text"] == migration.AP_DATES_RULE_TEXT
+    assert seeded_shared["ap_style_dates"]["severity"] == "warning"
+    assert seeded_shared["ap_style_dates"]["category"] == "formatting"


### PR DESCRIPTION
Closes #273

## Problem

Edited output omitted the comma AP style requires after a month-and-day date when the sentence continues ("Monday, Oct. 31 and Tuesday, Nov. 1"; "Wednesday, Sept. 16 in the Pitman Center"). Triage confirmed `ap_style_dates` is active on dev but its text never mentions the continuation comma.

## Fix

Extend the `ap_style_dates` rule text with the continuation-comma requirement and both of Joy's examples, applied to every date in a range or sequence. Severity unchanged (`warning`).

- Seed update in `shared_rules.json`
- Idempotent alembic upsert migration `e4b7c9d2a1f8` (revises `d8f2a6c4e9b3`); text-only revision, so downgrade is a documented no-op
- Migration regression tests (idempotent upsert, unrelated rules preserved, migration text matches seed)
- Prompt-delivery test asserting the `[SHOULD]` rule text reaches the assembled system prompt

## Testing

- `pytest` — 165 passed (full backend suite)
- `ruff check .` — clean
- `alembic heads` — single head `e4b7c9d2a1f8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)