### PR TITLE
Fix Joy link, weekday, and recurrence feedback

### DIFF
--- a/backend/alembic/versions/e2c4a6b8d0f1_extend_weekday_rule_to_all_dates.py
+++ b/backend/alembic/versions/e2c4a6b8d0f1_extend_weekday_rule_to_all_dates.py
@@ -1,0 +1,82 @@
+"""extend near-term weekday rule to all dates
+
+Revision ID: e2c4a6b8d0f1
+Revises: c5e7a9b1d3f6
+Create Date: 2026-08-18 10:30:00.000000
+
+Joy clarified that every date within the next 30 days needs its weekday,
+including deadlines and other non-event dates. The focused upsert preserves
+unrelated staff-managed rules.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "e2c4a6b8d0f1"
+down_revision: str | Sequence[str] | None = "c5e7a9b1d3f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+DAY_OF_WEEK_RULE_TEXT = (
+    "Pair the correct day of the week with every date that falls within the "
+    "next 30 days, based on the applicable calendar year. This applies to "
+    "event dates, deadlines, registration deadlines, application deadlines, "
+    "enrollment deadlines, submission deadlines, drawing dates, promotional "
+    "dates and every other date reference. Scan the entire submission before "
+    "finalizing so non-event dates are not overlooked. Dates beyond 30 days "
+    "do not need a day of the week."
+)
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _upsert_rule(connection: sa.Connection) -> None:
+    existing_id = connection.execute(
+        sa.select(style_rules.c.Id).where(
+            style_rules.c.Rule_Set == "shared",
+            style_rules.c.Rule_Key == "day_of_week_with_dates",
+        )
+    ).scalar_one_or_none()
+    values = {
+        "Category": "formatting",
+        "Rule_Text": DAY_OF_WEEK_RULE_TEXT,
+        "Is_Active": True,
+        "Severity": "error",
+    }
+    if existing_id:
+        connection.execute(
+            style_rules.update().where(style_rules.c.Id == existing_id).values(**values)
+        )
+    else:
+        connection.execute(
+            style_rules.insert().values(
+                Id=str(uuid.uuid4()),
+                Rule_Set="shared",
+                Rule_Key="day_of_week_with_dates",
+                **values,
+            )
+        )
+
+
+def upgrade() -> None:
+    _upsert_rule(op.get_bind())
+
+
+def downgrade() -> None:
+    # Text-only revision of a managed rule; prior wording is not restored.
+    pass

--- a/backend/app/services/ai/editor.py
+++ b/backend/app/services/ai/editor.py
@@ -36,6 +36,7 @@ from app.utils.style_checks import (
     detect_new_contact_channels,
     detect_new_contact_names,
     detect_changed_official_names,
+    detect_missing_near_term_weekdays,
     detect_weekday_date_mismatches,
 )
 
@@ -196,6 +197,14 @@ class AIEditor:
             add("ap_style_dates", f"Month without a specific date should be spelled out: '{found}'")
         for found in detect_weekday_date_mismatches(text, reference_date=reference_date):
             add("ap_style_dates", f"Weekday does not match the calendar date: '{found}'")
+        for found in detect_missing_near_term_weekdays(
+            text,
+            reference_date=reference_date,
+        ):
+            add(
+                "day_of_week_with_dates",
+                f"Near-term date is missing its weekday: '{found}'",
+            )
 
         for found in detect_nonstandard_meridiems(text):
             add("ap_style_times", f"Time should use lowercase a.m./p.m. with periods: '{found}'")

--- a/backend/app/utils/style_checks.py
+++ b/backend/app/utils/style_checks.py
@@ -68,6 +68,16 @@ _WEEKDAY_DATE = re.compile(
     r"Dec(?:ember)?)\.?\s+(?P<day>\d{1,2})(?:,\s*(?P<year>\d{4}))?\b",
     re.IGNORECASE,
 )
+_MONTH_DAY = re.compile(
+    r"\b(?P<month>Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|"
+    r"June?|July?|Aug(?:ust)?|Sept?(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|"
+    r"Dec(?:ember)?)\.?\s+(?P<day>\d{1,2})(?:,\s*(?P<year>\d{4}))?\b",
+    re.IGNORECASE,
+)
+_WEEKDAY_PREFIX = re.compile(
+    r"\b(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),?\s*$",
+    re.IGNORECASE,
+)
 _MONTH_NUMBERS = {
     "jan": 1, "january": 1,
     "feb": 2, "february": 2,
@@ -282,4 +292,48 @@ def detect_weekday_date_mismatches(
                 continue
         if event_date.strftime("%A").lower() != match.group("weekday").lower():
             findings.append(match.group().rstrip("."))
+    return findings
+
+
+def detect_missing_near_term_weekdays(
+    text: str,
+    *,
+    reference_date: date | None = None,
+) -> list[str]:
+    """Find dates in the next 30 days that are not paired with a weekday.
+
+    The check is intentionally context-agnostic: deadlines, enrollment dates,
+    drawings and promotional dates follow the same near-term rule as events.
+    Dates without a year use the same year-boundary resolution as the weekday
+    consistency check.
+    """
+    reference = reference_date or date.today()
+    findings: list[str] = []
+    plain_text = strip_html(text)
+
+    for match in _MONTH_DAY.finditer(plain_text):
+        if _WEEKDAY_PREFIX.search(plain_text[:match.start()]):
+            continue
+
+        month_key = match.group("month").lower().rstrip(".")
+        month = _MONTH_NUMBERS.get(month_key)
+        if month is None:
+            continue
+        day = int(match.group("day"))
+        explicit_year = match.group("year")
+        year = int(explicit_year) if explicit_year else reference.year
+        try:
+            candidate_date = date(year, month, day)
+        except ValueError:
+            continue
+        if not explicit_year and candidate_date < reference - timedelta(days=60):
+            try:
+                candidate_date = date(year + 1, month, day)
+            except ValueError:
+                continue
+
+        days_ahead = (candidate_date - reference).days
+        if 0 <= days_ahead <= 30:
+            findings.append(match.group().rstrip("."))
+
     return findings

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -164,8 +164,8 @@
   {
     "category": "formatting",
     "rule_key": "day_of_week_with_dates",
-    "rule_text": "Pair the day of the week with dates for events within the coming month. Events beyond 30 days out do not need a day of the week, only a date.",
-    "severity": "warning"
+    "rule_text": "Pair the correct day of the week with every date that falls within the next 30 days, based on the applicable calendar year. This applies to event dates, deadlines, registration deadlines, application deadlines, enrollment deadlines, submission deadlines, drawing dates, promotional dates and every other date reference. Scan the entire submission before finalizing so non-event dates are not overlooked. Dates beyond 30 days do not need a day of the week.",
+    "severity": "error"
   },
   {
     "category": "formatting",

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -1,6 +1,7 @@
 """Tests for AI edit task handling and failure behavior."""
 
 import asyncio
+from datetime import date
 
 import pytest
 import sqlalchemy as sa
@@ -10,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.edit_history import EditVersion
 from app.models.style_rule import StyleRule
 from app.models.submission import Submission
+from app.services.ai.editor import AIEditor
 from tests.conftest import TestSession, make_submission_data
 
 
@@ -1259,6 +1261,30 @@ class TestDeterministicPostValidation:
         by_rule = {flag["rule_key"]: flag for flag in flags}
         assert by_rule["ap_style_dates"]["type"] == "error"
         assert by_rule["online_not_platform"]["type"] == "warning"
+
+    async def test_missing_weekday_on_near_term_deadline_is_flagged(self):
+        flags = AIEditor(SuccessfulProvider()).post_analyze(
+            "Enroll for a meal plan",
+            "Enroll by Aug. 22 for a chance to win.",
+            "faculty_staff",
+            [
+                {
+                    "category": "formatting",
+                    "rule_key": "day_of_week_with_dates",
+                    "rule_text": "Managed near-term weekday rule.",
+                    "severity": "error",
+                }
+            ],
+            reference_date=date(2026, 8, 17),
+        )
+
+        assert flags == [
+            {
+                "type": "error",
+                "rule_key": "day_of_week_with_dates",
+                "message": "Near-term date is missing its weekday: 'Aug. 22'",
+            }
+        ]
 
     async def test_compliant_output_produces_no_post_validation_flags(
         self,

--- a/backend/tests/test_near_term_weekday_rule_migration.py
+++ b/backend/tests/test_near_term_weekday_rule_migration.py
@@ -1,0 +1,98 @@
+"""Regression coverage for the all-near-term-dates weekday rule migration."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "e2c4a6b8d0f1_extend_weekday_rule_to_all_dates.py"
+)
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("near_term_weekday_rule", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def style_rules_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+
+
+def test_rule_upsert_is_idempotent_and_preserves_unrelated_rules():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert(),
+            [
+                {
+                    "Id": "stale",
+                    "Rule_Set": "shared",
+                    "Category": "formatting",
+                    "Rule_Key": "day_of_week_with_dates",
+                    "Rule_Text": "Events only.",
+                    "Is_Active": False,
+                    "Severity": "warning",
+                },
+                {
+                    "Id": "custom",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "staff_custom",
+                    "Rule_Text": "Keep this staff rule.",
+                    "Is_Active": True,
+                    "Severity": "info",
+                },
+            ],
+        )
+
+        migration._upsert_rule(connection)
+        migration._upsert_rule(connection)
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    by_key = {row["Rule_Key"]: row for row in rows}
+    updated = by_key["day_of_week_with_dates"]
+    assert updated["Rule_Text"] == migration.DAY_OF_WEEK_RULE_TEXT
+    assert updated["Category"] == "formatting"
+    assert updated["Severity"] == "error"
+    assert updated["Is_Active"] is True
+    assert by_key["staff_custom"]["Rule_Text"] == "Keep this staff rule."
+    assert len(rows) == 2
+
+
+def test_migration_matches_the_seeded_rule():
+    migration = load_migration()
+    seed_path = Path(__file__).parents[1] / "data" / "style_rules" / "shared_rules.json"
+    seeded = {
+        rule["rule_key"]: rule
+        for rule in json.loads(seed_path.read_text())
+    }
+
+    rule = seeded["day_of_week_with_dates"]
+    assert rule["rule_text"] == migration.DAY_OF_WEEK_RULE_TEXT
+    assert rule["category"] == "formatting"
+    assert rule["severity"] == "error"

