### PR TITLE
Route UCM feature stories to the Feature Stories section

### DIFF
--- a/backend/app/services/newsletter_service.py
+++ b/backend/app/services/newsletter_service.py
@@ -400,7 +400,7 @@ def _get_category_section_map(newsletter_type: str) -> dict[str, str]:
             "faculty_staff": "employee-news",
             "employee_announcement": "employee-announcements",
             "survey": "employee-news",
-            "ucm_feature_story": "employee-news",
+            "ucm_feature_story": "feature-stories",
             "calendar_event": "todays-events",
             "kudos": "kudos",
             "news_release": "news-releases",

--- a/backend/tests/test_newsletters.py
+++ b/backend/tests/test_newsletters.py
@@ -542,6 +542,7 @@ def test_category_section_maps_target_seeded_sections():
     assert newsletter_service.get_academic_dates_section_slug() in myui_slugs
     tdr_map = newsletter_service._get_category_section_map("tdr")
     assert tdr_map["employee_announcement"] == "employee-announcements"
+    assert tdr_map["ucm_feature_story"] == "feature-stories"
 
 
 class TestCalendarEventParsing:


### PR DESCRIPTION
Follow-up to #292 (issue #279).

Verifying the #279 fix on dev exposed the identical drift for `ucm_feature_story`: the TDR category map routed it to `employee-news` while the `feature-stories` section exists, so re-assembly moved a feature story out of Feature Stories per the stale map. Corrected the mapping and extended the map-target guard test.

## Testing

- `pytest` — 185 passed
- `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)