### PR TITLE
Manage recurring run dates from the staff edit view

### DIFF
--- a/frontend/src/api/submissions.ts
+++ b/frontend/src/api/submissions.ts
@@ -87,9 +87,17 @@ export async function rescheduleScheduleOccurrence(
   );
 }
 
+export interface AddScheduleRequestData {
+  Requested_Date: string;
+  Second_Requested_Date?: string;
+  Recurrence_Type?: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday';
+  Recurrence_Interval?: number;
+  Recurrence_End_Date?: string;
+}
+
 export async function addScheduleRequest(
   submissionId: string,
-  data: { Requested_Date: string; Second_Requested_Date?: string },
+  data: AddScheduleRequestData,
 ): Promise<SubmissionScheduleRequest> {
   return apiFetch<SubmissionScheduleRequest>(
     `/submissions/${submissionId}/schedule`,
@@ -98,6 +106,15 @@ export async function addScheduleRequest(
       body: JSON.stringify(data),
     },
   );
+}
+
+export async function deleteScheduleRequest(
+  submissionId: string,
+  scheduleId: string,
+): Promise<void> {
+  await apiFetch(`/submissions/${submissionId}/schedule/${scheduleId}`, {
+    method: 'DELETE',
+  });
 }
 
 export async function uploadImage(submissionId: string, file: File): Promise<Submission> {

--- a/frontend/src/components/editor/SubmissionMeta.test.tsx
+++ b/frontend/src/components/editor/SubmissionMeta.test.tsx
@@ -1,0 +1,185 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getValidDates } from '../../api/schedule';
+import type { Submission, SubmissionScheduleRequest } from '../../types/submission';
+import SubmissionMeta from './SubmissionMeta';
+
+vi.mock('../../api/schedule', () => ({
+  getValidDates: vi.fn(),
+}));
+
+const getValidDatesMock = vi.mocked(getValidDates);
+
+function makeScheduleRequest(
+  overrides: Partial<SubmissionScheduleRequest> = {},
+): SubmissionScheduleRequest {
+  return {
+    Id: 'schedule-1',
+    Requested_Date: '2026-05-05',
+    Second_Requested_Date: null,
+    Repeat_Count: 1,
+    Repeat_Note: null,
+    Is_Flexible: false,
+    Flexible_Deadline: null,
+    Recurrence_Type: 'once',
+    Recurrence_Interval: 1,
+    Recurrence_End_Date: null,
+    Excluded_Dates: [],
+    Occurrence_Dates: ['2026-05-05'],
+    ...overrides,
+  };
+}
+
+function makeSubmission(overrides: Partial<Submission> = {}): Submission {
+  return {
+    Id: 'submission-1',
+    Category: 'employee_announcement',
+    Target_Newsletter: 'tdr',
+    Original_Headline: 'Campus forum',
+    Original_Body: 'Forum details.',
+    Submitter_Name: 'Jane Submitter',
+    Submitter_Email: 'jane@example.edu',
+    Submitter_Notes: null,
+    Assigned_Editor: null,
+    Editorial_Notes: null,
+    Survey_End_Date: null,
+    Has_Image: false,
+    Image_Path: null,
+    Status: 'approved',
+    Show_In_SLC_Calendar: false,
+    Event_Classification: null,
+    Created_At: '2026-04-28T12:00:00Z',
+    Updated_At: '2026-04-28T12:00:00Z',
+    Links: [],
+    Schedule_Requests: [makeScheduleRequest()],
+    Occurrence_Dates: ['2026-05-05'],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true, now: new Date(2026, 4, 1, 9, 0, 0) });
+  vi.clearAllMocks();
+  getValidDatesMock.mockResolvedValue({
+    dates: [
+      { date: '2026-05-05', newsletters: ['tdr'] },
+      { date: '2026-05-06', newsletters: ['tdr'] },
+    ],
+    blackout_dates: [],
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('SubmissionMeta schedule management', () => {
+  it('adds a plain run date without recurrence', async () => {
+    const user = userEvent.setup();
+    const onAddScheduleDate = vi.fn().mockResolvedValue(undefined);
+    render(
+      <SubmissionMeta
+        submission={makeSubmission()}
+        onAddScheduleDate={onAddScheduleDate}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /add run date/i }));
+    const dateInput = await screen.findByDisplayValue('');
+    await user.type(dateInput, '2026-05-06');
+    await waitFor(() => {
+      expect(screen.getByText('Valid publication date')).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(onAddScheduleDate).toHaveBeenCalledWith('tdr', '2026-05-06', undefined);
+    });
+  });
+
+  it('adds a recurring run date with interval and end date', async () => {
+    const user = userEvent.setup();
+    const onAddScheduleDate = vi.fn().mockResolvedValue(undefined);
+    render(
+      <SubmissionMeta
+        submission={makeSubmission()}
+        onAddScheduleDate={onAddScheduleDate}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /add run date/i }));
+    const dateInput = await screen.findByDisplayValue('');
+    await user.type(dateInput, '2026-05-06');
+    await user.selectOptions(screen.getByLabelText('Repeats'), 'weekly');
+    const intervalInput = screen.getByLabelText(/every n weeks/i);
+    fireEvent.change(intervalInput, { target: { value: '2' } });
+    await user.type(
+      screen.getByLabelText(/ends on/i),
+      '2026-06-30',
+    );
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(onAddScheduleDate).toHaveBeenCalledWith('tdr', '2026-05-06', {
+        Recurrence_Type: 'weekly',
+        Recurrence_Interval: 2,
+        Recurrence_End_Date: '2026-06-30',
+      });
+    });
+  });
+
+  it('rejects a recurrence end date before the first run date', async () => {
+    const user = userEvent.setup();
+    const onAddScheduleDate = vi.fn().mockResolvedValue(undefined);
+    render(
+      <SubmissionMeta
+        submission={makeSubmission()}
+        onAddScheduleDate={onAddScheduleDate}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /add run date/i }));
+    const dateInput = await screen.findByDisplayValue('');
+    await user.type(dateInput, '2026-05-06');
+    await user.selectOptions(screen.getByLabelText('Repeats'), 'weekly');
+    // Fake-timer clock is May 1, so May 5 is in range but before the run date.
+    const endInput = screen.getByLabelText(/ends on/i);
+    endInput.removeAttribute('min');
+    await user.type(endInput, '2026-05-05');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(
+      await screen.findByText(/end date cannot be before the first run date/i),
+    ).toBeInTheDocument();
+    expect(onAddScheduleDate).not.toHaveBeenCalled();
+  });
+
+  it('removes a schedule request', async () => {
+    const user = userEvent.setup();
+    const onRemoveScheduleRequest = vi.fn().mockResolvedValue(undefined);
+    render(
+      <SubmissionMeta
+        submission={makeSubmission({
+          Schedule_Requests: [
+            makeScheduleRequest({
+              Id: 'schedule-weekly',
+              Recurrence_Type: 'weekly',
+            }),
+          ],
+        })}
+        onRemoveScheduleRequest={onRemoveScheduleRequest}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+    await waitFor(() => {
+      expect(onRemoveScheduleRequest).toHaveBeenCalledWith('schedule-weekly');
+    });
+  });
+
+  it('hides the remove control when no handler is provided', () => {
+    render(<SubmissionMeta submission={makeSubmission()} />);
+    expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/editor/SubmissionMeta.tsx
+++ b/frontend/src/components/editor/SubmissionMeta.tsx
@@ -3,6 +3,12 @@ import type { Submission, TargetNewsletter } from '../../types/submission';
 import { getValidDates } from '../../api/schedule';
 import { parseAPIDateTime, parseISODate, addDaysISO } from '../../utils/date';
 
+export interface ScheduleRecurrence {
+  Recurrence_Type: 'weekly' | 'monthly_date' | 'monthly_nth_weekday';
+  Recurrence_Interval: number;
+  Recurrence_End_Date?: string;
+}
+
 interface SubmissionMetaProps {
   submission: Submission;
   onChangeNewsletter?: (target: TargetNewsletter) => void;
@@ -12,7 +18,12 @@ interface SubmissionMetaProps {
     occurrenceDate: string,
     newDate: string,
   ) => Promise<void>;
-  onAddScheduleDate?: (newsletter: string, date: string) => Promise<void>;
+  onAddScheduleDate?: (
+    newsletter: string,
+    date: string,
+    recurrence?: ScheduleRecurrence,
+  ) => Promise<void>;
+  onRemoveScheduleRequest?: (scheduleId: string) => Promise<void>;
   occurrenceActionLoading?: boolean;
 }
 
@@ -47,6 +58,7 @@ export default function SubmissionMeta({
   onSkipOccurrence,
   onRescheduleOccurrence,
   onAddScheduleDate,
+  onRemoveScheduleRequest,
   occurrenceActionLoading = false,
 }: SubmissionMetaProps) {
   const [rescheduleTarget, setRescheduleTarget] = useState<{
@@ -60,6 +72,12 @@ export default function SubmissionMeta({
   const [addDateValue, setAddDateValue] = useState('');
   const [addDateLoading, setAddDateLoading] = useState(false);
   const [addDateError, setAddDateError] = useState('');
+  const [addRecurrenceType, setAddRecurrenceType] = useState<
+    'once' | ScheduleRecurrence['Recurrence_Type']
+  >('once');
+  const [addRecurrenceInterval, setAddRecurrenceInterval] = useState(1);
+  const [addRecurrenceEnd, setAddRecurrenceEnd] = useState('');
+  const [removingScheduleId, setRemovingScheduleId] = useState<string | null>(null);
   const [validDatesSet, setValidDatesSet] = useState<Set<string>>(new Set());
 
   const getMinDate = () => addDaysISO(1);
@@ -91,6 +109,9 @@ export default function SubmissionMeta({
     setShowAddDate(true);
     setAddDateValue('');
     setAddDateError('');
+    setAddRecurrenceType('once');
+    setAddRecurrenceInterval(1);
+    setAddRecurrenceEnd('');
     setAddDateNewsletter(submission.Target_Newsletter === 'both' ? '' : submission.Target_Newsletter);
   };
 
@@ -98,6 +119,9 @@ export default function SubmissionMeta({
     setShowAddDate(false);
     setAddDateValue('');
     setAddDateError('');
+    setAddRecurrenceType('once');
+    setAddRecurrenceInterval(1);
+    setAddRecurrenceEnd('');
     setAddDateNewsletter('');
   };
 
@@ -109,15 +133,43 @@ export default function SubmissionMeta({
       setAddDateError(`Not a valid publication date for ${label}.`);
       return;
     }
+    if (
+      addRecurrenceType !== 'once'
+      && addRecurrenceEnd
+      && addRecurrenceEnd < addDateValue
+    ) {
+      setAddDateError('The recurrence end date cannot be before the first run date.');
+      return;
+    }
     setAddDateLoading(true);
     setAddDateError('');
     try {
-      await onAddScheduleDate(nl, addDateValue);
+      await onAddScheduleDate(
+        nl,
+        addDateValue,
+        addRecurrenceType === 'once'
+          ? undefined
+          : {
+              Recurrence_Type: addRecurrenceType,
+              Recurrence_Interval: addRecurrenceInterval,
+              Recurrence_End_Date: addRecurrenceEnd || undefined,
+            },
+      );
       handleCancelAddDate();
     } catch (err) {
       setAddDateError(err instanceof Error ? err.message : 'Failed to add date');
     } finally {
       setAddDateLoading(false);
+    }
+  };
+
+  const handleRemoveScheduleRequest = async (scheduleId: string) => {
+    if (!onRemoveScheduleRequest) return;
+    setRemovingScheduleId(scheduleId);
+    try {
+      await onRemoveScheduleRequest(scheduleId);
+    } finally {
+      setRemovingScheduleId(null);
     }
   };
 
@@ -215,6 +267,16 @@ export default function SubmissionMeta({
                   )}
                   {req.Repeat_Note && (
                     <span className="font-normal text-gray-500"> ({req.Repeat_Note})</span>
+                  )}
+                  {onRemoveScheduleRequest && (
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveScheduleRequest(req.Id)}
+                      disabled={removingScheduleId === req.Id}
+                      className="ml-2 text-xs font-normal text-red-600 hover:text-red-700 underline disabled:opacity-50"
+                    >
+                      {removingScheduleId === req.Id ? 'Removing...' : 'Remove'}
+                    </button>
                   )}
                 </div>
                 {req.Recurrence_End_Date && (
@@ -370,6 +432,70 @@ export default function SubmissionMeta({
                 />
                 {addDateValue && validDatesSet.size > 0 && validDatesSet.has(addDateValue) && (
                   <div className="text-[10px] text-green-600">Valid publication date</div>
+                )}
+                <div className="flex gap-2">
+                  <div className="flex-1">
+                    <label
+                      htmlFor="add-date-recurrence-type"
+                      className="block text-[10px] text-gray-500 mb-0.5"
+                    >
+                      Repeats
+                    </label>
+                    <select
+                      id="add-date-recurrence-type"
+                      value={addRecurrenceType}
+                      onChange={(e) => {
+                        const value = e.target.value as typeof addRecurrenceType;
+                        setAddRecurrenceType(value);
+                        setAddRecurrenceInterval(1);
+                        if (value === 'once') setAddRecurrenceEnd('');
+                        setAddDateError('');
+                      }}
+                      className="w-full rounded-md border border-gray-300 px-2 py-1 text-xs focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
+                    >
+                      <option value="once">Does not repeat</option>
+                      <option value="weekly">Weekly</option>
+                      <option value="monthly_date">Monthly on this date</option>
+                      <option value="monthly_nth_weekday">Monthly on this weekday pattern</option>
+                    </select>
+                  </div>
+                  {addRecurrenceType !== 'once' && (
+                    <div className="w-16">
+                      <label
+                        htmlFor="add-date-recurrence-interval"
+                        className="block text-[10px] text-gray-500 mb-0.5"
+                      >
+                        {addRecurrenceType === 'weekly' ? 'Every N weeks' : 'Every N months'}
+                      </label>
+                      <input
+                        id="add-date-recurrence-interval"
+                        type="number"
+                        min={1}
+                        max={12}
+                        value={addRecurrenceInterval}
+                        onChange={(e) => setAddRecurrenceInterval(parseInt(e.target.value, 10) || 1)}
+                        className="w-full rounded-md border border-gray-300 px-2 py-1 text-xs focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
+                      />
+                    </div>
+                  )}
+                </div>
+                {addRecurrenceType !== 'once' && (
+                  <div>
+                    <label
+                      htmlFor="add-date-recurrence-end"
+                      className="block text-[10px] text-gray-500 mb-0.5"
+                    >
+                      Ends on (leave blank to repeat until removed)
+                    </label>
+                    <input
+                      id="add-date-recurrence-end"
+                      type="date"
+                      value={addRecurrenceEnd}
+                      min={addDateValue || getMinDate()}
+                      onChange={(e) => { setAddRecurrenceEnd(e.target.value); setAddDateError(''); }}
+                      className="w-full rounded-md border border-gray-300 px-2 py-1 text-xs focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
+                    />
+                  </div>
                 )}
                 {addDateError && (
                   <div className="text-[10px] text-red-600">{addDateError}</div>

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
   addScheduleRequest,
+  deleteScheduleRequest,
   getSubmission,
   rescheduleScheduleOccurrence,
   skipScheduleOccurrence,
@@ -402,12 +403,31 @@ export default function EditPage() {
     }
   };
 
-  const handleAddScheduleDate = async (newsletter: string, date: string) => {
+  const handleAddScheduleDate = async (
+    newsletter: string,
+    date: string,
+    recurrence?: {
+      Recurrence_Type: 'weekly' | 'monthly_date' | 'monthly_nth_weekday';
+      Recurrence_Interval: number;
+      Recurrence_End_Date?: string;
+    },
+  ) => {
     if (!id) return;
-    await addScheduleRequest(id, { Requested_Date: date });
+    await addScheduleRequest(id, { Requested_Date: date, ...(recurrence ?? {}) });
+    const dateLabel = new Date(`${date}T12:00:00`).toLocaleDateString();
+    const newsletterLabel = newsletter === 'tdr' ? 'Daily Register' : 'My UI';
     showToast(
-      `Added run date ${new Date(`${date}T12:00:00`).toLocaleDateString()} for ${newsletter === 'tdr' ? 'Daily Register' : 'My UI'}`,
+      recurrence
+        ? `Added recurring run date starting ${dateLabel} for ${newsletterLabel}`
+        : `Added run date ${dateLabel} for ${newsletterLabel}`,
     );
+    await loadData();
+  };
+
+  const handleRemoveScheduleRequest = async (scheduleId: string) => {
+    if (!id) return;
+    await deleteScheduleRequest(id, scheduleId);
+    showToast('Removed run date schedule');
     await loadData();
   };
 
@@ -760,6 +780,7 @@ export default function EditPage() {
             onSkipOccurrence={isStaff ? handleSkipOccurrence : undefined}
             onRescheduleOccurrence={isStaff ? handleRescheduleOccurrence : undefined}
             onAddScheduleDate={isStaff ? handleAddScheduleDate : undefined}
+            onRemoveScheduleRequest={isStaff ? handleRemoveScheduleRequest : undefined}
             occurrenceActionLoading={isStaff ? occurrenceActionLoading : false}
           />
 


### PR DESCRIPTION
Closes #280

## Problem

Staff had to enter each run date individually in the edit view. Triage found the feature mostly existed: the schedule-request model/API already support recurrence (weekly, monthly-by-date, monthly-by-weekday; interval 1–12; optional end date meaning until-removed), occurrence generation already drives Builder assembly, and the create form exposes recurrence to staff. The gap was the staff edit view: its "Add Run Date" flow was date-only, and recurrence couldn't be removed after creation.

## Fix (frontend only — no backend changes needed)

- **Add Run Date** in the staff edit view now offers optional recurrence: a Repeats selector (weekly / monthly on this date / monthly on this weekday pattern), an every-N interval, and an optional end date ("leave blank to repeat until removed"). Sent through the existing `addScheduleRequest` payload; the server's staff-only enforcement and validation are unchanged.
- **Remove** control on each schedule-request row (rendered only when the staff handler is passed, mirroring the existing gating) deletes the schedule via the existing DELETE endpoint — this is how a recurring schedule is removed.
- Client-side guard mirrors the server rule: recurrence end date cannot precede the first run date.

## Testing

- New `SubmissionMeta.test.tsx`: plain add passes no recurrence; recurring add passes type/interval/end date; end-date-before-start is rejected client-side; Remove calls the handler with the schedule id; Remove is hidden without a handler (non-staff).
- `npx vitest run` — 64 passed (full frontend suite)
- `npm run lint` — clean
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)