### PR TITLE
Fix Joy staff review and AI source-fidelity regressions

### DIFF
--- a/backend/app/api/v1/ai_edits.py
+++ b/backend/app/api/v1/ai_edits.py
@@ -303,6 +303,11 @@ async def save_editor_final(
     submission = result.scalar_one_or_none()
     if not submission:
         raise HTTPException(status_code=404, detail="Submission not found")
+    if submission.Category != "job_opportunity" and not data.Headline.strip():
+        raise HTTPException(
+            status_code=422,
+            detail="Headline is required for non-Jobs submissions",
+        )
 
     # Snapshot the original into the version history if no AI edit did so yet,
     # so the timeline is complete even for purely manual edits
@@ -326,7 +331,7 @@ async def save_editor_final(
     version = EditVersion(
         Submission_Id=submission_id,
         Version_Type="editor_final",
-        Headline=data.Headline,
+        Headline="" if submission.Category == "job_opportunity" else data.Headline.strip(),
         Body=data.Body,
         Headline_Case=data.Headline_Case,
     )

--- a/backend/app/schemas/ai_edit.py
+++ b/backend/app/schemas/ai_edit.py
@@ -86,7 +86,9 @@ class EditVersionResponse(BaseModel):
 class EditorFinalCreate(BaseModel):
     """Request to save the editor's final version."""
 
-    Headline: str = Field(..., min_length=1)
+    # Jobs are deliberately body-only listings. The endpoint validates a
+    # non-empty headline for every other submission category.
+    Headline: str = Field(...)
     Body: str = Field(..., min_length=1)
     Headline_Case: str | None = Field(None, pattern=r"^(sentence_case|title_case)$")
     Approve_For_Newsletter: bool = False

--- a/backend/app/services/ai/editor.py
+++ b/backend/app/services/ai/editor.py
@@ -3,6 +3,7 @@
 import logging
 import re
 from dataclasses import dataclass, field
+from datetime import date
 
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -31,6 +32,11 @@ from app.utils.style_checks import (
     detect_platform_names,
     detect_undefined_acronyms,
     detect_repeated_cta_phrases,
+    detect_missing_source_contacts,
+    detect_new_contact_channels,
+    detect_new_contact_names,
+    detect_changed_official_names,
+    detect_weekday_date_mismatches,
 )
 
 logger = logging.getLogger(__name__)
@@ -160,6 +166,10 @@ class AIEditor:
         body: str,
         category: str,
         style_rules: list[dict],
+        *,
+        source_text: str = "",
+        source_comparison_output: str = "",
+        reference_date: date | None = None,
     ) -> list[dict]:
         """Run deterministic rule checks on the AI-edited output.
 
@@ -184,6 +194,8 @@ class AIEditor:
             add("ap_style_dates", f"Month should be abbreviated with a specific date: '{found}'")
         for found in detect_abbreviated_months_without_date(text):
             add("ap_style_dates", f"Month without a specific date should be spelled out: '{found}'")
+        for found in detect_weekday_date_mismatches(text, reference_date=reference_date):
+            add("ap_style_dates", f"Weekday does not match the calendar date: '{found}'")
 
         for found in detect_nonstandard_meridiems(text):
             add("ap_style_times", f"Time should use lowercase a.m./p.m. with periods: '{found}'")
@@ -218,10 +230,57 @@ class AIEditor:
             )
 
         if category == "job_opportunity":
+            if headline.strip():
+                add("job_posting_format", "Jobs listing includes a headline — keep it body-only")
             if re.search(r"\bMoscow\b", text):
                 add("job_posting_format", "Jobs listing mentions Moscow — omit the default location")
             if "\n" in body.strip():
                 add("job_posting_format", "Jobs listing spans multiple lines — keep it on one line")
+
+        if source_text:
+            comparison_output = source_comparison_output or f"{headline}\n{body}"
+            missing_contacts = detect_missing_source_contacts(
+                source_text,
+                comparison_output,
+            )
+            if missing_contacts:
+                listed = ", ".join(f"'{contact}'" for contact in missing_contacts[:5])
+                add(
+                    "preserve_purpose_contact_titles",
+                    f"Source contact information missing from AI edit: {listed}",
+                )
+
+            new_contact_channels = detect_new_contact_channels(
+                source_text,
+                comparison_output,
+            )
+            if new_contact_channels:
+                listed = ", ".join(
+                    f"'{contact}'" for contact in new_contact_channels[:5]
+                )
+                add(
+                    "no_fabricated_content",
+                    f"Contact information not found in submitted content: {listed}",
+                )
+
+            new_contact_names = detect_new_contact_names(source_text, comparison_output)
+            if new_contact_names:
+                listed = ", ".join(f"'{name}'" for name in new_contact_names[:5])
+                add(
+                    "no_fabricated_content",
+                    f"Contact name(s) not found in submitted content: {listed}",
+                )
+
+            changed_names = detect_changed_official_names(
+                source_text,
+                comparison_output,
+            )
+            if changed_names:
+                listed = ", ".join(f"'{name}'" for name in changed_names[:5])
+                add(
+                    "preserve_event_title_case",
+                    f"Official or branded source name(s) changed or removed: {listed}",
+                )
 
         return flags
 
@@ -309,8 +368,26 @@ class AIEditor:
             generate_word_diff(submission.Original_Body, edited_body)
         )
 
+        source_parts = [
+            submission.Original_Headline,
+            submission.Original_Body,
+            submission.Submitter_Notes or "",
+        ]
+        for link in submission.Links:
+            source_parts.extend([link.Url, link.Anchor_Text or ""])
+        comparison_output_parts = [edited_headline, edited_body]
+        for link in embedded_links:
+            comparison_output_parts.extend(
+                [str(link.get("url", "")), str(link.get("anchor_text", ""))]
+            )
         post_flags = self.post_analyze(
-            edited_headline, edited_body, submission.Category, style_rules
+            edited_headline,
+            edited_body,
+            submission.Category,
+            style_rules,
+            source_text="\n".join(source_parts),
+            source_comparison_output="\n".join(comparison_output_parts),
+            reference_date=date.today(),
         )
 
         all_flags = pre_flags + ai_flags + post_flags

--- a/backend/app/utils/style_checks.py
+++ b/backend/app/utils/style_checks.py
@@ -17,6 +17,7 @@ should be surfaced as warnings, never errors.
 """
 
 import re
+from datetime import date, timedelta
 
 _HTML_TAG = re.compile(r"<[^>]*>")
 
@@ -41,6 +42,46 @@ _KNOWN_ACRONYMS = {
 }
 
 _CTA_PHRASES = ("register", "sign up", "rsvp", "apply", "learn more")
+
+_EMAIL = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_PHONE = re.compile(
+    r"(?<!\d)(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s])\d{3}[-.\s]\d{4}(?!\d)"
+)
+_CONTACT_NAME = re.compile(
+    r"\b(?i:contact|email|call|reach)\s+(?:the\s+)?"
+    r"([A-Z][A-Za-z'’.-]+(?:\s+[A-Z][A-Za-z'’.-]+){1,3})\b",
+)
+_ORGANIZATION_SUFFIXES = {
+    "Center", "Centre", "Clinic", "College", "Department", "Division", "Ensemble",
+    "Entertainment", "Foundation", "Institute", "Office", "Program",
+    "School", "Services", "Team", "Unit", "University",
+}
+_OFFICIAL_NAME = re.compile(
+    r"\b[A-Z][A-Za-z'’.-]*"
+    r"(?:\s+(?:(?:and|of|for|the)\s+|&\s+)?[A-Z][A-Za-z'’.-]*){1,6}\b"
+)
+_BRANDED_TOKEN = re.compile(r"\b[A-Z][a-z]+[A-Z][A-Za-z]*\b")
+_WEEKDAY_DATE = re.compile(
+    r"\b(?P<weekday>Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)"
+    r",?\s+(?P<month>Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|"
+    r"June?|July?|Aug(?:ust)?|Sept?(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|"
+    r"Dec(?:ember)?)\.?\s+(?P<day>\d{1,2})(?:,\s*(?P<year>\d{4}))?\b",
+    re.IGNORECASE,
+)
+_MONTH_NUMBERS = {
+    "jan": 1, "january": 1,
+    "feb": 2, "february": 2,
+    "mar": 3, "march": 3,
+    "apr": 4, "april": 4,
+    "may": 5,
+    "jun": 6, "june": 6,
+    "jul": 7, "july": 7,
+    "aug": 8, "august": 8,
+    "sep": 9, "sept": 9, "september": 9,
+    "oct": 10, "october": 10,
+    "nov": 11, "november": 11,
+    "dec": 12, "december": 12,
+}
 
 
 def strip_html(text: str) -> str:
@@ -102,3 +143,143 @@ def detect_repeated_cta_phrases(text: str) -> list[str]:
         for phrase in _CTA_PHRASES
         if len(re.findall(rf"\b{phrase}\b", lowered)) >= 2
     ]
