### PR TITLE
Add deadline-preservation style rule (actionable dates outrank conciseness)

### DIFF
--- a/backend/alembic/versions/f9a3d5e7c2b4_add_preserve_deadlines_rule.py
+++ b/backend/alembic/versions/f9a3d5e7c2b4_add_preserve_deadlines_rule.py
@@ -1,0 +1,109 @@
+"""add preserve deadlines rule
+
+Revision ID: f9a3d5e7c2b4
+Revises: e4b7c9d2a1f8
+Create Date: 2026-08-07 14:00:00.000000
+
+Add Joy's standing rule that deadlines and other actionable dates
+survive condensing edits. Actionable information outranks conciseness:
+shorten surrounding prose instead of deleting deadlines. Idempotent;
+touches only the managed preserve_action_deadlines rule key.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f9a3d5e7c2b4"
+down_revision: str | Sequence[str] | None = "e4b7c9d2a1f8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+PRESERVE_DEADLINES_RULE_TEXT = (
+    "Preserve every deadline and actionable date from the original "
+    "submission: registration, application, abstract, proposal, "
+    "nomination and submission deadlines, event dates and times, "
+    "application periods, registration requirements and eligibility "
+    "information. Keep multiple deadlines when they serve different "
+    "purposes. Never replace a specific deadline with a generic call to "
+    "action such as 'Learn more and register'. When editing for "
+    "conciseness, shorten the surrounding prose instead of removing "
+    "deadlines. Example: 'Registration closes Oct. 23. Abstract "
+    "submissions are due Oct. 16. Learn more and register.' is correct; "
+    "dropping either date is not."
+)
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _upsert_rule(
+    connection: sa.Connection,
+    *,
+    rule_set: str,
+    rule_key: str,
+    category: str,
+    rule_text: str,
+    severity: str,
+) -> None:
+    existing_id = connection.execute(
+        sa.select(style_rules.c.Id).where(
+            style_rules.c.Rule_Set == rule_set,
+            style_rules.c.Rule_Key == rule_key,
+        )
+    ).scalar_one_or_none()
+    values = {
+        "Category": category,
+        "Rule_Text": rule_text,
+        "Is_Active": True,
+        "Severity": severity,
+    }
+    if existing_id:
+        connection.execute(
+            style_rules.update().where(style_rules.c.Id == existing_id).values(**values)
+        )
+    else:
+        connection.execute(
+            style_rules.insert().values(
+                Id=str(uuid.uuid4()),
+                Rule_Set=rule_set,
+                Rule_Key=rule_key,
+                **values,
+            )
+        )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    _upsert_rule(
+        connection,
+        rule_set="shared",
+        rule_key="preserve_action_deadlines",
+        category="content_filtering",
+        rule_text=PRESERVE_DEADLINES_RULE_TEXT,
+        severity="error",
+    )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    connection.execute(
+        style_rules.delete().where(
+            style_rules.c.Rule_Set == "shared",
+            style_rules.c.Rule_Key == "preserve_action_deadlines",
+            style_rules.c.Rule_Text == PRESERVE_DEADLINES_RULE_TEXT,
+        )
+    )

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -310,5 +310,11 @@
     "rule_key": "contact_line_format",
     "rule_text": "When the original submission provides an email address for a contact person or unit, hyperlink the person's or unit's name with that email address instead of displaying the address as plain text. Keep phone numbers from the original submission. Never repeat the contact's name in place of contact information: write 'contact Paul Rowley' (name linked) or 'contact Paul Rowley at 208-885-1234', never 'contact Paul Rowley at Paul Rowley' or 'contact Paul Rowley at prowley@uidaho.edu'. In a contact line, 'at' must be followed by meaningful information such as a phone number or location. If no email address or phone number is provided, use the name alone.",
     "severity": "error"
+  },
+  {
+    "category": "content_filtering",
+    "rule_key": "preserve_action_deadlines",
+    "rule_text": "Preserve every deadline and actionable date from the original submission: registration, application, abstract, proposal, nomination and submission deadlines, event dates and times, application periods, registration requirements and eligibility information. Keep multiple deadlines when they serve different purposes. Never replace a specific deadline with a generic call to action such as 'Learn more and register'. When editing for conciseness, shorten the surrounding prose instead of removing deadlines. Example: 'Registration closes Oct. 23. Abstract submissions are due Oct. 16. Learn more and register.' is correct; dropping either date is not.",
+    "severity": "error"
   }
 ]

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -360,6 +360,56 @@ class TestAIEditTasks:
             in SuccessfulProvider.last_system_prompt
         )
 
+    async def test_staff_ai_edit_receives_deadline_preservation_rule(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        SuccessfulProvider.last_system_prompt = ""
+        db.add(
+            StyleRule(
+                Rule_Set="shared",
+                Category="content_filtering",
+                Rule_Key="preserve_action_deadlines",
+                Rule_Text=(
+                    "Preserve every deadline and actionable date from the "
+                    "original submission. Never replace a specific deadline "
+                    "with a generic call to action."
+                ),
+                Severity="error",
+            )
+        )
+        await db.commit()
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: SuccessfulProvider(),
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Original_Body=(
+                    "Registration deadline: Oct. 23. Abstract submission "
+                    "deadline: Oct. 16. Join the microbiology meeting."
+                ),
+            ),
+        )
+        assert submission_resp.status_code == 201
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_resp.json()['Id']}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+        assert resp.status_code == 202
+        task = await wait_for_task(client, resp.json()["Task_Id"], staff_headers)
+        assert task["Status"] == "succeeded"
+        assert (
+            "[MUST] Preserve every deadline and actionable date"
+            in SuccessfulProvider.last_system_prompt
+        )
+
     async def test_staff_ai_edit_enforces_short_sentences_and_safe_semicolon_cleanup(
         self,
         client: AsyncClient,

--- a/backend/tests/test_preserve_deadlines_rule_migration.py
+++ b/backend/tests/test_preserve_deadlines_rule_migration.py
@@ -1,0 +1,104 @@
+"""Regression coverage for the add preserve deadlines rule migration."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "f9a3d5e7c2b4_add_preserve_deadlines_rule.py"
+)
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("preserve_deadlines_rule", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def style_rules_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+
+
+def test_rule_upserts_are_idempotent_and_preserve_unrelated_rules():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert(),
+            [
+                {
+                    "Id": "stale",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "preserve_action_deadlines",
+                    "Rule_Text": "Old wording.",
+                    "Is_Active": False,
+                    "Severity": "info",
+                },
+                {
+                    "Id": "custom",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "staff_custom",
+                    "Rule_Text": "Keep this staff rule.",
+                    "Is_Active": True,
+                    "Severity": "info",
+                },
+            ],
+        )
+
+        for _ in range(2):
+            migration._upsert_rule(
+                connection,
+                rule_set="shared",
+                rule_key="preserve_action_deadlines",
+                category="content_filtering",
+                rule_text=migration.PRESERVE_DEADLINES_RULE_TEXT,
+                severity="error",
+            )
+
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    by_key = {row["Rule_Key"]: row for row in rows}
+    assert by_key["preserve_action_deadlines"]["Rule_Text"] == migration.PRESERVE_DEADLINES_RULE_TEXT
+    assert by_key["preserve_action_deadlines"]["Category"] == "content_filtering"
+    assert by_key["preserve_action_deadlines"]["Severity"] == "error"
+    assert by_key["preserve_action_deadlines"]["Is_Active"] is True
+    assert by_key["staff_custom"]["Rule_Text"] == "Keep this staff rule."
+    assert len(rows) == 2
+
+
+def test_migration_values_match_style_rule_seeds():
+    migration = load_migration()
+    seed_dir = Path(__file__).parents[1] / "data" / "style_rules"
+    seeded_shared = {
+        rule["rule_key"]: rule
+        for rule in json.loads((seed_dir / "shared_rules.json").read_text())
+    }
+
+    assert seeded_shared["preserve_action_deadlines"]["rule_text"] == migration.PRESERVE_DEADLINES_RULE_TEXT
+    assert seeded_shared["preserve_action_deadlines"]["severity"] == "error"
+    assert seeded_shared["preserve_action_deadlines"]["category"] == "content_filtering"


### PR DESCRIPTION
Closes #274

## Problem

When condensing lengthy submissions the AI editor removed registration/application/abstract deadlines, sometimes replacing them with a generic CTA. Triage confirmed the conciseness pressure comes from active rules `trim_lengthy` and `concise_clear`, with no rule protecting deadlines.

## Fix

New mandatory (`error`) shared rule `preserve_action_deadlines`: preserve every deadline and actionable date, keep multiple deadlines serving different purposes, never swap a specific deadline for a generic CTA, and shorten surrounding prose instead. Includes Joy's registration + abstract example.

- Seed update in `shared_rules.json`
- Idempotent alembic upsert migration `f9a3d5e7c2b4` (revises `e4b7c9d2a1f8`), delete-on-downgrade guarded by exact text
- Migration regression tests (idempotency, unrelated rules preserved, text matches seed)
- Prompt-delivery test asserting the `[MUST]` rule reaches the assembled system prompt

## Testing

- `pytest` — 168 passed (full backend suite)
- `ruff check .` — clean
- `alembic heads` — single head `f9a3d5e7c2b4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)