### PR TITLE
Route employee announcements to their own Builder section

### DIFF
--- a/backend/alembic/versions/f2c6a8b4d1e3_add_manually_placed_to_newsletter_items.py
+++ b/backend/alembic/versions/f2c6a8b4d1e3_add_manually_placed_to_newsletter_items.py
@@ -1,0 +1,40 @@
+"""add Manually_Placed to newsletter items
+
+Revision ID: f2c6a8b4d1e3
+Revises: e8b2d4f6a1c9
+Create Date: 2026-08-07 15:00:00.000000
+
+Track whether staff moved a newsletter item to a different section so
+newsletter re-assembly can re-sync auto-placed items to the current
+category-to-section mapping without clobbering manual curation.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f2c6a8b4d1e3"
+down_revision: str | Sequence[str] | None = "e8b2d4f6a1c9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("newsletter_items", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "Manually_Placed",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("newsletter_items", schema=None) as batch_op:
+        batch_op.drop_column("Manually_Placed")

--- a/backend/app/models/newsletter.py
+++ b/backend/app/models/newsletter.py
@@ -80,6 +80,9 @@ class NewsletterItem(Base):
     Final_Headline: Mapped[str] = mapped_column(sa.Text, nullable=False)
     Final_Body: Mapped[str] = mapped_column(sa.Text, nullable=False)
     Run_Number: Mapped[int] = mapped_column(sa.Integer, default=1)
+    # Set when staff move the item to a different section; re-assembly then
+    # leaves the placement alone instead of re-syncing it to the category map.
+    Manually_Placed: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, default=False)
 
     Newsletter_Rel: Mapped["Newsletter"] = relationship(
         back_populates="Items", lazy="selectin"

--- a/backend/app/services/newsletter_service.py
+++ b/backend/app/services/newsletter_service.py
@@ -178,6 +178,9 @@ async def update_item(
     item = result.scalar_one_or_none()
     if not item:
         return None
+    new_section_id = kwargs.get("Section_Id")
+    if new_section_id is not None and new_section_id != item.Section_Id:
+        item.Manually_Placed = True
     for key, value in kwargs.items():
         if value is not None:
             setattr(item, key, value)
@@ -260,6 +263,8 @@ async def reorder_items(
             item.Position = pos.get("Position", pos.get("position", item.Position))
             section_id = pos.get("Section_Id") or pos.get("section_id")
             if section_id:
+                if section_id != item.Section_Id:
+                    item.Manually_Placed = True
                 item.Section_Id = section_id
     await db.commit()
 
@@ -315,7 +320,7 @@ async def assemble_newsletter(
     )
     submissions = list(subs_result.scalars().all())
 
-    existing_sub_ids = {item.Submission_Id for item in newsletter.Items}
+    existing_items_by_sub = {item.Submission_Id: item for item in newsletter.Items}
 
     sections_result = await db.execute(
         sa.select(NewsletterSection)
@@ -328,20 +333,19 @@ async def assemble_newsletter(
     occurrence_cache = submission_service.OccurrenceFilterCache()
 
     for sub in submissions:
-        if sub.Id in existing_sub_ids:
-            continue
-        occurrence_dates = await submission_service.get_submission_occurrence_dates(
-            db,
-            sub,
-            publish_date,
-            publish_date,
-            newsletter_type=newsletter_type,
-            occurrence_cache=occurrence_cache,
-        )
-        if publish_date not in occurrence_dates:
-            continue
+        existing_item = existing_items_by_sub.get(sub.Id)
+        if existing_item is None:
+            occurrence_dates = await submission_service.get_submission_occurrence_dates(
+                db,
+                sub,
+                publish_date,
+                publish_date,
+                newsletter_type=newsletter_type,
+                occurrence_cache=occurrence_cache,
+            )
+            if publish_date not in occurrence_dates:
+                continue
 
-        headline, body = _get_best_text(sub)
         section_slug = category_section_map.get(sub.Category)
         section = section_map.get(section_slug) if section_slug else None
         if not section:
@@ -354,6 +358,21 @@ async def assemble_newsletter(
         if not section:
             continue
 
+        if existing_item is not None:
+            # Re-sync auto-placed items to the current category mapping;
+            # placements staff moved by hand are left alone.
+            if not existing_item.Manually_Placed and existing_item.Section_Id != section.Id:
+                existing_item.Section_Id = section.Id
+                existing_item.Position = len(
+                    [
+                        it
+                        for it in newsletter.Items
+                        if it.Section_Id == section.Id and it.Id != existing_item.Id
+                    ]
+                )
+            continue
+
+        headline, body = _get_best_text(sub)
         section_items = [it for it in newsletter.Items if it.Section_Id == section.Id]
         position = len(section_items)
 
@@ -379,7 +398,7 @@ def _get_category_section_map(newsletter_type: str) -> dict[str, str]:
     if newsletter_type == "tdr":
         return {
             "faculty_staff": "employee-news",
-            "employee_announcement": "employee-news",
+            "employee_announcement": "employee-announcements",
             "survey": "employee-news",
             "ucm_feature_story": "employee-news",
             "calendar_event": "todays-events",

--- a/backend/tests/test_newsletters.py
+++ b/backend/tests/test_newsletters.py
@@ -1,13 +1,16 @@
 """Tests for Newsletter CRUD and assembly endpoints."""
 
+import json
 from datetime import date, datetime
+from pathlib import Path
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.newsletter import NewsletterItem
 from app.models.section import NewsletterSection
-from app.services import calendar_event_service, job_posting_service
+from app.services import calendar_event_service, job_posting_service, newsletter_service
 from tests.conftest import make_newsletter_data, make_submission_data
 
 
@@ -420,6 +423,125 @@ class TestNewsletterItems:
         assert len(items) == 1
         assert items[0]["Submission_Id"] == submission_id
         assert items[0]["Section_Id"] == "myui-news-updates"
+
+    async def test_assemble_places_employee_announcement_in_its_section_and_resyncs(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+    ):
+        db.add_all([
+            NewsletterSection(
+                Id="tdr-employee-news",
+                Newsletter_Type="tdr",
+                Name="Employee News",
+                Slug="employee-news",
+                Display_Order=1,
+                Is_Active=True,
+            ),
+            NewsletterSection(
+                Id="tdr-employee-announcements",
+                Newsletter_Type="tdr",
+                Name="Employee Announcements",
+                Slug="employee-announcements",
+                Display_Order=2,
+                Is_Active=True,
+            ),
+        ])
+        await db.commit()
+
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Category="employee_announcement",
+                Schedule_Requests=[{"Requested_Date": "2026-04-06"}],
+            ),
+            headers=staff_headers,
+        )
+        submission_id = submission_resp.json()["Id"]
+        await client.patch(
+            f"/api/v1/submissions/{submission_id}",
+            json={"Status": "approved"},
+        )
+
+        assemble_resp = await client.post(
+            "/api/v1/newsletters/assemble",
+            json={"Newsletter_Type": "tdr", "Publish_Date": "2026-04-06"},
+            headers=staff_headers,
+        )
+        assert assemble_resp.status_code == 200
+        newsletter_id = assemble_resp.json()["Id"]
+        items = assemble_resp.json()["Items"]
+        assert len(items) == 1
+        assert items[0]["Section_Id"] == "tdr-employee-announcements"
+        item_id = items[0]["Id"]
+
+        # Simulate an item placed by the stale pre-fix mapping: wrong section,
+        # not flagged as manually moved. Re-assembly re-syncs it.
+        item = await db.get(NewsletterItem, item_id)
+        item.Section_Id = "tdr-employee-news"
+        await db.commit()
+
+        reassemble_resp = await client.post(
+            "/api/v1/newsletters/assemble",
+            json={"Newsletter_Type": "tdr", "Publish_Date": "2026-04-06"},
+            headers=staff_headers,
+        )
+        assert reassemble_resp.status_code == 200
+        items = reassemble_resp.json()["Items"]
+        assert len(items) == 1
+        assert items[0]["Section_Id"] == "tdr-employee-announcements"
+
+        # A deliberate staff move (PATCH with a new section) sets the manual
+        # flag and survives re-assembly.
+        move_resp = await client.patch(
+            f"/api/v1/newsletters/{newsletter_id}/items/{item_id}",
+            json={"Section_Id": "tdr-employee-news"},
+            headers=staff_headers,
+        )
+        assert move_resp.status_code == 200
+
+        reassemble_resp = await client.post(
+            "/api/v1/newsletters/assemble",
+            json={"Newsletter_Type": "tdr", "Publish_Date": "2026-04-06"},
+            headers=staff_headers,
+        )
+        assert reassemble_resp.status_code == 200
+        items = reassemble_resp.json()["Items"]
+        assert len(items) == 1
+        assert items[0]["Section_Id"] == "tdr-employee-news"
+
+
+def test_category_section_maps_target_seeded_sections():
+    """Every section slug referenced by the assembly mappings must exist in
+    the seeded sections for that newsletter type, so new sections cannot
+    silently drift out of reach of the category map."""
+    data_dir = Path(__file__).parents[1] / "data" / "sections"
+    for newsletter_type, filename in (
+        ("tdr", "tdr_sections.json"),
+        ("myui", "myui_sections.json"),
+    ):
+        seeded_slugs = {
+            section["slug"]
+            for section in json.loads((data_dir / filename).read_text())
+        }
+        mapped_slugs = set(
+            newsletter_service._get_category_section_map(newsletter_type).values()
+        )
+        mapped_slugs.add(newsletter_service.get_calendar_section_slug(newsletter_type))
+        mapped_slugs.add(newsletter_service.get_job_postings_section_slug(newsletter_type))
+        missing = mapped_slugs - seeded_slugs
+        assert not missing, (
+            f"{newsletter_type} assembly maps to sections that are not seeded: {missing}"
+        )
+
+    myui_slugs = {
+        section["slug"]
+        for section in json.loads((data_dir / "myui_sections.json").read_text())
+    }
+    assert newsletter_service.get_academic_dates_section_slug() in myui_slugs
+    tdr_map = newsletter_service._get_category_section_map("tdr")
+    assert tdr_map["employee_announcement"] == "employee-announcements"
 
 
 class TestCalendarEventParsing:


### PR DESCRIPTION
Closes #279

## Problem

Joy's approved Employee Announcement for the Aug. 11 issue never appeared in the Builder's Employee Announcements section. Triage found it wasn't missing — the hard-coded TDR category→section map still routed `employee_announcement` to `employee-news`, so the item sat in Employee News. The `employee-announcements` section (added later, data-driven) was unreachable by any category. The second reported symptom (stale "UCM appreciation day" entry) was an active test recurring message, deactivated during triage — no code change needed.

## Fix

- TDR map now routes `employee_announcement` → `employee-announcements`.
- **Re-assembly semantics** (the part that heals existing drafts): a new `Manually_Placed` flag on newsletter items is set whenever staff move an item to a different section (item PATCH or drag reorder). `assemble_newsletter` re-syncs auto-placed items whose section no longer matches the current mapping, and leaves manually placed items alone — so re-assembling the Aug. 11 draft moves Joy's announcement into Employee Announcements without clobbering deliberate curation.
- Migration `f2c6a8b4d1e3` (revises `e8b2d4f6a1c9`) adds the column with a false server default.
- Guard test: every section slug referenced by the category maps and importer helpers must exist in the seeded sections for that newsletter type, so future sections can't silently drift out of reach.

## Testing

- New end-to-end test: assemble places the announcement in Employee Announcements; a stale wrong-section placement is re-synced on re-assemble; a deliberate staff move survives re-assemble.
- `pytest` — 185 passed (full backend suite)
- `ruff check .` — clean
- `alembic heads` — single head `f2c6a8b4d1e3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)