### PR TITLE
Make official event names survive sentence-case headline editing

### DIFF
--- a/backend/alembic/versions/d1f4b6c8e2a7_event_name_capitalization_precedence.py
+++ b/backend/alembic/versions/d1f4b6c8e2a7_event_name_capitalization_precedence.py
@@ -1,0 +1,143 @@
+"""make official event names survive sentence-case headlines
+
+Revision ID: d1f4b6c8e2a7
+Revises: c7d9a1b3e5f8
+Create Date: 2026-08-07 14:00:00.000000
+
+Joy reported official event names being lowercased, most visibly in
+headlines where the sentence-case rule pushes toward lowercase. State
+the precedence explicitly in both directions: official event, program
+and organization names are proper nouns that keep their official
+capitalization everywhere, including inside sentence-case headlines.
+Idempotent; touches only the three managed rule keys.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "d1f4b6c8e2a7"
+down_revision: str | Sequence[str] | None = "c7d9a1b3e5f8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+PRESERVE_EVENT_TITLE_RULE_TEXT = (
+    "Do not change event titles. Keep event titles in title case exactly "
+    "as submitted, even when the surrounding text uses sentence case. "
+    "This applies everywhere the name appears, including inside "
+    "sentence-case headlines: official event, program and organization "
+    "names are proper nouns, and preserving their official capitalization "
+    "takes precedence over sentence-casing. Example: 'Fraternity and "
+    "Sorority Life Bid Day' stays fully capitalized inside an otherwise "
+    "sentence-case headline, never 'fraternity and sorority Bid Day'."
+)
+
+TDR_SENTENCE_CASE_RULE_TEXT = (
+    "Headlines must be sentence case: capitalize only the first word and "
+    "proper nouns. Capitalize proper nouns, including official names of "
+    "departments, offices, buildings and programs (e.g., Copy Print "
+    "Center, Creative Services, Elizabeth Bradfield). Official event, "
+    "program and organization names also count as proper nouns and keep "
+    "their official capitalization inside a sentence-case headline (e.g., "
+    "'Celebrate Fraternity and Sorority Life Bid Day on Friday'). Never "
+    "leave proper names in lowercase. Example: 'Attend the research "
+    "awards ceremony' not 'Attend the Research Awards Ceremony'."
+)
+
+MYUI_SENTENCE_CASE_RULE_TEXT = (
+    "Headlines must be sentence case: capitalize only the first word and "
+    "proper nouns. Capitalize proper nouns, including official names of "
+    "departments, offices, buildings and programs (e.g., Copy Print "
+    "Center, Creative Services, Elizabeth Bradfield). Official event, "
+    "program and organization names also count as proper nouns and keep "
+    "their official capitalization inside a sentence-case headline (e.g., "
+    "'Celebrate Fraternity and Sorority Life Bid Day on Friday'). Never "
+    "leave proper names in lowercase. Example: 'Register for spring break "
+    "activities' not 'Register for Spring Break Activities'."
+)
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _upsert_rule(
+    connection: sa.Connection,
+    *,
+    rule_set: str,
+    rule_key: str,
+    category: str,
+    rule_text: str,
+    severity: str,
+) -> None:
+    existing_id = connection.execute(
+        sa.select(style_rules.c.Id).where(
+            style_rules.c.Rule_Set == rule_set,
+            style_rules.c.Rule_Key == rule_key,
+        )
+    ).scalar_one_or_none()
+    values = {
+        "Category": category,
+        "Rule_Text": rule_text,
+        "Is_Active": True,
+        "Severity": severity,
+    }
+    if existing_id:
+        connection.execute(
+            style_rules.update().where(style_rules.c.Id == existing_id).values(**values)
+        )
+    else:
+        connection.execute(
+            style_rules.insert().values(
+                Id=str(uuid.uuid4()),
+                Rule_Set=rule_set,
+                Rule_Key=rule_key,
+                **values,
+            )
+        )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    _upsert_rule(
+        connection,
+        rule_set="shared",
+        rule_key="preserve_event_title_case",
+        category="formatting",
+        rule_text=PRESERVE_EVENT_TITLE_RULE_TEXT,
+        severity="error",
+    )
+    _upsert_rule(
+        connection,
+        rule_set="tdr",
+        rule_key="sentence_case",
+        category="headlines",
+        rule_text=TDR_SENTENCE_CASE_RULE_TEXT,
+        severity="error",
+    )
+    _upsert_rule(
+        connection,
+        rule_set="myui",
+        rule_key="sentence_case",
+        category="headlines",
+        rule_text=MYUI_SENTENCE_CASE_RULE_TEXT,
+        severity="error",
+    )
+
+
+def downgrade() -> None:
+    # Text-only revision of managed rules; the prior wording is not
+    # restored on downgrade.
+    pass

--- a/backend/data/style_rules/myui_rules.json
+++ b/backend/data/style_rules/myui_rules.json
@@ -2,7 +2,7 @@
   {
     "category": "headlines",
     "rule_key": "sentence_case",
-    "rule_text": "Headlines must be sentence case: capitalize only the first word and proper nouns. Capitalize proper nouns, including official names of departments, offices, buildings and programs (e.g., Copy Print Center, Creative Services, Elizabeth Bradfield). Never leave proper names in lowercase. Example: 'Register for spring break activities' not 'Register for Spring Break Activities'.",
+    "rule_text": "Headlines must be sentence case: capitalize only the first word and proper nouns. Capitalize proper nouns, including official names of departments, offices, buildings and programs (e.g., Copy Print Center, Creative Services, Elizabeth Bradfield). Official event, program and organization names also count as proper nouns and keep their official capitalization inside a sentence-case headline (e.g., 'Celebrate Fraternity and Sorority Life Bid Day on Friday'). Never leave proper names in lowercase. Example: 'Register for spring break activities' not 'Register for Spring Break Activities'.",
     "severity": "error"
   },
   {

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -284,7 +284,7 @@
   {
     "category": "formatting",
     "rule_key": "preserve_event_title_case",
-    "rule_text": "Do not change event titles. Keep event titles in title case exactly as submitted, even when the surrounding text uses sentence case.",
+    "rule_text": "Do not change event titles. Keep event titles in title case exactly as submitted, even when the surrounding text uses sentence case. This applies everywhere the name appears, including inside sentence-case headlines: official event, program and organization names are proper nouns, and preserving their official capitalization takes precedence over sentence-casing. Example: 'Fraternity and Sorority Life Bid Day' stays fully capitalized inside an otherwise sentence-case headline, never 'fraternity and sorority Bid Day'.",
     "severity": "error"
   },
   {

--- a/backend/data/style_rules/tdr_rules.json
+++ b/backend/data/style_rules/tdr_rules.json
@@ -2,7 +2,7 @@
   {
     "category": "headlines",
     "rule_key": "sentence_case",
-    "rule_text": "Headlines must be sentence case: capitalize only the first word and proper nouns. Capitalize proper nouns, including official names of departments, offices, buildings and programs (e.g., Copy Print Center, Creative Services, Elizabeth Bradfield). Never leave proper names in lowercase. Example: 'Attend the research awards ceremony' not 'Attend the Research Awards Ceremony'.",
+    "rule_text": "Headlines must be sentence case: capitalize only the first word and proper nouns. Capitalize proper nouns, including official names of departments, offices, buildings and programs (e.g., Copy Print Center, Creative Services, Elizabeth Bradfield). Official event, program and organization names also count as proper nouns and keep their official capitalization inside a sentence-case headline (e.g., 'Celebrate Fraternity and Sorority Life Bid Day on Friday'). Never leave proper names in lowercase. Example: 'Attend the research awards ceremony' not 'Attend the Research Awards Ceremony'.",
     "severity": "error"
   },
   {

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -557,6 +557,73 @@ class TestAIEditTasks:
             in SuccessfulProvider.last_system_prompt
         )
 
+    async def test_staff_ai_edit_receives_event_name_precedence_rules(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        SuccessfulProvider.last_system_prompt = ""
+        db.add_all(
+            [
+                StyleRule(
+                    Rule_Set="shared",
+                    Category="formatting",
+                    Rule_Key="preserve_event_title_case",
+                    Rule_Text=(
+                        "Do not change event titles. Preserving their official "
+                        "capitalization takes precedence over sentence-casing."
+                    ),
+                    Severity="error",
+                ),
+                StyleRule(
+                    Rule_Set="tdr",
+                    Category="headlines",
+                    Rule_Key="sentence_case",
+                    Rule_Text=(
+                        "Headlines must be sentence case. Official event, "
+                        "program and organization names also count as proper "
+                        "nouns and keep their official capitalization."
+                    ),
+                    Severity="error",
+                ),
+            ]
+        )
+        await db.commit()
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: SuccessfulProvider(),
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Original_Headline="Fraternity and Sorority Life Bid Day",
+                Original_Body=(
+                    "Fraternity and Sorority Life Bid Day is Saturday, "
+                    "Aug. 22, on Idaho Avenue."
+                ),
+            ),
+        )
+        assert submission_resp.status_code == 201
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_resp.json()['Id']}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+        assert resp.status_code == 202
+        task = await wait_for_task(client, resp.json()["Task_Id"], staff_headers)
+        assert task["Status"] == "succeeded"
+        assert (
+            "takes precedence over sentence-casing"
+            in SuccessfulProvider.last_system_prompt
+        )
+        assert (
+            "keep their official capitalization"
+            in SuccessfulProvider.last_system_prompt
+        )
+
     async def test_staff_ai_edit_enforces_short_sentences_and_safe_semicolon_cleanup(
         self,
         client: AsyncClient,

--- a/backend/tests/test_event_name_precedence_migration.py
+++ b/backend/tests/test_event_name_precedence_migration.py
@@ -1,0 +1,148 @@
+"""Regression coverage for the make official event names survive sentence-case headlines migration."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "d1f4b6c8e2a7_event_name_capitalization_precedence.py"
+)
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("event_name_precedence", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def style_rules_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+
+
+def test_rule_upserts_are_idempotent_and_preserve_unrelated_rules():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert(),
+            [
+                {
+                    "Id": "stale",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "preserve_event_title_case",
+                    "Rule_Text": "Old wording.",
+                    "Is_Active": False,
+                    "Severity": "info",
+                },
+                {
+                    "Id": "custom",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "staff_custom",
+                    "Rule_Text": "Keep this staff rule.",
+                    "Is_Active": True,
+                    "Severity": "info",
+                },
+            ],
+        )
+
+        for _ in range(2):
+            migration._upsert_rule(
+                connection,
+                rule_set="shared",
+                rule_key="preserve_event_title_case",
+                category="formatting",
+                rule_text=migration.PRESERVE_EVENT_TITLE_RULE_TEXT,
+                severity="error",
+            )
+            migration._upsert_rule(
+                connection,
+                rule_set="tdr",
+                rule_key="sentence_case",
+                category="headlines",
+                rule_text=migration.TDR_SENTENCE_CASE_RULE_TEXT,
+                severity="error",
+            )
+            migration._upsert_rule(
+                connection,
+                rule_set="myui",
+                rule_key="sentence_case",
+                category="headlines",
+                rule_text=migration.MYUI_SENTENCE_CASE_RULE_TEXT,
+                severity="error",
+            )
+
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    by_key = {(row["Rule_Set"], row["Rule_Key"]): row for row in rows}
+    assert by_key[("shared", "preserve_event_title_case")]["Rule_Text"] == (
+        migration.PRESERVE_EVENT_TITLE_RULE_TEXT
+    )
+    assert by_key[("shared", "preserve_event_title_case")]["Category"] == "formatting"
+    assert by_key[("shared", "preserve_event_title_case")]["Severity"] == "error"
+    assert by_key[("shared", "preserve_event_title_case")]["Is_Active"] is True
+    assert by_key[("tdr", "sentence_case")]["Rule_Text"] == (
+        migration.TDR_SENTENCE_CASE_RULE_TEXT
+    )
+    assert by_key[("tdr", "sentence_case")]["Category"] == "headlines"
+    assert by_key[("tdr", "sentence_case")]["Severity"] == "error"
+    assert by_key[("tdr", "sentence_case")]["Is_Active"] is True
+    assert by_key[("myui", "sentence_case")]["Rule_Text"] == (
+        migration.MYUI_SENTENCE_CASE_RULE_TEXT
+    )
+    assert by_key[("myui", "sentence_case")]["Category"] == "headlines"
+    assert by_key[("myui", "sentence_case")]["Severity"] == "error"
+    assert by_key[("myui", "sentence_case")]["Is_Active"] is True
+    assert by_key[("shared", "staff_custom")]["Rule_Text"] == "Keep this staff rule."
+    assert len(rows) == 4
+
+
+def test_migration_values_match_style_rule_seeds():
+    migration = load_migration()
+    seed_dir = Path(__file__).parents[1] / "data" / "style_rules"
+    seeded_shared = {
+        rule["rule_key"]: rule
+        for rule in json.loads((seed_dir / "shared_rules.json").read_text())
+    }
+    seeded_myui = {
+        rule["rule_key"]: rule
+        for rule in json.loads((seed_dir / "myui_rules.json").read_text())
+    }
+    seeded_tdr = {
+        rule["rule_key"]: rule
+        for rule in json.loads((seed_dir / "tdr_rules.json").read_text())
+    }
+
+    assert seeded_shared["preserve_event_title_case"]["rule_text"] == migration.PRESERVE_EVENT_TITLE_RULE_TEXT
+    assert seeded_shared["preserve_event_title_case"]["severity"] == "error"
+    assert seeded_shared["preserve_event_title_case"]["category"] == "formatting"
+    assert seeded_tdr["sentence_case"]["rule_text"] == migration.TDR_SENTENCE_CASE_RULE_TEXT
+    assert seeded_tdr["sentence_case"]["severity"] == "error"
+    assert seeded_tdr["sentence_case"]["category"] == "headlines"
+    assert seeded_myui["sentence_case"]["rule_text"] == migration.MYUI_SENTENCE_CASE_RULE_TEXT
+    assert seeded_myui["sentence_case"]["severity"] == "error"
+    assert seeded_myui["sentence_case"]["category"] == "headlines"