+
+
+def _contact_channels(text: str) -> dict[str, str]:
+    """Return normalized contact channels while preserving report-friendly text."""
+    channels = {match.group().lower(): match.group() for match in _EMAIL.finditer(text)}
+    for match in _PHONE.finditer(text):
+        digits = re.sub(r"\D", "", match.group())
+        channels[digits[-10:]] = match.group()
+    return channels
+
+
+def detect_missing_source_contacts(source_text: str, edited_text: str) -> list[str]:
+    """Find source emails or phone numbers removed from the edited copy.
+
+    Raw HTML is intentionally retained so an address preserved only in a
+    ``mailto:`` destination still counts as present.
+    """
+    source = _contact_channels(source_text)
+    edited = _contact_channels(edited_text)
+    return [display for key, display in source.items() if key not in edited]
+
+
+def detect_new_contact_channels(source_text: str, edited_text: str) -> list[str]:
+    """Find emails or phone numbers introduced by the edited copy."""
+    source = _contact_channels(source_text)
+    edited = _contact_channels(edited_text)
+    return [display for key, display in edited.items() if key not in source]
+
+
+def detect_new_contact_names(source_text: str, edited_text: str) -> list[str]:
+    """Find likely person names introduced by contact instructions.
+
+    This is deliberately narrow: it only examines two-or-more-word title-case
+    spans after contact verbs and ignores common organization suffixes. The
+    narrow seam catches the production regression without treating ordinary
+    rewritten prose as a new identity.
+    """
+    source_lower = strip_html(source_text).lower()
+    findings: list[str] = []
+    for match in _CONTACT_NAME.finditer(strip_html(edited_text)):
+        candidate = match.group(1).strip()
+        if candidate.lower() in source_lower:
+            continue
+        if any(word in _ORGANIZATION_SUFFIXES for word in candidate.split()):
+            continue
+        if candidate not in findings:
+            findings.append(candidate)
+    return findings
+
+
+def _official_name_candidates(source_text: str) -> list[str]:
+    text = strip_html(source_text)
+    candidates: list[tuple[int, str]] = []
+
+    for match in _OFFICIAL_NAME.finditer(text):
+        candidate = match.group().strip()
+        candidate = re.sub(
+            r"^(?:Attend|Join|Register|Apply|Audition|Email|Contact|Learn|Visit)"
+            r"\s+(?:(?:for|at|with|the)\s+)?",
+            "",
+            candidate,
+        )
+        words = candidate.split()
+        if words and words[0] == "The":
+            candidate = " ".join(words[1:])
+            words = words[1:]
+        if candidate.startswith("University of Idaho"):
+            # The managed U of I abbreviation rule intentionally rewrites this phrase.
+            continue
+        has_branded_token = any(_BRANDED_TOKEN.fullmatch(word) for word in words)
+        has_org_marker = any(word.strip(".,") in _ORGANIZATION_SUFFIXES for word in words)
+        has_vandal_brand = any(word.startswith("Vandal") for word in words)
+        if has_branded_token or has_org_marker or has_vandal_brand:
+            marker_positions = [
+                index
+                for index, word in enumerate(words)
+                if word.strip(".,") in _ORGANIZATION_SUFFIXES
+            ]
+            if marker_positions:
+                candidate = " ".join(words[: marker_positions[-1] + 1])
+            elif has_branded_token or has_vandal_brand:
+                candidate = " ".join(words[:2])
+            candidates.append((match.start(), candidate))
+
+    for match in _BRANDED_TOKEN.finditer(text):
+        if not any(match.group() in candidate for _, candidate in candidates):
+            candidates.append((match.start(), match.group()))
+
+    ordered: list[str] = []
+    for _, candidate in sorted(candidates):
+        if candidate not in ordered:
+            ordered.append(candidate)
+    return ordered
+
+
+def detect_changed_official_names(source_text: str, edited_text: str) -> list[str]:
+    """Find protected official/branded source spans no longer present exactly."""
+    edited = strip_html(edited_text)
+    return [
+        candidate
+        for candidate in _official_name_candidates(source_text)
+        if candidate not in edited
+    ]
+
+
+def detect_weekday_date_mismatches(
+    text: str,
+    *,
+    reference_date: date | None = None,
+) -> list[str]:
+    """Find weekday/month/day combinations that disagree with the calendar.
+
+    Dates without a year use the reference year unless that date is more than
+    60 days in the past, in which case the next calendar year is assumed. This
+    mirrors the newsletter's upcoming-event and year-boundary behavior.
+    """
+    reference = reference_date or date.today()
+    findings: list[str] = []
+    for match in _WEEKDAY_DATE.finditer(strip_html(text)):
+        month_key = match.group("month").lower().rstrip(".")
+        month = _MONTH_NUMBERS.get(month_key)
+        if month is None:
+            continue
+        day = int(match.group("day"))
+        explicit_year = match.group("year")
+        year = int(explicit_year) if explicit_year else reference.year
+        try:
+            event_date = date(year, month, day)
+        except ValueError:
+            findings.append(match.group().rstrip("."))
+            continue
+        if not explicit_year and event_date < reference - timedelta(days=60):
+            try:
+                event_date = date(year + 1, month, day)
+            except ValueError:
+                findings.append(match.group().rstrip("."))
+                continue
+        if event_date.strftime("%A").lower() != match.group("weekday").lower():
+            findings.append(match.group().rstrip("."))
+    return findings

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -844,6 +844,47 @@ class TestAIEditTasks:
 
 @pytest.mark.asyncio
 class TestFinalizePreservesOriginal:
