### PR TITLE
Ban generic CTA filler words such as "here"

### DIFF
--- a/backend/alembic/versions/a6c8e2f4b7d9_ban_generic_cta_filler.py
+++ b/backend/alembic/versions/a6c8e2f4b7d9_ban_generic_cta_filler.py
@@ -1,0 +1,105 @@
+"""ban generic CTA filler words
+
+Revision ID: a6c8e2f4b7d9
+Revises: f9a3d5e7c2b4
+Create Date: 2026-08-07 14:00:00.000000
+
+Strengthen the cta_structure rule: no call to action may be built on
+filler words such as 'here' or 'click here'. Link the action verb or
+the object of the action instead. Idempotent; touches only the managed
+cta_structure rule key.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "a6c8e2f4b7d9"
+down_revision: str | Sequence[str] | None = "f9a3d5e7c2b4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+CTA_RULE_TEXT = (
+    "Structure announcements around a clear call to action: open with the "
+    "action the reader should take, follow with context, dates and "
+    "incentives, and close with an explicit final call to action such as "
+    "'Learn more and register'. Replace vague instructions with explicit "
+    "actions. Do not introduce audience qualifiers that are not in the "
+    "original submission. When the submission provides a contact's full "
+    "name, use it rather than a bare email address. Never build a call to "
+    "action on filler words: no CTA may contain 'here', 'click here', "
+    "'learn more here', 'register here', 'apply here' or 'sign up here'. "
+    "Link the action verb or the object of the action instead: 'Sign up', "
+    "'Register for the workshop', 'Apply for the scholarship' — never "
+    "'Sign up here'."
+)
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _upsert_rule(
+    connection: sa.Connection,
+    *,
+    rule_set: str,
+    rule_key: str,
+    category: str,
+    rule_text: str,
+    severity: str,
+) -> None:
+    existing_id = connection.execute(
+        sa.select(style_rules.c.Id).where(
+            style_rules.c.Rule_Set == rule_set,
+            style_rules.c.Rule_Key == rule_key,
+        )
+    ).scalar_one_or_none()
+    values = {
+        "Category": category,
+        "Rule_Text": rule_text,
+        "Is_Active": True,
+        "Severity": severity,
+    }
+    if existing_id:
+        connection.execute(
+            style_rules.update().where(style_rules.c.Id == existing_id).values(**values)
+        )
+    else:
+        connection.execute(
+            style_rules.insert().values(
+                Id=str(uuid.uuid4()),
+                Rule_Set=rule_set,
+                Rule_Key=rule_key,
+                **values,
+            )
+        )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    _upsert_rule(
+        connection,
+        rule_set="shared",
+        rule_key="cta_structure",
+        category="voice",
+        rule_text=CTA_RULE_TEXT,
+        severity="warning",
+    )
+
+
+def downgrade() -> None:
+    # Text-only revision of managed rules; the prior wording is not
+    # restored on downgrade.
+    pass

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -302,7 +302,7 @@
   {
     "category": "voice",
     "rule_key": "cta_structure",
-    "rule_text": "Structure announcements around a clear call to action: open with the action the reader should take, follow with context, dates and incentives, and close with an explicit final call to action such as 'Learn more and register'. Replace vague instructions with explicit actions. Do not introduce audience qualifiers that are not in the original submission. When the submission provides a contact's full name, use it rather than a bare email address.",
+    "rule_text": "Structure announcements around a clear call to action: open with the action the reader should take, follow with context, dates and incentives, and close with an explicit final call to action such as 'Learn more and register'. Replace vague instructions with explicit actions. Do not introduce audience qualifiers that are not in the original submission. When the submission provides a contact's full name, use it rather than a bare email address. Never build a call to action on filler words: no CTA may contain 'here', 'click here', 'learn more here', 'register here', 'apply here' or 'sign up here'. Link the action verb or the object of the action instead: 'Sign up', 'Register for the workshop', 'Apply for the scholarship' — never 'Sign up here'.",
     "severity": "warning"
   },
   {

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -410,6 +410,53 @@ class TestAIEditTasks:
             in SuccessfulProvider.last_system_prompt
         )
 
+    async def test_staff_ai_edit_receives_cta_filler_ban(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        SuccessfulProvider.last_system_prompt = ""
+        db.add(
+            StyleRule(
+                Rule_Set="shared",
+                Category="voice",
+                Rule_Key="cta_structure",
+                Rule_Text=(
+                    "Never build a call to action on filler words: no CTA may "
+                    "contain 'here' or 'click here'. Link the action verb or "
+                    "the object of the action instead."
+                ),
+                Severity="warning",
+            )
+        )
+        await db.commit()
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: SuccessfulProvider(),
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Original_Body="Employees can sign up here for the newsletter.",
+            ),
+        )
+        assert submission_resp.status_code == 201
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_resp.json()['Id']}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+        assert resp.status_code == 202
+        task = await wait_for_task(client, resp.json()["Task_Id"], staff_headers)
+        assert task["Status"] == "succeeded"
+        assert (
+            "[SHOULD] Never build a call to action on filler words"
+            in SuccessfulProvider.last_system_prompt
+        )
+
     async def test_staff_ai_edit_enforces_short_sentences_and_safe_semicolon_cleanup(
         self,
         client: AsyncClient,

--- a/backend/tests/test_cta_filler_rule_migration.py
+++ b/backend/tests/test_cta_filler_rule_migration.py
@@ -1,0 +1,104 @@
+"""Regression coverage for the ban generic CTA filler words migration."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "a6c8e2f4b7d9_ban_generic_cta_filler.py"
+)
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("cta_filler_rule", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def style_rules_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+
+
+def test_rule_upserts_are_idempotent_and_preserve_unrelated_rules():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert(),
+            [
+                {
+                    "Id": "stale",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "cta_structure",
+                    "Rule_Text": "Old wording.",
+                    "Is_Active": False,
+                    "Severity": "info",
+                },
+                {
+                    "Id": "custom",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "staff_custom",
+                    "Rule_Text": "Keep this staff rule.",
+                    "Is_Active": True,
+                    "Severity": "info",
+                },
+            ],
+        )
+
+        for _ in range(2):
+            migration._upsert_rule(
+                connection,
+                rule_set="shared",
+                rule_key="cta_structure",
+                category="voice",
+                rule_text=migration.CTA_RULE_TEXT,
+                severity="warning",
+            )
+
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    by_key = {row["Rule_Key"]: row for row in rows}
+    assert by_key["cta_structure"]["Rule_Text"] == migration.CTA_RULE_TEXT
+    assert by_key["cta_structure"]["Category"] == "voice"
+    assert by_key["cta_structure"]["Severity"] == "warning"
+    assert by_key["cta_structure"]["Is_Active"] is True
+    assert by_key["staff_custom"]["Rule_Text"] == "Keep this staff rule."
+    assert len(rows) == 2
+
+
+def test_migration_values_match_style_rule_seeds():
+    migration = load_migration()
+    seed_dir = Path(__file__).parents[1] / "data" / "style_rules"
+    seeded_shared = {
+        rule["rule_key"]: rule
+        for rule in json.loads((seed_dir / "shared_rules.json").read_text())
+    }
+
+    assert seeded_shared["cta_structure"]["rule_text"] == migration.CTA_RULE_TEXT
+    assert seeded_shared["cta_structure"]["severity"] == "warning"
+    assert seeded_shared["cta_structure"]["category"] == "voice"