--- a/backend/tests/test_joy_style_rule_migration.py
+++ b/backend/tests/test_joy_style_rule_migration.py
@@ -116,11 +116,15 @@ def test_migration_values_match_the_style_rule_seed_files():
         key = (rule["rule_set"], rule["rule_key"])
         assert seeded[key]["category"] == rule["category"]
         # August follow-up migrations supersede the recurring event-order,
-        # short-sentence, and CTA-structure rules. Dedicated regression tests
-        # verify their latest seed values; all other July values remain exact.
+        # short-sentence, CTA-structure, event-name, and sentence-case rules.
+        # Dedicated regression tests verify their latest seed values; all
+        # other July values remain exact.
         if key not in {
             ("shared", "short_sentences"),
             ("shared", "cta_structure"),
+            ("shared", "preserve_event_title_case"),
+            ("tdr", "sentence_case"),
+            ("myui", "sentence_case"),
         }:
             assert seeded[key]["rule_text"] == rule["rule_text"]
         if key not in {


### PR DESCRIPTION
Closes #278

## Problem

Official event names were lowercased ("fraternity and sorority Bid Day") even though `preserve_event_title_case` is active at `error` severity. Triage identified the conflict: the `sentence_case` headline rule (also `error`) instructs lowercasing everything but the first word and proper nouns, and nothing said official event/program names count as proper nouns inside headlines.

## Fix

State the precedence explicitly in both directions:

- `preserve_event_title_case` (shared): applies everywhere the name appears including sentence-case headlines; name preservation takes precedence over sentence-casing, with the "Fraternity and Sorority Life Bid Day" example
- `sentence_case` (tdr **and** myui): official event, program, and organization names count as proper nouns and keep their official capitalization inside a sentence-case headline

Delivery: seed updates in all three rule files plus idempotent alembic upsert migration `d1f4b6c8e2a7` (revises `c7d9a1b3e5f8`); text-only revisions, documented no-op downgrade. Migration regression tests key rows by (rule set, rule key) since `sentence_case` exists in two rule sets. Prompt-delivery test asserts both precedence texts reach the assembled system prompt for a TDR edit. The July Joy-migration seed-match test now lists these three rules among superseded entries.

## Testing

- `pytest` — 180 passed (full backend suite)
- `ruff check .` — clean
- `alembic heads` — single head `d1f4b6c8e2a7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)