+    async def test_finalize_allows_body_only_jobs_but_not_body_only_news(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+    ):
+        job_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(Category="job_opportunity"),
+        )
+        job_id = job_resp.json()["Id"]
+
+        finalize_job = await client.post(
+            f"/api/v1/ai-edits/{job_id}/finalize",
+            json={
+                "Headline": "This headline must not be published",
+                "Body": "Administrative specialist III, College of Engineering",
+                "Approve_For_Newsletter": True,
+            },
+            headers=staff_headers,
+        )
+
+        assert finalize_job.status_code == 200
+        assert finalize_job.json()["Headline"] == ""
+        job_detail = await client.get(
+            f"/api/v1/submissions/{job_id}",
+            headers=staff_headers,
+        )
+        assert job_detail.json()["Status"] == "approved"
+
+        news_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(Category="faculty_staff"),
+        )
+        finalize_news = await client.post(
+            f"/api/v1/ai-edits/{news_resp.json()['Id']}/finalize",
+            json={"Headline": "", "Body": "Body-only news item."},
+            headers=staff_headers,
+        )
+
+        assert finalize_news.status_code == 422
+
     async def test_finalize_replaces_links_with_validated_editor_links(
         self,
         client: AsyncClient,
@@ -1063,7 +1104,7 @@ class CompliantProvider:
             "edited_headline": "NNSA briefing set",
             "edited_body": (
                 "The National Nuclear Security Administration (NNSA) briefing "
-                "is at 9 a.m. Wednesday, Oct. 2, online. Register for the briefing."
+                "is at 9 a.m. Friday, Oct. 2, 2026, online. Register for the briefing."
             ),
             "changes_made": [],
             "flags": [],
@@ -1086,6 +1127,52 @@ class SingleLineJobsProvider:
             "edited_body": (
                 "Laboratory manager, Image and Data Acquisition Core, Institute "
                 "for Modeling Collaboration and Innovation, Moscow"
+            ),
+            "changes_made": [],
+            "flags": [],
+            "embedded_links": [],
+            "confidence": 0.9,
+        }
+
+
+class SourceFidelityRegressionProvider:
+    """Reproduces Joy's contact, branded-name and weekday regressions."""
+
+    model = "test-model"
+
+    async def complete(self, *args, **kwargs):  # pragma: no cover - unused interface method
+        raise NotImplementedError
+
+    async def complete_json(self, *args, **kwargs):
+        return {
+            "edited_headline": "Join U of I Dance Ensemble auditions",
+            "edited_body": (
+                "Contact Melanie Meenan at melanie@example.com or 208-555-0199 "
+                "about auditions at 3 p.m. "
+                "Thursday, Aug. 25, 2026."
+            ),
+            "changes_made": [],
+            "flags": [],
+            "embedded_links": [],
+            "confidence": 0.9,
+        }
+
+
+class SourceFidelityCompliantProvider:
+    """Preserves source contacts/names and uses the correct weekday."""
+
+    model = "test-model"
+
+    async def complete(self, *args, **kwargs):  # pragma: no cover - unused interface method
+        raise NotImplementedError
+
+    async def complete_json(self, *args, **kwargs):
+        return {
+            "edited_headline": "Join UIdaho Dance Ensemble auditions",
+            "edited_body": (
+                "The UIdaho Dance Ensemble holds auditions at 3 p.m. "
+                "Tuesday, Aug. 25, 2026. Contact the "
+                '<a href="mailto:dance@uidaho.edu">dance program</a>.'
             ),
             "changes_made": [],
             "flags": [],
@@ -1215,5 +1302,72 @@ class TestDeterministicPostValidation:
         jobs_flags = [flag for flag in flags if flag["rule_key"] == "job_posting_format"]
 
         assert jobs_flags
-        assert jobs_flags[0]["type"] == "error"
-        assert "Moscow" in jobs_flags[0]["message"]
+        assert all(flag["type"] == "error" for flag in jobs_flags)
+        assert any("headline" in flag["message"] for flag in jobs_flags)
+        assert any("Moscow" in flag["message"] for flag in jobs_flags)
+
+    @pytest.mark.parametrize(
+        "provider,expected",
+        [
+            (
+                SourceFidelityRegressionProvider(),
+                {
+                    "no_fabricated_content",
+                    "preserve_purpose_contact_titles",
+                    "preserve_event_title_case",
+                    "ap_style_dates",
+                },
+            ),
+            (SourceFidelityCompliantProvider(), set()),
+        ],
+    )
+    async def test_source_fidelity_and_calendar_validation(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+        provider,
+        expected: set[str],
+    ):
+        for category, rule_key in (
+            ("content_filtering", "no_fabricated_content"),
+            ("formatting", "preserve_purpose_contact_titles"),
+            ("formatting", "preserve_event_title_case"),
+        ):
+            db.add(
+                StyleRule(
+                    Rule_Set="shared",
+                    Category=category,
+                    Rule_Key=rule_key,
+                    Rule_Text=f"Managed rule {rule_key}.",
+                    Severity="error",
+                )
+            )
+        await db.commit()
+
+        flags = await self._run_edit(
+            client,
+            db,
+            staff_headers,
+            monkeypatch,
+            provider,
+            Original_Headline="UIdaho Dance Ensemble auditions",
+            Original_Body=(
+                "UIdaho Dance Ensemble auditions are at 3 p.m. Aug. 25, 2026. "
+                "Email dance@uidaho.edu for alternate audition options."
+            ),
+        )
+        relevant = {
+            flag["rule_key"]
+            for flag in flags
+            if flag["rule_key"]
+            in {
+                "no_fabricated_content",
+                "preserve_purpose_contact_titles",
+                "preserve_event_title_case",
+                "ap_style_dates",
+            }
+        }
+
+        assert relevant == expected

--- a/backend/tests/test_style_checks.py
+++ b/backend/tests/test_style_checks.py
@@ -1,5 +1,7 @@
 """Unit tests for the deterministic post-edit style detectors."""
 
+from datetime import date
+
 from app.utils.style_checks import (
     strip_html,
     detect_unabbreviated_month_dates,
@@ -9,6 +11,11 @@ from app.utils.style_checks import (
     detect_platform_names,
     detect_undefined_acronyms,
     detect_repeated_cta_phrases,
+    detect_missing_source_contacts,
+    detect_new_contact_channels,
+    detect_new_contact_names,
+    detect_changed_official_names,
+    detect_weekday_date_mismatches,
 )
 
 
@@ -91,3 +98,69 @@ def test_strip_html_removes_tags_but_keeps_anchor_text():
     assert "href" not in stripped
     assert "the briefing" in stripped
     assert detect_nonstandard_meridiems(stripped) == []
+
+
+class TestSourceFidelity:
+    def test_flags_removed_source_contact_and_new_contact_name(self):
+        source = "Email dance@uidaho.edu for alternate audition options."
+        edited = (
+            "Contact Melanie Meenan at melanie@example.com or 208-555-0199 "
+            "for alternate audition options."
+        )
+
+        assert detect_missing_source_contacts(source, edited) == ["dance@uidaho.edu"]
+        assert detect_new_contact_channels(source, edited) == [
+            "melanie@example.com",
+            "208-555-0199",
+        ]
+        assert detect_new_contact_names(source, edited) == ["Melanie Meenan"]
+
+    def test_accepts_source_email_preserved_in_mailto_link(self):
+        source = "Email dance@uidaho.edu for alternate audition options."
+        edited = (
+            'Contact the <a href="mailto:dance@uidaho.edu">dance program</a> '
+            "for alternate audition options."
+        )
+
+        assert detect_missing_source_contacts(source, edited) == []
+        assert detect_new_contact_channels(source, edited) == []
+        assert detect_new_contact_names(source, edited) == []
+
+    def test_flags_changed_official_and_branded_names(self):
+        source = "Audition for UIdaho Dance Ensemble and manage details in VandalStar."
+        edited = "Audition for U of I Dance Ensemble and manage details in Vandal Star."
+
+        assert detect_changed_official_names(source, edited) == [
+            "UIdaho Dance Ensemble",
+            "VandalStar",
+        ]
+
+    def test_accepts_exact_official_and_branded_names(self):
+        text = "Audition for UIdaho Dance Ensemble and manage details in VandalStar."
+
+        assert detect_changed_official_names(text, text) == []
+
+
+class TestWeekdayDateConsistency:
+    def test_flags_weekday_that_disagrees_with_explicit_date(self):
+        assert detect_weekday_date_mismatches(
+            "Auditions are Thursday, Aug. 25, 2026.",
+            reference_date=date(2026, 8, 13),
+        ) == ["Thursday, Aug. 25, 2026"]
+
+    def test_accepts_correct_weekday_for_explicit_date(self):
+        assert detect_weekday_date_mismatches(
+            "Auditions are Tuesday, Aug. 25, 2026.",
+            reference_date=date(2026, 8, 13),
+        ) == []
+
+    def test_resolves_year_boundary_for_dates_without_year(self):
+        assert detect_weekday_date_mismatches(
+            "Orientation is Thursday, Jan. 1.",
+            reference_date=date(2026, 12, 20),
+        ) == ["Thursday, Jan. 1"]
+
+        assert detect_weekday_date_mismatches(
+            "Orientation is Friday, Jan. 1.",
+            reference_date=date(2027, 1, 1),
+        ) == []

--- a/frontend/src/pages/EditPage.test.tsx
+++ b/frontend/src/pages/EditPage.test.tsx
@@ -286,6 +286,70 @@ describe('EditPage', () => {
     );
   });
 
+  it('reviews, edits and approves a body-only Jobs AI version', async () => {
+    const user = userEvent.setup();
+    getSubmissionMock.mockResolvedValue(makeSubmission({
+      Category: 'job_opportunity',
+      Status: 'ai_edited',
+    }));
+    listEditVersionsMock.mockResolvedValue([
+      makeVersion({
+        Headline: '',
+        Body: 'Administrative specialist III, College of Engineering',
+      }),
+    ]);
+
+    renderEditPage();
+
+    await screen.findByText('Administrative specialist III, College of Engineering');
+    await user.click(screen.getByRole('button', { name: /use ai suggestion in final edit/i }));
+
+    const finalEdit = screen.getByRole('region', { name: 'Final edit' });
+    expect(within(finalEdit).queryByPlaceholderText('Enter headline...')).not.toBeInTheDocument();
+    expect(screen.queryByText('No AI suggestion is available for final editing.')).not.toBeInTheDocument();
+
+    const body = within(finalEdit).getByPlaceholderText('Enter body text...');
+    await user.clear(body);
+    await user.type(body, 'Administrative specialist III, College of Engineering, Boise');
+    await user.tab();
+    await user.click(within(finalEdit).getByRole('button', { name: /save and approve/i }));
+
+    await waitFor(() => {
+      expect(saveEditorFinalMock).toHaveBeenCalledWith('submission-1', {
+        Headline: '',
+        Body: 'Administrative specialist III, College of Engineering, Boise',
+        Headline_Case: 'sentence_case',
+        Approve_For_Newsletter: true,
+      });
+    });
+  });
+
+  it('opens a newly generated body-only Jobs suggestion before versions reload', async () => {
+    const user = userEvent.setup();
+    getSubmissionMock.mockResolvedValue(makeSubmission({
+      Category: 'job_opportunity',
+      Status: 'ai_edited',
+    }));
+    listEditVersionsMock.mockResolvedValue([]);
+    triggerAIEditMock.mockResolvedValue(makeAIResponse({
+      Edited_Headline: '',
+      Edited_Body: 'Academic advisor, College of Business and Economics',
+    }));
+
+    renderEditPage();
+
+    await screen.findByText('Original campus headline');
+    await user.click(screen.getByRole('button', { name: /tdr/i }));
+    await screen.findByText('Academic advisor, College of Business and Economics');
+    await user.click(screen.getByRole('button', { name: /use ai suggestion in final edit/i }));
+
+    const finalEdit = screen.getByRole('region', { name: 'Final edit' });
+    expect(within(finalEdit).getByPlaceholderText('Enter body text...')).toHaveValue(
+      'Academic advisor, College of Business and Economics',
+    );
+    expect(screen.queryByText('No AI suggestion is available for final editing.')).not.toBeInTheDocument();
+  });
+
   it('uses the original submission when an editor bypasses an existing AI suggestion', async () => {
     const user = userEvent.setup();
     listEditVersionsMock.mockResolvedValue([

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -231,12 +231,13 @@ export default function EditPage() {
       const aiVersion = [...versions].reverse().find((v) => v.Version_Type === 'ai_suggested');
       const headline = aiVersion?.Headline || aiEditResult?.Edited_Headline;
       const body = aiVersion?.Body || aiEditResult?.Edited_Body;
-      if (!headline || !body) {
+      const headlineRequired = submission.Category !== 'job_opportunity';
+      if (!body || (headlineRequired && !headline)) {
         setError('No AI suggestion is available for final editing.');
         return;
       }
       const editable = prepareBodyForEditing(body, submission.Links);
-      setEditHeadline(headline);
+      setEditHeadline(headline || '');
       setEditBody(editable.body);
       setEditLinks(editable.links);
     }
@@ -258,7 +259,7 @@ export default function EditPage() {
           : undefined;
       const links = normalizedBodyLinks(editLinks);
       await saveEditorFinal(id, {
-        Headline: editHeadline,
+        Headline: submission?.Category === 'job_opportunity' ? '' : editHeadline,
         Body: buildLinkedBody(editBody, links),
         Headline_Case: sourceVersion?.Headline_Case || undefined,
         Approve_For_Newsletter: approveForNewsletter,
@@ -463,6 +464,7 @@ export default function EditPage() {
   const canApproveFinal = ['new', 'ai_edited', 'in_review', 'approved'].includes(
     submission.Status,
   );
+  const isJobSubmission = submission.Category === 'job_opportunity';
 
   const tabs: { id: Tab; label: string; available: boolean }[] = [
     { id: 'original', label: 'Original', available: true },
@@ -696,11 +698,20 @@ export default function EditPage() {
                       Starting point: {finalEditSourceLabel}
                     </p>
                   </div>
-                  <HeadlineEditor
-                    value={editHeadline}
-                    onChange={setEditHeadline}
-                    headlineCase={aiVersion?.Headline_Case || null}
-                  />
+                  {isJobSubmission ? (
+                    <div className="rounded-md border border-ui-gold-200 bg-ui-gold-50 px-3 py-2">
+                      <p className="text-xs font-medium text-ui-gold-800">Jobs listing</p>
+                      <p className="mt-0.5 text-xs text-ui-gold-700">
+                        Jobs run as one linked line without a separate headline.
+                      </p>
+                    </div>
+                  ) : (
+                    <HeadlineEditor
+                      value={editHeadline}
+                      onChange={setEditHeadline}
+                      headlineCase={aiVersion?.Headline_Case || null}
+                    />
+                  )}
                   <BodyEditor value={editBody} onChange={setEditBody} />
                   <div className="border-t border-gray-100 pt-4">
                     <LinkEditor


### PR DESCRIPTION
## Summary

- allow body-only Jobs submissions to open in Final Edit, be manually edited and be approved
- enforce the Jobs no-headline contract in both the UI and API
- add deterministic checks for missing or fabricated contact details, altered official/branded names and incorrect weekday/date combinations
- cover stored and newly generated Jobs versions plus AI source-fidelity regressions

## Root cause

The Final Edit flow applied the non-Jobs headline requirement to Jobs submissions even though Jobs are intentionally body-only. Separately, source fidelity and calendar correctness depended on prompt compliance, so model output could silently alter contact information, official names or weekdays.

## Impact

Staff can review and approve Jobs normally. AI edits now surface deterministic error flags when they remove source contacts, introduce unsupported names/email addresses/phone numbers, alter protected names or pair a date with the wrong weekday.

## Validation

- Backend: 234 tests passed
- Backend: Ruff passed
- Frontend: 68 tests passed
- Frontend: ESLint passed
- Frontend: production build passed
- `git diff --check` passed

Closes #304
Closes #305
Closes #306
Closes #307
