### PR TITLE
Resolve PR #302 audit follow-ups: rule conflicts, overflow, deterministic checks

### DIFF
--- a/backend/alembic/versions/c5e7a9b1d3f6_resolve_editorial_rule_conflicts.py
+++ b/backend/alembic/versions/c5e7a9b1d3f6_resolve_editorial_rule_conflicts.py
@@ -1,0 +1,102 @@
+"""resolve editorial rule conflicts and authorize acronym expansions
+
+Revision ID: c5e7a9b1d3f6
+Revises: a7c9e1f3b5d2
+Create Date: 2026-08-11 09:30:00.000000
+
+The Aug. 10 rule batch left two contradictions the editor cannot resolve on
+its own: the no-fabrication rule forbade supplying an acronym's full name even
+though the acronym rule demands a first-reference definition, and the
+composition-title rule ordered AP title case and quotation marks for works
+that the event-title rules ordered preserved verbatim and unquoted. Amend the
+four affected shared rules to state the authorization and the precedence
+explicitly. The focused upserts preserve unrelated staff-managed rules.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "c5e7a9b1d3f6"
+down_revision: str | Sequence[str] | None = "a7c9e1f3b5d2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+STYLE_RULE_UPDATES = [
+    {
+        "category": "content_filtering",
+        "rule_key": "no_fabricated_content",
+        "rule_text": "NEVER add information, facts, names, URLs, or references that are not present in the original submission, except approved canonical expansions or addresses supplied by an active style rule, or the standard full name of an acronym when the acronym rule requires a first-reference definition. When you supply an acronym's full name that is not in the submitted text, add a warning flag naming spell_out_acronyms so an editor can verify the expansion. Every remaining detail in the edited version must be traceable to the submitted text. Do not merge or cross-reference content from other submissions.",
+        "severity": "error",
+    },
+    {
+        "category": "formatting",
+        "rule_key": "composition_title_format",
+        "rule_text": "Apply AP title capitalization to composition titles. Use single quotation marks in headlines and double quotation marks in body text for books, films, plays, poems, albums, songs, operas, programs, lectures, speeches and works of art. Do not quote holy books, reference works, software, apps, game titles or sculptures. Preserve consistent quotation and capitalization throughout the item. When an event is named for a composition — a film screening, play, reading, lecture or similar work — this rule governs the title's quotation marks and capitalization and takes precedence over event-title preservation and the ban on quoting event names in headlines.",
+        "severity": "error",
+    },
+    {
+        "category": "formatting",
+        "rule_key": "preserve_event_title_case",
+        "rule_text": "Do not change event titles. Keep event titles in title case exactly as submitted, even when the surrounding text uses sentence case. This applies everywhere the name appears, including inside sentence-case headlines: official event, program and organization names are proper nouns, and preserving their official capitalization takes precedence over sentence-casing. Example: 'Fraternity and Sorority Life Bid Day' stays fully capitalized inside an otherwise sentence-case headline, never 'fraternity and sorority Bid Day'. Exception: when an event title is itself a composition title, such as a film, play or lecture title, format it under the composition-title rule instead.",
+        "severity": "error",
+    },
+    {
+        "category": "headlines",
+        "rule_key": "no_event_name_quotes",
+        "rule_text": "Do not put quotation marks around event names in headlines. Exception: when the headline names a composition such as a film, play or book, quote it per the composition-title rule.",
+        "severity": "warning",
+    },
+]
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _apply_style_rule_updates(bind: sa.Connection) -> None:
+    for rule in STYLE_RULE_UPDATES:
+        values = {
+            "Category": rule["category"],
+            "Rule_Text": rule["rule_text"],
+            "Is_Active": True,
+            "Severity": rule["severity"],
+        }
+        result = bind.execute(
+            style_rules.update()
+            .where(
+                style_rules.c.Rule_Set == "shared",
+                style_rules.c.Rule_Key == rule["rule_key"],
+            )
+            .values(**values)
+        )
+        if result.rowcount == 0:
+            bind.execute(
+                style_rules.insert().values(
+                    Id=str(uuid.uuid4()),
+                    Rule_Set="shared",
+                    Rule_Key=rule["rule_key"],
+                    **values,
+                )
+            )
+
+
+def upgrade() -> None:
+    _apply_style_rule_updates(op.get_bind())
+
+
+def downgrade() -> None:
+    # Text-only updates of managed rules; prior wording is not restored.
+    pass

--- a/backend/app/services/ai/editor.py
+++ b/backend/app/services/ai/editor.py
@@ -22,6 +22,16 @@ from app.utils.text import (
     is_event_category,
 )
 from app.utils.hyperlinks import parse_submitter_notes
+from app.utils.style_checks import (
+    strip_html,
+    detect_unabbreviated_month_dates,
+    detect_abbreviated_months_without_date,
+    detect_nonstandard_meridiems,
+    detect_twelve_oclock_meridiems,
+    detect_platform_names,
+    detect_undefined_acronyms,
+    detect_repeated_cta_phrases,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -144,6 +154,77 @@ class AIEditor:
 
         return flags
 
+    def post_analyze(
+        self,
+        headline: str,
+        body: str,
+        category: str,
+        style_rules: list[dict],
+    ) -> list[dict]:
+        """Run deterministic rule checks on the AI-edited output.
+
+        Prompt injection alone does not guarantee compliance, so the
+        mechanically verifiable rules are re-checked here. Each check runs
+        only while its rule is active, so deactivating a rule in the app
+        also silences its deterministic check. Exact-match checks flag at
+        the rule's severity; heuristic checks always flag as warnings.
+        """
+        active = {rule["rule_key"]: rule for rule in style_rules}
+        flags: list[dict] = []
+        text = strip_html(f"{headline}\n{body}")
+
+        def add(rule_key: str, message: str, *, heuristic: bool = False) -> None:
+            rule = active.get(rule_key)
+            if rule is None:
+                return
+            flag_type = "warning" if heuristic or rule["severity"] != "error" else "error"
+            flags.append({"type": flag_type, "rule_key": rule_key, "message": message})
+
+        for found in detect_unabbreviated_month_dates(text):
+            add("ap_style_dates", f"Month should be abbreviated with a specific date: '{found}'")
+        for found in detect_abbreviated_months_without_date(text):
+            add("ap_style_dates", f"Month without a specific date should be spelled out: '{found}'")
+
+        for found in detect_nonstandard_meridiems(text):
+            add("ap_style_times", f"Time should use lowercase a.m./p.m. with periods: '{found}'")
+        for found in detect_twelve_oclock_meridiems(text):
+            add("ap_style_times", f"Use noon or midnight instead of '{found}'")
+
+        platforms = detect_platform_names(text)
+        if platforms:
+            names = ", ".join(f"'{name}'" for name in sorted(set(platforms)))
+            add(
+                "online_not_platform",
+                f"Platform name(s) {names} found — use 'online' unless the platform is essential",
+                heuristic=True,
+            )
+
+        acronyms = detect_undefined_acronyms(strip_html(body))
+        if acronyms:
+            listed = ", ".join(acronyms[:5])
+            add(
+                "spell_out_acronyms",
+                f"Acronym(s) never defined in the body as Full Name (ACRONYM): {listed}",
+                heuristic=True,
+            )
+
+        repeated = detect_repeated_cta_phrases(text)
+        if repeated:
+            listed = ", ".join(f"'{phrase}'" for phrase in repeated)
+            add(
+                "single_cta",
+                f"Call-to-action phrase(s) repeated: {listed}",
+                heuristic=True,
+            )
+
+        if category == "job_opportunity":
+            if re.search(r"\bMoscow\b", text):
+                add("job_posting_format", "Jobs listing mentions Moscow — omit the default location")
+            if "\n" in body.strip():
+                add("job_posting_format", "Jobs listing spans multiple lines — keep it on one line")
+
+        return flags
+
     async def edit_submission(
         self,
         session: AsyncSession,
@@ -228,7 +309,11 @@ class AIEditor:
             generate_word_diff(submission.Original_Body, edited_body)
         )
 
-        all_flags = pre_flags + ai_flags
+        post_flags = self.post_analyze(
+            edited_headline, edited_body, submission.Category, style_rules
+        )
+
+        all_flags = pre_flags + ai_flags + post_flags
 
         return EditResult(
             edited_headline=edited_headline,

--- a/backend/app/services/ai/prompts.py
+++ b/backend/app/services/ai/prompts.py
@@ -23,7 +23,7 @@ def build_system_prompt(
     headline_case = "sentence case"
     jobs_guidance = (
         "- For Jobs-category submissions, the active Jobs style rule takes "
-        "precedence over generic length and structure guidance."
+        "precedence over generic length and structure guidance.\n"
         if category == "job_opportunity"
         else ""
     )
@@ -101,15 +101,14 @@ Your task is to edit submissions to comply with the university's editorial style
 - Do not use semicolons. Replace them with periods and split compound or lengthy sentences.
 - Favor clear, direct wording over complex sentence structures.
 - Remove redundant phrasing, lists of minor duties, and excessive detail.
-{jobs_guidance}
-- Collapse bullet lists into flowing prose when possible.
+{jobs_guidance}- Collapse bullet lists into flowing prose when possible.
 
 ### Content Filtering
 - Flag content that may not be appropriate for this newsletter (thesis defenses, limited audience, non-university affiliated).
 
 ## Important Notes
 - Preserve the core meaning and all factual details of the submission.
-- **CRITICAL: Do not add ANY information, facts, names, links, or references that were not in the original submission, except canonical expansions or addresses explicitly approved by an active rule. Do not combine or reference content from other submissions. Every other sentence in your output must trace back to the original submission text.**
+- **CRITICAL: Do not add ANY information, facts, names, links, or references that were not in the original submission, except canonical expansions or addresses explicitly approved by an active rule, or an acronym's full name when the acronym rule requires a first-reference definition — flag any full name you supply so an editor can verify it. Do not combine or reference content from other submissions. Every remaining sentence in your output must trace back to the original submission text.**
 - When in doubt about a factual claim, preserve it and flag it for human review.
 - Always embed links with meaningful anchor text, never raw URLs in the final text.
 - The submitter notes often contain critical link instructions — always follow them.

--- a/backend/app/utils/style_checks.py
+++ b/backend/app/utils/style_checks.py
@@ -1,0 +1,104 @@
+"""Deterministic post-edit style checks for AI-edited copy.
+
+The AI editing pipeline injects the active style rules into the system prompt,
+but prompt text alone cannot guarantee compliance: Joy's Aug. 10 production
+feedback (issues #299 and #300) showed the model violating rules that were
+active in the prompt at the time. The detectors here cover the subset of those
+rules that can be verified mechanically — AP month abbreviation, a.m./p.m.
+formatting, platform names, undefined acronyms, repeated calls to action and
+the Jobs single-line contract — so a violation surfaces as a flag on the AI
+version regardless of whether the model honored the prompt.
+
+Each detector is a pure function over edited text and returns the offending
+fragments. Mapping findings to flags (and gating on whether the corresponding
+rule is active) happens in the AIEditor, keeping these functions independent
+of the database. Detectors marked heuristic can produce false positives and
+should be surfaced as warnings, never errors.
+"""
+
+import re
+
+_HTML_TAG = re.compile(r"<[^>]*>")
+
+# Months AP abbreviates when paired with a specific date.
+_ABBREVIATABLE_FULL = "January|February|August|September|October|November|December"
+_MONTH_ABBREV = "Jan|Feb|Aug|Sept|Oct|Nov|Dec"
+
+_FULL_MONTH_WITH_DATE = re.compile(rf"\b(?:{_ABBREVIATABLE_FULL})\s+\d{{1,2}}(?!\d)")
+_ABBREV_WITHOUT_DATE = re.compile(rf"\b(?:{_MONTH_ABBREV})\.(?!\s*\d)")
+
+_BAD_MERIDIEM = re.compile(r"\b\d{1,2}(?::\d{2})?\s*(?:AM|PM|A\.M\.|P\.M\.|am\b|pm\b)")
+_TWELVE_MERIDIEM = re.compile(r"\b12(?::00)?\s*(?:a\.m\.|p\.m\.)", re.IGNORECASE)
+
+_PLATFORM_NAMES = re.compile(r"\b(?:Zoom|Webex|Microsoft Teams|Google Meet|Skype)\b")
+
+_ACRONYM_TOKEN = re.compile(r"\b[A-Z]{2,6}\b")
+_ROMAN_NUMERAL = re.compile(r"^[IVXLCDM]+$")
+# Acronyms AP or campus usage treats as standing on their own.
+_KNOWN_ACRONYMS = {
+    "AP", "US", "USA", "TDR", "RSVP", "GPA", "ID", "PDF", "FAQ", "HR", "IT",
+    "TV", "AV", "GED", "ADA", "FYI", "AM", "PM",
+}
+
+_CTA_PHRASES = ("register", "sign up", "rsvp", "apply", "learn more")
+
+
+def strip_html(text: str) -> str:
+    """Replace HTML tags with spaces so detectors never match inside markup."""
+    return _HTML_TAG.sub(" ", text)
+
+
+def detect_unabbreviated_month_dates(text: str) -> list[str]:
+    """Find spelled-out abbreviatable months used with a specific date."""
+    return _FULL_MONTH_WITH_DATE.findall(text)
+
+
+def detect_abbreviated_months_without_date(text: str) -> list[str]:
+    """Find abbreviated months that are not followed by a specific date."""
+    return _ABBREV_WITHOUT_DATE.findall(text)
+
+
+def detect_nonstandard_meridiems(text: str) -> list[str]:
+    """Find times whose a.m./p.m. marker is not lowercase with periods."""
+    return _BAD_MERIDIEM.findall(text)
+
+
+def detect_twelve_oclock_meridiems(text: str) -> list[str]:
+    """Find '12 p.m.'/'12 a.m.', which AP replaces with noon and midnight."""
+    return _TWELVE_MERIDIEM.findall(text)
+
+
+def detect_platform_names(text: str) -> list[str]:
+    """Heuristic: find virtual-meeting platform names that may need 'online'."""
+    return _PLATFORM_NAMES.findall(text)
+
+
+def detect_undefined_acronyms(body: str) -> list[str]:
+    """Heuristic: find acronyms the body never defines as Full Name (ACRONYM).
+
+    Roman numerals (job classifications such as III) and widely recognized
+    acronyms are skipped. A token counts as defined when it appears in
+    parentheses anywhere in the body, the shape the acronym rule requires.
+    """
+    tokens = set(_ACRONYM_TOKEN.findall(body))
+    return sorted(
+        token
+        for token in tokens
+        if token not in _KNOWN_ACRONYMS
+        and not _ROMAN_NUMERAL.fullmatch(token)
+        and f"({token})" not in body
+    )
+
+
+def detect_repeated_cta_phrases(text: str) -> list[str]:
+    """Heuristic: find call-to-action phrases that appear more than once.
+
+    'Register' is also the newsletter's name, so occurrences inside 'Daily
+    Register' are not counted.
+    """
+    lowered = re.sub(r"daily\s+register", "", text.lower())
+    return [
+        phrase
+        for phrase in _CTA_PHRASES
+        if len(re.findall(rf"\b{phrase}\b", lowered)) >= 2
+    ]

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -110,7 +110,7 @@
   {
     "category": "headlines",
     "rule_key": "no_event_name_quotes",
-    "rule_text": "Do not put quotation marks around event names in headlines.",
+    "rule_text": "Do not put quotation marks around event names in headlines. Exception: when the headline names a composition such as a film, play or book, quote it per the composition-title rule.",
     "severity": "warning"
   },
   {
@@ -230,7 +230,7 @@
   {
     "category": "content_filtering",
     "rule_key": "no_fabricated_content",
-    "rule_text": "NEVER add information, facts, names, URLs, or references that are not present in the original submission, except approved canonical expansions or addresses supplied by an active style rule. Every other detail in the edited version must be traceable to the submitted text. Do not merge or cross-reference content from other submissions.",
+    "rule_text": "NEVER add information, facts, names, URLs, or references that are not present in the original submission, except approved canonical expansions or addresses supplied by an active style rule, or the standard full name of an acronym when the acronym rule requires a first-reference definition. When you supply an acronym's full name that is not in the submitted text, add a warning flag naming spell_out_acronyms so an editor can verify the expansion. Every remaining detail in the edited version must be traceable to the submitted text. Do not merge or cross-reference content from other submissions.",
     "severity": "error"
   },
   {
@@ -284,7 +284,7 @@
   {
     "category": "formatting",
     "rule_key": "preserve_event_title_case",
-    "rule_text": "Do not change event titles. Keep event titles in title case exactly as submitted, even when the surrounding text uses sentence case. This applies everywhere the name appears, including inside sentence-case headlines: official event, program and organization names are proper nouns, and preserving their official capitalization takes precedence over sentence-casing. Example: 'Fraternity and Sorority Life Bid Day' stays fully capitalized inside an otherwise sentence-case headline, never 'fraternity and sorority Bid Day'.",
+    "rule_text": "Do not change event titles. Keep event titles in title case exactly as submitted, even when the surrounding text uses sentence case. This applies everywhere the name appears, including inside sentence-case headlines: official event, program and organization names are proper nouns, and preserving their official capitalization takes precedence over sentence-casing. Example: 'Fraternity and Sorority Life Bid Day' stays fully capitalized inside an otherwise sentence-case headline, never 'fraternity and sorority Bid Day'. Exception: when an event title is itself a composition title, such as a film, play or lecture title, format it under the composition-title rule instead.",
     "severity": "error"
   },
   {
@@ -344,7 +344,7 @@
   {
     "category": "formatting",
     "rule_key": "composition_title_format",
-    "rule_text": "Apply AP title capitalization to composition titles. Use single quotation marks in headlines and double quotation marks in body text for books, films, plays, poems, albums, songs, operas, programs, lectures, speeches and works of art. Do not quote holy books, reference works, software, apps, game titles or sculptures. Preserve consistent quotation and capitalization throughout the item.",
+    "rule_text": "Apply AP title capitalization to composition titles. Use single quotation marks in headlines and double quotation marks in body text for books, films, plays, poems, albums, songs, operas, programs, lectures, speeches and works of art. Do not quote holy books, reference works, software, apps, game titles or sculptures. Preserve consistent quotation and capitalization throughout the item. When an event is named for a composition — a film screening, play, reading, lecture or similar work — this rule governs the title's quotation marks and capitalization and takes precedence over event-title preservation and the ban on quoting event names in headlines.",
     "severity": "error"
   },
   {

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -1026,3 +1026,194 @@ class TestFinalizePreservesOriginal:
             "original",
             "editor_final",
         ]
+
+
+class NoncompliantProvider:
+    """Returns output that violates several active [MUST] rules at once."""
+
+    model = "test-model"
+
+    async def complete(self, *args, **kwargs):  # pragma: no cover - unused interface method
+        raise NotImplementedError
+
+    async def complete_json(self, *args, **kwargs):
+        return {
+            "edited_headline": "NNSA briefing set",
+            "edited_body": (
+                "The NNSA briefing is at 9 AM Wednesday, October 2, via Zoom. "
+                "Register for the briefing. Space is limited, so register soon."
+            ),
+            "changes_made": [],
+            "flags": [],
+            "embedded_links": [],
+            "confidence": 0.9,
+        }
+
+
+class CompliantProvider:
+    """Returns output that satisfies every deterministically checked rule."""
+
+    model = "test-model"
+
+    async def complete(self, *args, **kwargs):  # pragma: no cover - unused interface method
+        raise NotImplementedError
+
+    async def complete_json(self, *args, **kwargs):
+        return {
+            "edited_headline": "NNSA briefing set",
+            "edited_body": (
+                "The National Nuclear Security Administration (NNSA) briefing "
+                "is at 9 a.m. Wednesday, Oct. 2, online. Register for the briefing."
+            ),
+            "changes_made": [],
+            "flags": [],
+            "embedded_links": [],
+            "confidence": 0.9,
+        }
+
+
+class SingleLineJobsProvider:
+    """Returns a Jobs listing that wrongly retains the Moscow location."""
+
+    model = "test-model"
+
+    async def complete(self, *args, **kwargs):  # pragma: no cover - unused interface method
+        raise NotImplementedError
+
+    async def complete_json(self, *args, **kwargs):
+        return {
+            "edited_headline": "Laboratory manager",
+            "edited_body": (
+                "Laboratory manager, Image and Data Acquisition Core, Institute "
+                "for Modeling Collaboration and Innovation, Moscow"
+            ),
+            "changes_made": [],
+            "flags": [],
+            "embedded_links": [],
+            "confidence": 0.9,
+        }
+
+
+CHECKED_RULES = [
+    ("shared", "formatting", "ap_style_dates", "error"),
+    ("shared", "formatting", "ap_style_times", "error"),
+    ("shared", "formatting", "online_not_platform", "error"),
+    ("shared", "formatting", "spell_out_acronyms", "error"),
+    ("shared", "voice", "single_cta", "error"),
+]
+
+
+@pytest.mark.asyncio
+class TestDeterministicPostValidation:
+    """An active rule the model ignores must surface as a flag (issue #300)."""
+
+    async def _run_edit(self, client, db, staff_headers, monkeypatch, provider, **overrides):
+        for rule_set, category, rule_key, severity in CHECKED_RULES:
+            db.add(
+                StyleRule(
+                    Rule_Set=rule_set,
+                    Category=category,
+                    Rule_Key=rule_key,
+                    Rule_Text=f"Managed rule {rule_key}.",
+                    Severity=severity,
+                )
+            )
+        await db.commit()
+        monkeypatch.setattr(
+            "app.api.v1.ai_edits.get_llm_provider",
+            lambda settings: provider,
+        )
+        submission_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(**overrides),
+        )
+        assert submission_resp.status_code == 201
+        submission_id = submission_resp.json()["Id"]
+
+        resp = await client.post(
+            f"/api/v1/ai-edits/{submission_id}/edit",
+            json={"Newsletter_Type": "tdr"},
+            headers=staff_headers,
+        )
+        assert resp.status_code == 202
+        task = await wait_for_task(client, resp.json()["Task_Id"], staff_headers)
+        assert task["Status"] == "succeeded"
+
+        versions_resp = await client.get(
+            f"/api/v1/ai-edits/{submission_id}/versions",
+            headers=staff_headers,
+        )
+        assert versions_resp.status_code == 200
+        ai_version = next(
+            version
+            for version in versions_resp.json()
+            if version["Version_Type"] == "ai_suggested"
+        )
+        return ai_version["Flags"] or []
+
+    async def test_ignored_must_rules_are_flagged_on_the_ai_version(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        flags = await self._run_edit(
+            client, db, staff_headers, monkeypatch, NoncompliantProvider()
+        )
+        flagged_rules = {flag["rule_key"] for flag in flags}
+
+        assert "ap_style_dates" in flagged_rules  # October 2
+        assert "ap_style_times" in flagged_rules  # 9 AM
+        assert "online_not_platform" in flagged_rules  # Zoom
+        assert "spell_out_acronyms" in flagged_rules  # undefined NNSA
+        assert "single_cta" in flagged_rules  # register twice
+
+        by_rule = {flag["rule_key"]: flag for flag in flags}
+        assert by_rule["ap_style_dates"]["type"] == "error"
+        assert by_rule["online_not_platform"]["type"] == "warning"
+
+    async def test_compliant_output_produces_no_post_validation_flags(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        flags = await self._run_edit(
+            client, db, staff_headers, monkeypatch, CompliantProvider()
+        )
+        checked = {rule_key for _, _, rule_key, _ in CHECKED_RULES}
+
+        assert not [flag for flag in flags if flag["rule_key"] in checked]
+
+    async def test_jobs_listing_that_keeps_moscow_is_flagged(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        db.add(
+            StyleRule(
+                Rule_Set="tdr",
+                Category="formatting",
+                Rule_Key="job_posting_format",
+                Rule_Text="Managed Jobs rule.",
+                Severity="error",
+            )
+        )
+        await db.commit()
+        flags = await self._run_edit(
+            client,
+            db,
+            staff_headers,
+            monkeypatch,
+            SingleLineJobsProvider(),
+            Category="job_opportunity",
+        )
+        jobs_flags = [flag for flag in flags if flag["rule_key"] == "job_posting_format"]
+
+        assert jobs_flags
+        assert jobs_flags[0]["type"] == "error"
+        assert "Moscow" in jobs_flags[0]["message"]

--- a/backend/tests/test_ai_prompts.py
+++ b/backend/tests/test_ai_prompts.py
@@ -47,3 +47,34 @@ def test_prompt_allows_only_rule_approved_canonical_enrichment():
     )
 
     assert "except canonical expansions or addresses explicitly approved by an active rule" in prompt
+
+
+def test_prompt_authorizes_flagged_acronym_expansions():
+    prompt = build_system_prompt(
+        newsletter_type="tdr",
+        category="faculty_staff",
+        style_rules=[],
+    )
+
+    assert "an acronym's full name when the acronym rule requires a first-reference definition" in prompt
+    assert "flag any full name you supply" in prompt
+
+
+def test_length_section_has_no_stray_blank_line_for_non_jobs_categories():
+    prompt = build_system_prompt(
+        newsletter_type="tdr",
+        category="faculty_staff",
+        style_rules=[],
+    )
+
+    assert "excessive detail.\n- Collapse bullet lists" in prompt
+
+
+def test_jobs_guidance_line_is_embedded_cleanly_for_jobs_submissions():
+    prompt = build_system_prompt(
+        newsletter_type="tdr",
+        category="job_opportunity",
+        style_rules=[],
+    )
+
+    assert "precedence over generic length and structure guidance.\n- Collapse bullet lists" in prompt

--- a/backend/tests/test_august_10_joy_style_rules.py
+++ b/backend/tests/test_august_10_joy_style_rules.py
@@ -87,9 +87,15 @@ def test_migration_is_idempotent_and_matches_shared_seed():
 
     seeded = seeded_rules()
     assert len(rows) == len(migration.STYLE_RULE_UPDATES)
+    # The rule-conflict resolution migration supersedes these two texts;
+    # test_editorial_rule_conflicts_migration verifies their latest seed values.
+    superseded = {"no_fabricated_content", "composition_title_format"}
     for row in rows:
         seed = seeded[row["Rule_Key"]]
-        assert row["Rule_Text"] == seed["rule_text"]
+        if row["Rule_Key"] in superseded:
+            assert row["Rule_Text"] != seed["rule_text"]
+        else:
+            assert row["Rule_Text"] == seed["rule_text"]
         assert row["Category"] == seed["category"]
         assert row["Severity"] == seed["severity"]
         assert row["Is_Active"] is True

--- a/backend/tests/test_editorial_rule_conflicts_migration.py
+++ b/backend/tests/test_editorial_rule_conflicts_migration.py
@@ -1,0 +1,119 @@
+"""Regression coverage for the editorial rule-conflict resolution migration."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "c5e7a9b1d3f6_resolve_editorial_rule_conflicts.py"
+)
+SEED_PATH = Path(__file__).parents[1] / "data" / "style_rules" / "shared_rules.json"
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("rule_conflicts", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def seeded_rules() -> dict[str, dict]:
+    return {rule["rule_key"]: rule for rule in json.loads(SEED_PATH.read_text())}
+
+
+def style_rules_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+
+
+def test_rule_upserts_are_idempotent_and_preserve_unrelated_rules():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert(),
+            [
+                {
+                    "Id": "stale",
+                    "Rule_Set": "shared",
+                    "Category": "content_filtering",
+                    "Rule_Key": "no_fabricated_content",
+                    "Rule_Text": "Old wording.",
+                    "Is_Active": False,
+                    "Severity": "warning",
+                },
+                {
+                    "Id": "custom",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "staff_custom",
+                    "Rule_Text": "Keep this staff rule.",
+                    "Is_Active": True,
+                    "Severity": "info",
+                },
+            ],
+        )
+
+        for _ in range(2):
+            migration._apply_style_rule_updates(connection)
+
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    by_key = {row["Rule_Key"]: row for row in rows}
+    assert len(rows) == len(migration.STYLE_RULE_UPDATES) + 1
+    assert by_key["staff_custom"]["Rule_Text"] == "Keep this staff rule."
+    assert by_key["no_fabricated_content"]["Id"] == "stale"
+    assert by_key["no_fabricated_content"]["Is_Active"] is True
+
+
+def test_migration_matches_shared_seed_values():
+    migration = load_migration()
+    seeded = seeded_rules()
+
+    for rule in migration.STYLE_RULE_UPDATES:
+        seed = seeded[rule["rule_key"]]
+        assert rule["rule_text"] == seed["rule_text"]
+        assert rule["category"] == seed["category"]
+        assert rule["severity"] == seed["severity"]
+
+
+def test_acronym_expansions_are_authorized_and_flagged_for_review():
+    rule_text = seeded_rules()["no_fabricated_content"]["rule_text"]
+
+    assert "standard full name of an acronym" in rule_text
+    assert "warning flag naming spell_out_acronyms" in rule_text
+
+
+def test_composition_titles_take_precedence_over_event_title_rules():
+    seeded = seeded_rules()
+
+    assert "takes precedence over event-title preservation" in (
+        seeded["composition_title_format"]["rule_text"]
+    )
+    assert "format it under the composition-title rule instead" in (
+        seeded["preserve_event_title_case"]["rule_text"]
+    )
+    assert "quote it per the composition-title rule" in (
+        seeded["no_event_name_quotes"]["rule_text"]
+    )

--- a/backend/tests/test_event_name_precedence_migration.py
+++ b/backend/tests/test_event_name_precedence_migration.py
@@ -137,7 +137,13 @@ def test_migration_values_match_style_rule_seeds():
         for rule in json.loads((seed_dir / "tdr_rules.json").read_text())
     }
 
-    assert seeded_shared["preserve_event_title_case"]["rule_text"] == migration.PRESERVE_EVENT_TITLE_RULE_TEXT
+    # The rule-conflict resolution migration supersedes this text with a
+    # composition-title exception; test_editorial_rule_conflicts_migration
+    # verifies the latest seed value.
+    assert seeded_shared["preserve_event_title_case"]["rule_text"] != migration.PRESERVE_EVENT_TITLE_RULE_TEXT
+    assert seeded_shared["preserve_event_title_case"]["rule_text"].startswith(
+        migration.PRESERVE_EVENT_TITLE_RULE_TEXT
+    )
     assert seeded_shared["preserve_event_title_case"]["severity"] == "error"
     assert seeded_shared["preserve_event_title_case"]["category"] == "formatting"
     assert seeded_tdr["sentence_case"]["rule_text"] == migration.TDR_SENTENCE_CASE_RULE_TEXT

--- a/backend/tests/test_style_checks.py
+++ b/backend/tests/test_style_checks.py
@@ -1,0 +1,93 @@
+"""Unit tests for the deterministic post-edit style detectors."""
+
+from app.utils.style_checks import (
+    strip_html,
+    detect_unabbreviated_month_dates,
+    detect_abbreviated_months_without_date,
+    detect_nonstandard_meridiems,
+    detect_twelve_oclock_meridiems,
+    detect_platform_names,
+    detect_undefined_acronyms,
+    detect_repeated_cta_phrases,
+)
+
+
+class TestMonthAbbreviation:
+    def test_flags_spelled_out_month_with_specific_date(self):
+        assert detect_unabbreviated_month_dates("The deadline is October 2.") == ["October 2"]
+
+    def test_accepts_correctly_abbreviated_date(self):
+        assert detect_unabbreviated_month_dates("The deadline is Oct. 2.") == []
+
+    def test_accepts_month_with_year_only(self):
+        assert detect_unabbreviated_month_dates("Classes start in October 2026.") == []
+
+    def test_accepts_never_abbreviated_months(self):
+        assert detect_unabbreviated_month_dates("The fair is March 5.") == []
+
+    def test_flags_abbreviated_month_without_date(self):
+        assert detect_abbreviated_months_without_date("Sessions resume in Oct. after break.") == ["Oct."]
+
+    def test_accepts_abbreviated_month_followed_by_date(self):
+        assert detect_abbreviated_months_without_date("11 a.m. Wednesday, Sept. 2, online.") == []
+
+
+class TestMeridiems:
+    def test_flags_uppercase_meridiems(self):
+        assert detect_nonstandard_meridiems("Join at 9 AM or 3:30 PM.") == ["9 AM", "3:30 PM"]
+
+    def test_flags_lowercase_without_periods(self):
+        assert detect_nonstandard_meridiems("Doors open at 7 pm.") == ["7 pm"]
+
+    def test_accepts_ap_style_times(self):
+        assert detect_nonstandard_meridiems("The talk runs 3-4 p.m. and ends by 5:15 p.m.") == []
+
+    def test_flags_twelve_oclock_instead_of_noon_or_midnight(self):
+        assert detect_twelve_oclock_meridiems("Lunch begins at 12 p.m. sharp.") == ["12 p.m."]
+
+    def test_accepts_noon(self):
+        assert detect_twelve_oclock_meridiems("Lunch begins at noon.") == []
+
+
+class TestPlatformNames:
+    def test_flags_zoom(self):
+        assert detect_platform_names("Attend via Zoom from anywhere.") == ["Zoom"]
+
+    def test_accepts_online_wording(self):
+        assert detect_platform_names("Attend online from anywhere.") == []
+
+    def test_does_not_flag_bare_teams(self):
+        assert detect_platform_names("Teams of students compete Friday.") == []
+
+
+class TestUndefinedAcronyms:
+    def test_flags_acronym_never_defined(self):
+        assert detect_undefined_acronyms("The NNSA hosts a briefing.") == ["NNSA"]
+
+    def test_accepts_defined_acronym(self):
+        body = "The National Nuclear Security Administration (NNSA) hosts a briefing. NNSA staff attend."
+        assert detect_undefined_acronyms(body) == []
+
+    def test_skips_roman_numerals_and_known_acronyms(self):
+        assert detect_undefined_acronyms("Administrative specialist III, HR office, RSVP required.") == []
+
+
+class TestRepeatedCta:
+    def test_flags_repeated_register_cta(self):
+        text = "Register for the workshop today. Space is limited, so register soon."
+        assert detect_repeated_cta_phrases(text) == ["register"]
+
+    def test_ignores_the_newsletter_name(self):
+        text = "Read the Daily Register and register for the workshop."
+        assert detect_repeated_cta_phrases(text) == []
+
+    def test_accepts_single_cta(self):
+        assert detect_repeated_cta_phrases("Sign up for the training.") == []
+
+
+def test_strip_html_removes_tags_but_keeps_anchor_text():
+    html = 'Attend <a href="https://example.com/PM">the briefing</a> online.'
+    stripped = strip_html(html)
+    assert "href" not in stripped
+    assert "the briefing" in stripped
+    assert detect_nonstandard_meridiems(stripped) == []

--- a/frontend/src/pages/EditPage.test.tsx
+++ b/frontend/src/pages/EditPage.test.tsx
@@ -378,7 +378,9 @@ describe('EditPage', () => {
   it('contains long unbroken original text inside its final-edit grid column', async () => {
     const user = userEvent.setup();
     const longUrl = `https://example.com/register/${'unbroken'.repeat(40)}`;
+    const longHeadlineToken = `headline${'token'.repeat(40)}`;
     getSubmissionMock.mockResolvedValue(makeSubmission({
+      Original_Headline: longHeadlineToken,
       Original_Body: `Register at ${longUrl}`,
     }));
     listEditVersionsMock.mockResolvedValue([]);
@@ -390,8 +392,27 @@ describe('EditPage', () => {
 
     const original = screen.getByRole('region', { name: 'Original submission' });
     const originalBody = within(original).getByText(/Register at https:\/\/example\.com\/register\//);
+    const originalHeadline = within(original).getByText(new RegExp(longHeadlineToken.slice(0, 20)));
     expect(original).toHaveClass('min-w-0');
     expect(originalBody).toHaveClass('break-words');
+    expect(originalHeadline).toHaveClass('break-words');
+  });
+
+  it('wraps long unbroken text in the original tab view', async () => {
+    const longUrl = `https://example.com/register/${'unbroken'.repeat(40)}`;
+    const longHeadlineToken = `headline${'token'.repeat(40)}`;
+    getSubmissionMock.mockResolvedValue(makeSubmission({
+      Original_Headline: longHeadlineToken,
+      Original_Body: `Register at ${longUrl}`,
+    }));
+    listEditVersionsMock.mockResolvedValue([]);
+
+    renderEditPage();
+
+    const body = await screen.findByText(/Register at https:\/\/example\.com\/register\//);
+    const headline = screen.getByText(new RegExp(longHeadlineToken.slice(0, 20)));
+    expect(body).toHaveClass('break-words');
+    expect(headline).toHaveClass('break-words');
   });
 
   it('lists submitted links in display order inside the original reference panel', async () => {

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -559,7 +559,7 @@ export default function EditPage() {
                   <label className="block text-xs font-medium text-gray-500 mb-1">
                     Original Headline
                   </label>
-                  <p className="text-sm font-medium text-gray-900 bg-gray-50 p-3 rounded">
+                  <p className="break-words text-sm font-medium text-gray-900 bg-gray-50 p-3 rounded">
                     {submission.Original_Headline}
                   </p>
                 </div>
@@ -567,7 +567,7 @@ export default function EditPage() {
                   <label className="block text-xs font-medium text-gray-500 mb-1">
                     Original Body
                   </label>
-                  <p className="text-sm text-gray-700 bg-gray-50 p-3 rounded whitespace-pre-wrap">
+                  <p className="break-words text-sm text-gray-700 bg-gray-50 p-3 rounded whitespace-pre-wrap">
                     {submission.Original_Body}
                   </p>
                 </div>
@@ -660,7 +660,7 @@ export default function EditPage() {
                   </div>
                   <div>
                     <p className="mb-1 text-xs font-medium text-gray-500">Headline</p>
-                    <p className="text-sm font-medium text-gray-900">
+                    <p className="break-words text-sm font-medium text-gray-900">
                       {submission.Original_Headline}
                     </p>
                   </div>


### PR DESCRIPTION
Follow-ups from the read-only audit of #302 (issues #299, #300, #301).

## What changed

### Authorize acronym expansions (audit P1)
The Aug. 10 rules contradicted each other: `spell_out_acronyms` [MUST] demands a first-reference `Full Name (ACRONYM)` definition, while `no_fabricated_content` [MUST] only permitted expansions *supplied by an active style rule* (i.e., IMCI and the eight venue addresses) — and the new self-audit instruction told the model to preserve source wording and flag instead of inventing an unapproved fact. A rule-following model would therefore refuse to define NNSA in `e51952c7…`, the flagship case of #300. `no_fabricated_content` now explicitly authorizes supplying an acronym's standard full name when the acronym rule requires it, and requires a warning flag naming `spell_out_acronyms` so an editor verifies every supplied expansion. The static prompt's CRITICAL line is aligned.

### Composition-title precedence (audit P2)
`composition_title_format` ordered AP title case and quotation marks for films/plays/lectures while `preserve_event_title_case` ordered event titles kept verbatim and `no_event_name_quotes` banned headline quotes — two conflicting [MUST] directives for titles like "Echoes in Black" and "Tumbbad". The composition-title rule now states its precedence explicitly, and both event-title rules carry matching exceptions.

Both rule changes ship via seed JSON **and** migration `c5e7a9b1d3f6` (idempotent upserts, unrelated staff-managed rules preserved, seed/migration parity tested, single Alembic head).

### Deterministic post-edit validation (audit P1)
New `app/utils/style_checks.py` + a `post_analyze` pass in `AIEditor`: after every AI edit, the mechanically verifiable rules are re-checked in code and violations surface as flags on the AI version — spelled-out months with a specific date ("October 2"), abbreviated months without one, non-AP `AM`/`PM`, `12 p.m./a.m.` instead of noon/midnight, platform names (Zoom/Webex/Microsoft Teams/Google Meet/Skype), undefined acronyms, repeated CTA phrases (ignoring "Daily Register"), and the Jobs Moscow/single-line contract. Each check runs only while its rule is active, so deactivating a rule in the app also silences its check. Exact-match checks flag at the rule's severity; heuristic checks always flag as warnings.

This closes the #300 acceptance-criterion gap "tests distinguish a missing rule from an active rule present in the prompt but ignored": pipeline tests drive the real edit task with a provider returning noncompliant output and assert all five rules flag, that compliant output produces zero post-validation flags, and that a Jobs listing retaining Moscow gets an error flag.

### Final Edit overflow — headline gap (audit P2)
#301's fix covered the original body but not the headline. `break-words` added to the Original headline in the Final Edit panel, and the same fix applied to the **Original tab** view, which browser verification showed had the identical overflow (text painting under the right sidebar). Regression tests extended for both views.

### Prompt cleanups (audit P3)
Removed the stray blank line the empty jobs guidance left in every non-Jobs prompt, and fixed the ambiguous "every other sentence" wording. Both have regression tests.

## Verification
- Backend: 224/224 pytest (was 193), `ruff check` clean, single Alembic head, full `alembic upgrade head` runs cleanly on a fresh database
- Frontend: 66/66 vitest, `npm run build` and `npm run lint` clean
- In-browser at 1272px (Joy's width) with a real submission containing a long unbroken headline and a long raw URL: both panels contain their text (`scrollWidth == clientWidth`), the Original panel's right edge stays left of the Final edit column, no horizontal page scroll; mobile stays stacked with no horizontal overflow

## Not included
A live-LLM eval harness for the four #300 fixture submissions — the deterministic checks cover the mechanically verifiable subset; audience-narrowing and purpose/context preservation still rely on the prompt and human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)