### PR TITLE
Require single-line listings for Jobs submissions

### DIFF
--- a/backend/alembic/versions/e8b2d4f6a1c9_jobs_single_line_format.py
+++ b/backend/alembic/versions/e8b2d4f6a1c9_jobs_single_line_format.py
@@ -1,0 +1,105 @@
+"""format job submissions as single-line listings
+
+Revision ID: e8b2d4f6a1c9
+Revises: d1f4b6c8e2a7
+Create Date: 2026-08-07 14:00:00.000000
+
+Joy reported Jobs submissions being formatted as news items with a
+headline, summary paragraph and apply language. Extend the TDR
+job_posting_format rule (keeping its policy content) with the required
+output format: one line of job title (sentence case), department or
+unit, and location. Raise severity to error since this is a hard
+format requirement. Idempotent; touches only the managed rule key.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "e8b2d4f6a1c9"
+down_revision: str | Sequence[str] | None = "d1f4b6c8e2a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+JOB_POSTING_RULE_TEXT = (
+    "Job postings are linked to PeopleAdmin listings. Must be listed with "
+    "Human Resources. Posted for two weeks, newest at top. Format every "
+    "Jobs-category submission as a single-line listing, not a news item: "
+    "job title (sentence case: capitalize only the first word and proper "
+    "nouns), department or unit, location — e.g. 'Administrative "
+    "specialist III, College of Engineering, Moscow'. Do not write a "
+    "headline, a descriptive paragraph, promotional language such as "
+    "'apply now', instructions directing readers to apply, or an "
+    "application deadline unless one is specifically requested. Keep the "
+    "entire entry on one line and preserve the hyperlink to the listing."
+)
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _upsert_rule(
+    connection: sa.Connection,
+    *,
+    rule_set: str,
+    rule_key: str,
+    category: str,
+    rule_text: str,
+    severity: str,
+) -> None:
+    existing_id = connection.execute(
+        sa.select(style_rules.c.Id).where(
+            style_rules.c.Rule_Set == rule_set,
+            style_rules.c.Rule_Key == rule_key,
+        )
+    ).scalar_one_or_none()
+    values = {
+        "Category": category,
+        "Rule_Text": rule_text,
+        "Is_Active": True,
+        "Severity": severity,
+    }
+    if existing_id:
+        connection.execute(
+            style_rules.update().where(style_rules.c.Id == existing_id).values(**values)
+        )
+    else:
+        connection.execute(
+            style_rules.insert().values(
+                Id=str(uuid.uuid4()),
+                Rule_Set=rule_set,
+                Rule_Key=rule_key,
+                **values,
+            )
+        )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    _upsert_rule(
+        connection,
+        rule_set="tdr",
+        rule_key="job_posting_format",
+        category="formatting",
+        rule_text=JOB_POSTING_RULE_TEXT,
+        severity="error",
+    )
+
+
+def downgrade() -> None:
+    # Text-only revision of managed rules; the prior wording is not
+    # restored on downgrade.
+    pass

--- a/backend/data/style_rules/tdr_rules.json
+++ b/backend/data/style_rules/tdr_rules.json
@@ -56,8 +56,8 @@
   {
     "category": "formatting",
     "rule_key": "job_posting_format",
-    "rule_text": "Job postings are linked to PeopleAdmin listings. Must be listed with Human Resources. Posted for two weeks, newest at top.",
-    "severity": "info"
+    "rule_text": "Job postings are linked to PeopleAdmin listings. Must be listed with Human Resources. Posted for two weeks, newest at top. Format every Jobs-category submission as a single-line listing, not a news item: job title (sentence case: capitalize only the first word and proper nouns), department or unit, location — e.g. 'Administrative specialist III, College of Engineering, Moscow'. Do not write a headline, a descriptive paragraph, promotional language such as 'apply now', instructions directing readers to apply, or an application deadline unless one is specifically requested. Keep the entire entry on one line and preserve the hyperlink to the listing.",
+    "severity": "error"
   },
   {
     "category": "voice",

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -624,6 +624,58 @@ class TestAIEditTasks:
             in SuccessfulProvider.last_system_prompt
         )
 
+    async def test_staff_ai_edit_receives_jobs_single_line_rule(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        SuccessfulProvider.last_system_prompt = ""
+        db.add(
+            StyleRule(
+                Rule_Set="tdr",
+                Category="formatting",
+                Rule_Key="job_posting_format",
+                Rule_Text=(
+                    "Format every Jobs-category submission as a single-line "
+                    "listing, not a news item: job title (sentence case), "
+                    "department or unit, location."
+                ),
+                Severity="error",
+            )
+        )
+        await db.commit()
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: SuccessfulProvider(),
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Category="job_opportunity",
+                Original_Headline="Administrative Specialist III",
+                Original_Body=(
+                    "Department: College of Engineering. Location: Moscow. "
+                    "Apply using the linked posting."
+                ),
+            ),
+        )
+        assert submission_resp.status_code == 201
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_resp.json()['Id']}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+        assert resp.status_code == 202
+        task = await wait_for_task(client, resp.json()["Task_Id"], staff_headers)
+        assert task["Status"] == "succeeded"
+        assert (
+            "[MUST] Format every Jobs-category submission as a single-line"
+            in SuccessfulProvider.last_system_prompt
+        )
+
     async def test_staff_ai_edit_enforces_short_sentences_and_safe_semicolon_cleanup(
         self,
         client: AsyncClient,

--- a/backend/tests/test_jobs_single_line_rule_migration.py
+++ b/backend/tests/test_jobs_single_line_rule_migration.py
@@ -1,0 +1,104 @@
+"""Regression coverage for the format job submissions as single-line listings migration."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "e8b2d4f6a1c9_jobs_single_line_format.py"
+)
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("jobs_single_line_rule", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def style_rules_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+
+
+def test_rule_upserts_are_idempotent_and_preserve_unrelated_rules():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert(),
+            [
+                {
+                    "Id": "stale",
+                    "Rule_Set": "tdr",
+                    "Category": "voice",
+                    "Rule_Key": "job_posting_format",
+                    "Rule_Text": "Old wording.",
+                    "Is_Active": False,
+                    "Severity": "info",
+                },
+                {
+                    "Id": "custom",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "staff_custom",
+                    "Rule_Text": "Keep this staff rule.",
+                    "Is_Active": True,
+                    "Severity": "info",
+                },
+            ],
+        )
+
+        for _ in range(2):
+            migration._upsert_rule(
+                connection,
+                rule_set="tdr",
+                rule_key="job_posting_format",
+                category="formatting",
+                rule_text=migration.JOB_POSTING_RULE_TEXT,
+                severity="error",
+            )
+
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    by_key = {row["Rule_Key"]: row for row in rows}
+    assert by_key["job_posting_format"]["Rule_Text"] == migration.JOB_POSTING_RULE_TEXT
+    assert by_key["job_posting_format"]["Category"] == "formatting"
+    assert by_key["job_posting_format"]["Severity"] == "error"
+    assert by_key["job_posting_format"]["Is_Active"] is True
+    assert by_key["staff_custom"]["Rule_Text"] == "Keep this staff rule."
+    assert len(rows) == 2
+
+
+def test_migration_values_match_style_rule_seeds():
+    migration = load_migration()
+    seed_dir = Path(__file__).parents[1] / "data" / "style_rules"
+    seeded_tdr = {
+        rule["rule_key"]: rule
+        for rule in json.loads((seed_dir / "tdr_rules.json").read_text())
+    }
+
+    assert seeded_tdr["job_posting_format"]["rule_text"] == migration.JOB_POSTING_RULE_TEXT
+    assert seeded_tdr["job_posting_format"]["severity"] == "error"
+    assert seeded_tdr["job_posting_format"]["category"] == "formatting"