--- a/backend/tests/test_joy_style_rule_migration.py
+++ b/backend/tests/test_joy_style_rule_migration.py
@@ -115,10 +115,13 @@ def test_migration_values_match_the_style_rule_seed_files():
     for rule in migration.STYLE_RULE_UPDATES:
         key = (rule["rule_set"], rule["rule_key"])
         assert seeded[key]["category"] == rule["category"]
-        # August follow-up migrations supersede the recurring event-order and
-        # short-sentence rules. Dedicated regression tests verify their latest
-        # seed values; all other July values remain exact.
-        if key != ("shared", "short_sentences"):
+        # August follow-up migrations supersede the recurring event-order,
+        # short-sentence, and CTA-structure rules. Dedicated regression tests
+        # verify their latest seed values; all other July values remain exact.
+        if key not in {
+            ("shared", "short_sentences"),
+            ("shared", "cta_structure"),
+        }:
             assert seeded[key]["rule_text"] == rule["rule_text"]
         if key not in {
             ("shared", "event_detail_ordering"),


### PR DESCRIPTION
Closes #275

## Problem

Edited output contained generic CTAs built on filler words ("sign up here," "register here," "click here"). Triage confirmed `cta_structure` is active and delivered to the prompt on dev, but its text says nothing about filler words — a rule-text gap, not a delivery failure.

## Fix

Extend the `cta_structure` rule text: no CTA may contain "here" or generic click phrasing; link the action verb or the object of the action ("Sign up," "Register for the workshop," "Apply for the scholarship"). Severity unchanged (`warning`).

- Seed update in `shared_rules.json`
- Idempotent alembic upsert migration `a6c8e2f4b7d9` (revises `f9a3d5e7c2b4`); text-only revision, downgrade is a documented no-op
- Migration regression tests (idempotency, unrelated rules preserved, text matches seed)
- Prompt-delivery test asserting the rule text reaches the assembled system prompt
- The July Joy-migration seed-match test now lists `cta_structure` among superseded rules (same mechanism it already used for `short_sentences`)

## Testing

- `pytest` — 171 passed (full backend suite)
- `ruff check .` — clean
- `alembic heads` — single head `a6c8e2f4b7d9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)