### PR TITLE
Add distinct-headline style rule (headline must not duplicate the lead sentence)

### DIFF
--- a/backend/alembic/versions/b3e5f7a9c1d6_add_distinct_headline_rule.py
+++ b/backend/alembic/versions/b3e5f7a9c1d6_add_distinct_headline_rule.py
@@ -1,0 +1,106 @@
+"""add distinct headline rule
+
+Revision ID: b3e5f7a9c1d6
+Revises: a6c8e2f4b7d9
+Create Date: 2026-08-07 14:00:00.000000
+
+Add Joy's standing headline rule: the headline must not duplicate or
+lightly reword the body's first sentence. It should summarize the
+purpose, opportunity or benefit so headline and body each contribute
+unique information. Idempotent; touches only the managed
+headline_distinct_from_lead rule key.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b3e5f7a9c1d6"
+down_revision: str | Sequence[str] | None = "a6c8e2f4b7d9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+DISTINCT_HEADLINE_RULE_TEXT = (
+    "The headline must not be the first sentence of the body or a minor "
+    "rewording of it. Write a headline that summarizes the purpose, "
+    "opportunity or benefit of the announcement so the headline and body "
+    "each contribute unique information. Example: for a body opening "
+    "'Sign up for the sustainability newsletter.', write the headline "
+    "'Receive monthly sustainability updates', not 'Sign up for "
+    "sustainability newsletter'."
+)
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _upsert_rule(
+    connection: sa.Connection,
+    *,
+    rule_set: str,
+    rule_key: str,
+    category: str,
+    rule_text: str,
+    severity: str,
+) -> None:
+    existing_id = connection.execute(
+        sa.select(style_rules.c.Id).where(
+            style_rules.c.Rule_Set == rule_set,
+            style_rules.c.Rule_Key == rule_key,
+        )
+    ).scalar_one_or_none()
+    values = {
+        "Category": category,
+        "Rule_Text": rule_text,
+        "Is_Active": True,
+        "Severity": severity,
+    }
+    if existing_id:
+        connection.execute(
+            style_rules.update().where(style_rules.c.Id == existing_id).values(**values)
+        )
+    else:
+        connection.execute(
+            style_rules.insert().values(
+                Id=str(uuid.uuid4()),
+                Rule_Set=rule_set,
+                Rule_Key=rule_key,
+                **values,
+            )
+        )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    _upsert_rule(
+        connection,
+        rule_set="shared",
+        rule_key="headline_distinct_from_lead",
+        category="headlines",
+        rule_text=DISTINCT_HEADLINE_RULE_TEXT,
+        severity="warning",
+    )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    connection.execute(
+        style_rules.delete().where(
+            style_rules.c.Rule_Set == "shared",
+            style_rules.c.Rule_Key == "headline_distinct_from_lead",
+            style_rules.c.Rule_Text == DISTINCT_HEADLINE_RULE_TEXT,
+        )
+    )

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -316,5 +316,11 @@
     "rule_key": "preserve_action_deadlines",
     "rule_text": "Preserve every deadline and actionable date from the original submission: registration, application, abstract, proposal, nomination and submission deadlines, event dates and times, application periods, registration requirements and eligibility information. Keep multiple deadlines when they serve different purposes. Never replace a specific deadline with a generic call to action such as 'Learn more and register'. When editing for conciseness, shorten the surrounding prose instead of removing deadlines. Example: 'Registration closes Oct. 23. Abstract submissions are due Oct. 16. Learn more and register.' is correct; dropping either date is not.",
     "severity": "error"
+  },
+  {
+    "category": "headlines",
+    "rule_key": "headline_distinct_from_lead",
+    "rule_text": "The headline must not be the first sentence of the body or a minor rewording of it. Write a headline that summarizes the purpose, opportunity or benefit of the announcement so the headline and body each contribute unique information. Example: for a body opening 'Sign up for the sustainability newsletter.', write the headline 'Receive monthly sustainability updates', not 'Sign up for sustainability newsletter'.",
+    "severity": "warning"
   }
 ]

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -457,6 +457,56 @@ class TestAIEditTasks:
             in SuccessfulProvider.last_system_prompt
         )
 
+    async def test_staff_ai_edit_receives_distinct_headline_rule(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        SuccessfulProvider.last_system_prompt = ""
+        db.add(
+            StyleRule(
+                Rule_Set="shared",
+                Category="headlines",
+                Rule_Key="headline_distinct_from_lead",
+                Rule_Text=(
+                    "The headline must not be the first sentence of the body "
+                    "or a minor rewording of it."
+                ),
+                Severity="warning",
+            )
+        )
+        await db.commit()
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: SuccessfulProvider(),
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Original_Headline="Sign up for sustainability newsletter",
+                Original_Body=(
+                    "Sign up for the sustainability newsletter. A monthly "
+                    "issue starts in September."
+                ),
+            ),
+        )
+        assert submission_resp.status_code == 201
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_resp.json()['Id']}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+        assert resp.status_code == 202
+        task = await wait_for_task(client, resp.json()["Task_Id"], staff_headers)
+        assert task["Status"] == "succeeded"
+        assert (
+            "[SHOULD] The headline must not be the first sentence of the body"
+            in SuccessfulProvider.last_system_prompt
+        )
+
     async def test_staff_ai_edit_enforces_short_sentences_and_safe_semicolon_cleanup(
         self,
         client: AsyncClient,

--- a/backend/tests/test_distinct_headline_rule_migration.py
+++ b/backend/tests/test_distinct_headline_rule_migration.py
@@ -1,0 +1,104 @@
+"""Regression coverage for the add distinct headline rule migration."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "b3e5f7a9c1d6_add_distinct_headline_rule.py"
+)
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("distinct_headline_rule", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def style_rules_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+
+
+def test_rule_upserts_are_idempotent_and_preserve_unrelated_rules():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert(),
+            [
+                {
+                    "Id": "stale",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "headline_distinct_from_lead",
+                    "Rule_Text": "Old wording.",
+                    "Is_Active": False,
+                    "Severity": "info",
+                },
+                {
+                    "Id": "custom",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "staff_custom",
+                    "Rule_Text": "Keep this staff rule.",
+                    "Is_Active": True,
+                    "Severity": "info",
+                },
+            ],
+        )
+
+        for _ in range(2):
+            migration._upsert_rule(
+                connection,
+                rule_set="shared",
+                rule_key="headline_distinct_from_lead",
+                category="headlines",
+                rule_text=migration.DISTINCT_HEADLINE_RULE_TEXT,
+                severity="warning",
+            )
+
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    by_key = {row["Rule_Key"]: row for row in rows}
+    assert by_key["headline_distinct_from_lead"]["Rule_Text"] == migration.DISTINCT_HEADLINE_RULE_TEXT
+    assert by_key["headline_distinct_from_lead"]["Category"] == "headlines"
+    assert by_key["headline_distinct_from_lead"]["Severity"] == "warning"
+    assert by_key["headline_distinct_from_lead"]["Is_Active"] is True
+    assert by_key["staff_custom"]["Rule_Text"] == "Keep this staff rule."
+    assert len(rows) == 2
+
+
+def test_migration_values_match_style_rule_seeds():
+    migration = load_migration()
+    seed_dir = Path(__file__).parents[1] / "data" / "style_rules"
+    seeded_shared = {
+        rule["rule_key"]: rule
+        for rule in json.loads((seed_dir / "shared_rules.json").read_text())
+    }
+
+    assert seeded_shared["headline_distinct_from_lead"]["rule_text"] == migration.DISTINCT_HEADLINE_RULE_TEXT
+    assert seeded_shared["headline_distinct_from_lead"]["severity"] == "warning"
+    assert seeded_shared["headline_distinct_from_lead"]["category"] == "headlines"


### PR DESCRIPTION
Closes #276

## Problem

The AI editor sometimes produced a headline that was the body's first sentence or a minor rewording of it. Triage confirmed the active headline rules (`headline_reader_perspective`, `sentence_case`, `active_complete`) govern tone, casing, and structure, but none forbids duplicating the lead.

## Fix

New shared `headlines` rule `headline_distinct_from_lead` (`warning`): the headline must summarize the purpose, opportunity, or benefit in wording distinct from the body's first sentence, with Joy's sustainability-newsletter example. Composes with the existing headline rules rather than replacing them.

- Seed update in `shared_rules.json`
- Idempotent alembic upsert migration `b3e5f7a9c1d6` (revises `a6c8e2f4b7d9`), delete-on-downgrade guarded by exact text
- Migration regression tests (idempotency, unrelated rules preserved, text matches seed)
- Prompt-delivery test asserting the rule text reaches the assembled system prompt

## Testing

- `pytest` — 174 passed (full backend suite)
- `ruff check .` — clean
- `alembic heads` — single head `b3e5f7a9c1d6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)