### PR TITLE
Add event-context preservation style rule

### DIFF
--- a/backend/alembic/versions/c7d9a1b3e5f8_add_preserve_event_context_rule.py
+++ b/backend/alembic/versions/c7d9a1b3e5f8_add_preserve_event_context_rule.py
@@ -1,0 +1,108 @@
+"""add preserve event context rule
+
+Revision ID: c7d9a1b3e5f8
+Revises: b3e5f7a9c1d6
+Create Date: 2026-08-07 14:00:00.000000
+
+Add Joy's standing rule that meaningful event context survives
+condensing edits: traditions, participant activities, routes and
+logistics are preserved; conciseness comes from tightening wording,
+not deleting them. Idempotent; touches only the managed
+preserve_event_context rule key.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "c7d9a1b3e5f8"
+down_revision: str | Sequence[str] | None = "b3e5f7a9c1d6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+PRESERVE_EVENT_CONTEXT_RULE_TEXT = (
+    "When condensing, distinguish unnecessary repetition from meaningful "
+    "context. Preserve traditions and ceremonies, participant activities, "
+    "routes, locations and event logistics, notable event features, and "
+    "details that help readers visualize or understand the event. Achieve "
+    "conciseness by tightening wording, not by deleting these details. "
+    "Example: 'Sororities will open bids at 11:15 a.m. and run home to "
+    "their chapters down Idaho Avenue.' is correct; shortening it to "
+    "'Sororities will open bids at 11:15 a.m.' removes a meaningful part "
+    "of the event and is not."
+)
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _upsert_rule(
+    connection: sa.Connection,
+    *,
+    rule_set: str,
+    rule_key: str,
+    category: str,
+    rule_text: str,
+    severity: str,
+) -> None:
+    existing_id = connection.execute(
+        sa.select(style_rules.c.Id).where(
+            style_rules.c.Rule_Set == rule_set,
+            style_rules.c.Rule_Key == rule_key,
+        )
+    ).scalar_one_or_none()
+    values = {
+        "Category": category,
+        "Rule_Text": rule_text,
+        "Is_Active": True,
+        "Severity": severity,
+    }
+    if existing_id:
+        connection.execute(
+            style_rules.update().where(style_rules.c.Id == existing_id).values(**values)
+        )
+    else:
+        connection.execute(
+            style_rules.insert().values(
+                Id=str(uuid.uuid4()),
+                Rule_Set=rule_set,
+                Rule_Key=rule_key,
+                **values,
+            )
+        )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    _upsert_rule(
+        connection,
+        rule_set="shared",
+        rule_key="preserve_event_context",
+        category="content_filtering",
+        rule_text=PRESERVE_EVENT_CONTEXT_RULE_TEXT,
+        severity="warning",
+    )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    connection.execute(
+        style_rules.delete().where(
+            style_rules.c.Rule_Set == "shared",
+            style_rules.c.Rule_Key == "preserve_event_context",
+            style_rules.c.Rule_Text == PRESERVE_EVENT_CONTEXT_RULE_TEXT,
+        )
+    )

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -322,5 +322,11 @@
     "rule_key": "headline_distinct_from_lead",
     "rule_text": "The headline must not be the first sentence of the body or a minor rewording of it. Write a headline that summarizes the purpose, opportunity or benefit of the announcement so the headline and body each contribute unique information. Example: for a body opening 'Sign up for the sustainability newsletter.', write the headline 'Receive monthly sustainability updates', not 'Sign up for sustainability newsletter'.",
     "severity": "warning"
+  },
+  {
+    "category": "content_filtering",
+    "rule_key": "preserve_event_context",
+    "rule_text": "When condensing, distinguish unnecessary repetition from meaningful context. Preserve traditions and ceremonies, participant activities, routes, locations and event logistics, notable event features, and details that help readers visualize or understand the event. Achieve conciseness by tightening wording, not by deleting these details. Example: 'Sororities will open bids at 11:15 a.m. and run home to their chapters down Idaho Avenue.' is correct; shortening it to 'Sororities will open bids at 11:15 a.m.' removes a meaningful part of the event and is not.",
+    "severity": "warning"
   }
 ]

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -507,6 +507,56 @@ class TestAIEditTasks:
             in SuccessfulProvider.last_system_prompt
         )
 
+    async def test_staff_ai_edit_receives_event_context_preservation_rule(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        SuccessfulProvider.last_system_prompt = ""
+        db.add(
+            StyleRule(
+                Rule_Set="shared",
+                Category="content_filtering",
+                Rule_Key="preserve_event_context",
+                Rule_Text=(
+                    "When condensing, distinguish unnecessary repetition from "
+                    "meaningful context. Preserve traditions, participant "
+                    "activities, routes and event logistics."
+                ),
+                Severity="warning",
+            )
+        )
+        await db.commit()
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: SuccessfulProvider(),
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Original_Body=(
+                    "The sororities will open bids at 11:15 and promptly run "
+                    "home to their chapters down Idaho Avenue."
+                ),
+            ),
+        )
+        assert submission_resp.status_code == 201
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_resp.json()['Id']}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+        assert resp.status_code == 202
+        task = await wait_for_task(client, resp.json()["Task_Id"], staff_headers)
+        assert task["Status"] == "succeeded"
+        assert (
+            "[SHOULD] When condensing, distinguish unnecessary repetition"
+            in SuccessfulProvider.last_system_prompt
+        )
+
     async def test_staff_ai_edit_enforces_short_sentences_and_safe_semicolon_cleanup(
         self,
         client: AsyncClient,

--- a/backend/tests/test_preserve_event_context_rule_migration.py
+++ b/backend/tests/test_preserve_event_context_rule_migration.py
@@ -1,0 +1,104 @@
+"""Regression coverage for the add preserve event context rule migration."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "c7d9a1b3e5f8_add_preserve_event_context_rule.py"
+)
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("preserve_event_context_rule", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def style_rules_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+
+
+def test_rule_upserts_are_idempotent_and_preserve_unrelated_rules():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert(),
+            [
+                {
+                    "Id": "stale",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "preserve_event_context",
+                    "Rule_Text": "Old wording.",
+                    "Is_Active": False,
+                    "Severity": "info",
+                },
+                {
+                    "Id": "custom",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "staff_custom",
+                    "Rule_Text": "Keep this staff rule.",
+                    "Is_Active": True,
+                    "Severity": "info",
+                },
+            ],
+        )
+
+        for _ in range(2):
+            migration._upsert_rule(
+                connection,
+                rule_set="shared",
+                rule_key="preserve_event_context",
+                category="content_filtering",
+                rule_text=migration.PRESERVE_EVENT_CONTEXT_RULE_TEXT,
+                severity="warning",
+            )
+
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    by_key = {row["Rule_Key"]: row for row in rows}
+    assert by_key["preserve_event_context"]["Rule_Text"] == migration.PRESERVE_EVENT_CONTEXT_RULE_TEXT
+    assert by_key["preserve_event_context"]["Category"] == "content_filtering"
+    assert by_key["preserve_event_context"]["Severity"] == "warning"
+    assert by_key["preserve_event_context"]["Is_Active"] is True
+    assert by_key["staff_custom"]["Rule_Text"] == "Keep this staff rule."
+    assert len(rows) == 2
+
+
+def test_migration_values_match_style_rule_seeds():
+    migration = load_migration()
+    seed_dir = Path(__file__).parents[1] / "data" / "style_rules"
+    seeded_shared = {
+        rule["rule_key"]: rule
+        for rule in json.loads((seed_dir / "shared_rules.json").read_text())
+    }
+
+    assert seeded_shared["preserve_event_context"]["rule_text"] == migration.PRESERVE_EVENT_CONTEXT_RULE_TEXT
+    assert seeded_shared["preserve_event_context"]["severity"] == "warning"
+    assert seeded_shared["preserve_event_context"]["category"] == "content_filtering"


### PR DESCRIPTION
Closes #277

## Problem

When shortening event submissions the AI editor removed details that are part of the event's meaning — traditions, participant activities, routes/logistics (e.g. Bid Day participants running home down Idaho Avenue). Triage confirmed the pressure comes from active rules `trim_lengthy` and `concise_clear`, with no rule distinguishing redundant text from meaningful color.

## Fix

New shared rule `preserve_event_context` (`warning`): preserve traditions and ceremonies, participant activities, routes/locations/logistics, notable features, and details that help readers visualize the event; achieve conciseness by tightening wording. Includes Joy's Bid Day correct/incorrect example. Worded to compose with the deadline-preservation rule from #274.

- Seed update in `shared_rules.json`
- Idempotent alembic upsert migration `c7d9a1b3e5f8` (revises `b3e5f7a9c1d6`), delete-on-downgrade guarded by exact text
- Migration regression tests (idempotency, unrelated rules preserved, text matches seed)
- Prompt-delivery test asserting the rule text reaches the assembled system prompt

## Testing

- `pytest` — 177 passed (full backend suite)
- `ruff check .` — clean
- `alembic heads` — single head `c7d9a1b3e5f8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)