--- a/backend/tests/test_style_checks.py
+++ b/backend/tests/test_style_checks.py
@@ -15,6 +15,7 @@ from app.utils.style_checks import (
     detect_new_contact_channels,
     detect_new_contact_names,
     detect_changed_official_names,
+    detect_missing_near_term_weekdays,
     detect_weekday_date_mismatches,
 )
 
@@ -142,6 +143,33 @@ class TestSourceFidelity:
 
 
 class TestWeekdayDateConsistency:
+    def test_flags_near_term_dates_without_weekdays_in_any_context(self):
+        assert detect_missing_near_term_weekdays(
+            (
+                "Enroll by Aug. 22. Registration closes Sept. 10. "
+                "Applications are due Aug. 28. The drawing is Aug. 30."
+            ),
+            reference_date=date(2026, 8, 17),
+        ) == ["Aug. 22", "Sept. 10", "Aug. 28", "Aug. 30"]
+
+    def test_accepts_near_term_dates_with_correct_weekdays(self):
+        assert detect_missing_near_term_weekdays(
+            "Enroll by Saturday, Aug. 22. Applications are due Friday, Aug. 28.",
+            reference_date=date(2026, 8, 17),
+        ) == []
+
+    def test_ignores_dates_beyond_the_next_thirty_days(self):
+        assert detect_missing_near_term_weekdays(
+            "Registration closes Sept. 16. Applications are due Sept. 17.",
+            reference_date=date(2026, 8, 17),
+        ) == ["Sept. 16"]
+
+    def test_resolves_near_term_dates_across_year_boundary(self):
+        assert detect_missing_near_term_weekdays(
+            "Apply by Jan. 5.",
+            reference_date=date(2026, 12, 20),
+        ) == ["Jan. 5"]
+
     def test_flags_weekday_that_disagrees_with_explicit_date(self):
         assert detect_weekday_date_mismatches(
             "Auditions are Thursday, Aug. 25, 2026.",

--- a/frontend/src/components/editor/SubmissionMeta.test.tsx
+++ b/frontend/src/components/editor/SubmissionMeta.test.tsx
@@ -129,6 +129,52 @@ describe('SubmissionMeta schedule management', () => {
     });
   });
 