### PR DESCRIPTION
Closes #281

## Problem

The AI editor formatted Jobs submissions like news announcements — headline, descriptive paragraph, promotional apply language. Triage confirmed the TDR `job_posting_format` rule is active (`info`) but covers posting policy (PeopleAdmin linkage, HR listing, duration) and says nothing about output format. The submission form's composed job body even includes "Apply using the linked posting." — exactly the language the rule must strip.

## Fix

Extend `job_posting_format` (keeping its policy content) with the required output format: a single line of job title (sentence case), department/unit, location — e.g. "Administrative specialist III, College of Engineering, Moscow" — with no headline, no summary, no apply instruction, no unrequested deadline, and the listing hyperlink preserved. Severity raised `info` → `error` as this is a hard format requirement.

- Seed update in `tdr_rules.json`
- Idempotent alembic upsert migration `e8b2d4f6a1c9` (revises `d1f4b6c8e2a7`); text revision, documented no-op downgrade
- Migration regression tests (idempotency, unrelated rules preserved, text matches seed)
- Prompt-delivery test asserting the `[MUST]` rule reaches the assembled system prompt for a Jobs-category TDR edit

## Testing

- `pytest` — 183 passed (full backend suite)
- `ruff check .` — clean
- `alembic heads` — single head `e8b2d4f6a1c9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)