+  it('adds an indefinite recurring run date when a first run date is selected', async () => {
+    const user = userEvent.setup();
+    const onAddScheduleDate = vi.fn().mockResolvedValue(undefined);
+    render(
+      <SubmissionMeta
+        submission={makeSubmission()}
+        onAddScheduleDate={onAddScheduleDate}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /add run date/i }));
+    const dateInput = await screen.findByDisplayValue('');
+    await user.type(dateInput, '2026-05-06');
+    await user.selectOptions(screen.getByLabelText('Repeats'), 'weekly');
+    fireEvent.change(screen.getByLabelText(/every n weeks/i), {
+      target: { value: '6' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(onAddScheduleDate).toHaveBeenCalledWith('tdr', '2026-05-06', {
+        Recurrence_Type: 'weekly',
+        Recurrence_Interval: 6,
+        Recurrence_End_Date: undefined,
+      });
+    });
+  });
+
+  it('explains that a recurring schedule needs a first run date', async () => {
+    const user = userEvent.setup();
+    render(
+      <SubmissionMeta
+        submission={makeSubmission()}
+        onAddScheduleDate={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /add run date/i }));
+    await user.selectOptions(screen.getByLabelText('Repeats'), 'weekly');
+
+    expect(
+      screen.getByText('Select a first run date to enable Save.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
   it('rejects a recurrence end date before the first run date', async () => {
     const user = userEvent.setup();
     const onAddScheduleDate = vi.fn().mockResolvedValue(undefined);

--- a/frontend/src/components/editor/SubmissionMeta.tsx
+++ b/frontend/src/components/editor/SubmissionMeta.tsx
@@ -422,14 +422,31 @@ export default function SubmissionMeta({
             )}
             {(submission.Target_Newsletter !== 'both' || addDateNewsletter) && (
               <>
-                <input
-                  type="date"
-                  value={addDateValue}
-                  min={getMinDate()}
-                  max={getMaxDate()}
-                  onChange={(e) => { setAddDateValue(e.target.value); setAddDateError(''); }}
-                  className="w-full rounded-md border border-gray-300 px-2 py-1 text-xs focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
-                />
+                <div>
+                  <label
+                    htmlFor="add-date-value"
+                    className="block text-[10px] text-gray-500 mb-0.5"
+                  >
+                    {addRecurrenceType === 'once' ? 'Run date' : 'First run date'}
+                  </label>
+                  <input
+                    id="add-date-value"
+                    type="date"
+                    value={addDateValue}
+                    min={getMinDate()}
+                    max={getMaxDate()}
+                    aria-describedby={!addDateValue ? 'add-date-required-help' : undefined}
+                    onChange={(e) => { setAddDateValue(e.target.value); setAddDateError(''); }}
+                    className="w-full rounded-md border border-gray-300 px-2 py-1 text-xs focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
+                  />
+                  {!addDateValue && (
+                    <div id="add-date-required-help" className="mt-1 text-[10px] text-amber-700">
+                      {addRecurrenceType === 'once'
+                        ? 'Select a run date to enable Save.'
+                        : 'Select a first run date to enable Save.'}
+                    </div>
+                  )}
+                </div>
                 {addDateValue && validDatesSet.size > 0 && validDatesSet.has(addDateValue) && (
                   <div className="text-[10px] text-green-600">Valid publication date</div>
                 )}

--- a/frontend/src/utils/bodyLinks.test.ts
+++ b/frontend/src/utils/bodyLinks.test.ts
@@ -51,4 +51,30 @@ describe('body link editing', () => {
     expect(editable.links).toHaveLength(1);
     expect(editable.links[0].Anchor_Text).toBe('event details');
   });
+
+  it('deduplicates equivalent destinations when one URL contains encoded spaces', () => {
+    const editable = prepareBodyForEditing(
+      'Additional details are available on the '
+        + '<a href="https://example.com/Inside%20UI/details">committee page</a>.',
+      [
+        {
+          Url: 'https://example.com/Inside UI/details',
+          Anchor_Text: 'University Curriculum Committee Inside U of I page',
+          Display_Order: 0,
+        },
+      ],
+    );
+
+    expect(editable.links).toEqual([
+      {
+        Url: 'https://example.com/Inside%20UI/details',
+        Anchor_Text: 'committee page',
+        Display_Order: 0,
+      },
+    ]);
+    expect(buildLinkedBody(editable.body, editable.links)).toBe(
+      'Additional details are available on the '
+        + '<a href="https://example.com/Inside%20UI/details">committee page</a>.',
+    );
+  });
 });

--- a/frontend/src/utils/bodyLinks.ts
+++ b/frontend/src/utils/bodyLinks.ts
@@ -13,6 +13,15 @@ export function normalizeEditableLinkUrl(value: string): string {
   return trimmed;
 }
 
+function canonicalLinkDestination(value: string): string {
+  const normalized = normalizeEditableLinkUrl(value);
+  try {
+    return new URL(normalized).href;
+  } catch {
+    return normalized;
+  }
+}
+
 export function isSafeLinkDestination(value: string): boolean {
   const normalized = normalizeEditableLinkUrl(value);
   try {
@@ -44,7 +53,10 @@ export function prepareBodyForEditing(
   ) => {
     if (isSafeLinkDestination(href)) {
       const normalizedUrl = normalizeEditableLinkUrl(href);
-      if (!bodyLinks.some((candidate) => candidate.Url === normalizedUrl)) {
+      const canonicalUrl = canonicalLinkDestination(normalizedUrl);
+      if (!bodyLinks.some(
+        (candidate) => canonicalLinkDestination(candidate.Url) === canonicalUrl,
+      )) {
         bodyLinks.push({
           Url: normalizedUrl,
           Anchor_Text: anchorText,
@@ -85,9 +97,12 @@ export function prepareBodyForEditing(
     (left, right) => (left.Display_Order ?? 0) - (right.Display_Order ?? 0),
   )) {
     const normalizedUrl = normalizeEditableLinkUrl(link.Url);
+    const canonicalUrl = canonicalLinkDestination(normalizedUrl);
     const anchorText = link.Anchor_Text?.trim() || '';
     if (!isSafeLinkDestination(normalizedUrl)) continue;
-    if (links.some((candidate) => candidate.Url === normalizedUrl)) continue;
+    if (links.some(
+      (candidate) => canonicalLinkDestination(candidate.Url) === canonicalUrl,
+    )) continue;
     links.push({
       Url: normalizedUrl,
       Anchor_Text: anchorText,
@@ -112,13 +127,20 @@ function safeAttributeValue(value: string): string {
 }
 
 export function buildLinkedBody(body: string, links: EditableBodyLink[]): string {
+  const seenDestinations = new Set<string>();
   const validLinks = links
     .map((link, index) => ({
       ...link,
       Url: normalizeEditableLinkUrl(link.Url),
       Display_Order: index,
     }))
-    .filter((link) => link.Url && isSafeLinkDestination(link.Url));
+    .filter((link) => {
+      if (!link.Url || !isSafeLinkDestination(link.Url)) return false;
+      const canonicalUrl = canonicalLinkDestination(link.Url);
+      if (seenDestinations.has(canonicalUrl)) return false;
+      seenDestinations.add(canonicalUrl);
+      return true;
+    });
 
   const occupiedRanges: Array<{ start: number; end: number }> = [];
   const replacements: Array<{ start: number; end: number; markup: string }> = [];
@@ -164,11 +186,18 @@ export function buildLinkedBody(body: string, links: EditableBodyLink[]): string
 }
 
 export function normalizedBodyLinks(links: EditableBodyLink[]): EditableBodyLink[] {
+  const seenDestinations = new Set<string>();
   return links
     .map((link, index) => ({
       Url: normalizeEditableLinkUrl(link.Url),
       Anchor_Text: link.Anchor_Text.trim(),
       Display_Order: index,
     }))
-    .filter((link) => link.Url && isSafeLinkDestination(link.Url));
+    .filter((link) => {
+      if (!link.Url || !isSafeLinkDestination(link.Url)) return false;
+      const canonicalUrl = canonicalLinkDestination(link.Url);
+      if (seenDestinations.has(canonicalUrl)) return false;
+      seenDestinations.add(canonicalUrl);
+      return true;
+    });
 }


### PR DESCRIPTION
## Summary

- canonicalize equivalent link destinations so literal spaces and percent-encoded spaces cannot produce duplicate URLs or CTA content
- enforce the weekday requirement for every date within the next 30 days, including deadlines and other non-event dates
- clarify that recurring schedules require a first run date while preserving blank end dates for indefinite recurrence

## Root causes and impact

The final-edit link workflow compared normalized URL strings without canonicalizing their destinations. The same link could therefore survive twice when one representation used a literal space and the other used `%20`.

The managed weekday rule described events only, and deterministic validation checked incorrect weekday/date pairs but not missing weekdays. This change broadens the managed rule, adds an idempotent migration, and deterministically checks the complete edited text for near-term dates in every context.

Recurring schedules already supported a blank end date. The reported Save failure occurred because Add Run Date opened with its required start date blank while the disabled Save button offered no explanation. The form now labels this as the first run date and explains the requirement.

## Validation

- frontend: 71 tests passed
- backend: 241 tests passed
- frontend ESLint passed
- frontend production build passed
- backend Ruff passed
- staged diff whitespace check passed

Fixes #309
Fixes #310
Fixes #311
