### PR TITLE
Preserve source context across AI edits

### DIFF
--- a/backend/alembic/versions/f3d5b7c9e1a2_preserve_source_context.py
+++ b/backend/alembic/versions/f3d5b7c9e1a2_preserve_source_context.py
@@ -1,0 +1,166 @@
+"""preserve organizational and participant source context
+
+Revision ID: f3d5b7c9e1a2
+Revises: e2c4a6b8d0f1
+Create Date: 2026-08-18 11:30:00.000000
+
+Joy's source-fidelity feedback clarified six forms of meaning that must take
+precedence over concision. This focused upsert adds organizational and
+information-option rules and strengthens the existing requirement, participant
+context and contact-title rules without replacing unrelated staff-managed data.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f3d5b7c9e1a2"
+down_revision: str | Sequence[str] | None = "e2c4a6b8d0f1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+PRESERVE_REQUIREMENTS_RULE_TEXT = (
+    "Preserve every deadline, actionable date and mandatory requirement from the "
+    "original submission: registration, application, abstract, proposal, nomination "
+    "and submission deadlines; event dates and times; application periods; eligibility, "
+    "age and enrollment conditions; regulatory requirements; and required licenses or "
+    "certifications. Keep mandatory language mandatory and never shorten a requirement "
+    "until it appears optional or less important. Keep multiple deadlines when they "
+    "serve different purposes. Never replace a specific deadline with a generic call to "
+    "action such as 'Learn more and register'. When editing for conciseness, shorten the "
+    "surrounding prose instead of removing deadlines or requirements. Example: "
+    "'Registration closes Oct. 23. Abstract submissions are due Oct. 16. Applicants "
+    "must be TIPS certified. Learn more and register.' is correct; dropping any deadline "
+    "or requirement is not."
+)
+PRESERVE_ORGANIZATIONAL_CONTEXT_RULE_TEXT = (
+    "Preserve the specific organization that grants, administers or oversees an award, "
+    "ranking, rating, certification, accreditation, recognition or designation. Also "
+    "preserve the university program, office, department or initiative that offers, "
+    "sponsors or administers an opportunity, service, event, grant, program or activity. "
+    "When that entity is central to understanding the opportunity, name it early in the "
+    "body; retaining it only in the headline is not sufficient. Shorten surrounding "
+    "wording, not the identity or role of the awarding or sponsoring entity. Example: "
+    "keep 'Association for Advancement in Sustainability in Higher Education STARS "
+    "Gold-rated university,' not only 'STARS Gold-rated university,' and keep 'raise "
+    "funds through Idaho Eats,' not only 'raise funds.'"
+)
+PRESERVE_INFORMATION_OPTIONS_RULE_TEXT = (
+    "Preserve every distinct action and information-seeking option offered by the source. "
+    "If readers may sign up or learn more, retain both options; do not narrow a general "
+    "invitation to contact or reach out into registration-only language unless "
+    "registration is the source's sole purpose. A request for more information is not a "
+    "duplicate call to action and takes precedence over the single-CTA rule. Shorten "
+    "surrounding wording instead of deleting the information path."
+)
+PRESERVE_PARTICIPANT_CONTEXT_RULE_TEXT = (
+    "When condensing, distinguish unnecessary repetition from meaningful context. "
+    "Preserve participant responsibilities and operational details explaining what "
+    "volunteers, attendees or other participants will actually do. Also preserve "
+    "traditions and ceremonies, participant activities, routes, locations and event "
+    "logistics, notable event features, and details that help readers visualize or "
+    "understand the event or opportunity. Achieve conciseness by tightening wording, not "
+    "by deleting these details. Example: 'Sororities will open bids at 11:15 a.m. and "
+    "run home to their chapters down Idaho Avenue.' is correct; shortening it to "
+    "'Sororities will open bids at 11:15 a.m.' removes meaningful participant activity "
+    "and is not."
+)
+PRESERVE_CONTACT_TITLES_RULE_TEXT = (
+    "Preserve the purpose, value and context that explain why an event, service or "
+    "opportunity is offered. Preserve contact information and every official contact "
+    "title supplied by the source; never remove a title solely for brevity. Capitalize a "
+    "title immediately before a person's name. Prefer placing it after the name in "
+    "AP-style lowercase, such as 'Danny Conklin, concessions manager,' and keep each "
+    "title associated with the correct person. Shorten wording, not meaning or "
+    "credentials."
+)
+
+
+RULES = (
+    (
+        "content_filtering",
+        "preserve_action_deadlines",
+        PRESERVE_REQUIREMENTS_RULE_TEXT,
+        "error",
+    ),
+    (
+        "content_filtering",
+        "preserve_organizational_context",
+        PRESERVE_ORGANIZATIONAL_CONTEXT_RULE_TEXT,
+        "error",
+    ),
+    (
+        "content_filtering",
+        "preserve_information_options",
+        PRESERVE_INFORMATION_OPTIONS_RULE_TEXT,
+        "error",
+    ),
+    (
+        "content_filtering",
+        "preserve_event_context",
+        PRESERVE_PARTICIPANT_CONTEXT_RULE_TEXT,
+        "error",
+    ),
+    (
+        "content_filtering",
+        "preserve_purpose_contact_titles",
+        PRESERVE_CONTACT_TITLES_RULE_TEXT,
+        "error",
+    ),
+)
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _upsert_rules(connection: sa.Connection) -> None:
+    for category, rule_key, rule_text, severity in RULES:
+        existing_id = connection.execute(
+            sa.select(style_rules.c.Id).where(
+                style_rules.c.Rule_Set == "shared",
+                style_rules.c.Rule_Key == rule_key,
+            )
+        ).scalar_one_or_none()
+        values = {
+            "Category": category,
+            "Rule_Text": rule_text,
+            "Is_Active": True,
+            "Severity": severity,
+        }
+        if existing_id:
+            connection.execute(
+                style_rules.update()
+                .where(style_rules.c.Id == existing_id)
+                .values(**values)
+            )
+        else:
+            connection.execute(
+                style_rules.insert().values(
+                    Id=str(uuid.uuid4()),
+                    Rule_Set="shared",
+                    Rule_Key=rule_key,
+                    **values,
+                )
+            )
+
+
+def upgrade() -> None:
+    _upsert_rules(op.get_bind())
+
+
+def downgrade() -> None:
+    # Text-only revisions of managed rules are not automatically reverted.
+    pass

--- a/backend/app/services/ai/editor.py
+++ b/backend/app/services/ai/editor.py
@@ -36,7 +36,11 @@ from app.utils.style_checks import (
     detect_new_contact_channels,
     detect_new_contact_names,
     detect_changed_official_names,
+    detect_missing_anchored_requirements,
+    detect_missing_contact_titles,
+    detect_missing_information_options,
     detect_missing_near_term_weekdays,
+    detect_missing_protected_organizations,
     detect_weekday_date_mismatches,
 )
 
@@ -169,6 +173,7 @@ class AIEditor:
         style_rules: list[dict],
         *,
         source_text: str = "",
+        source_body: str = "",
         source_comparison_output: str = "",
         reference_date: date | None = None,
     ) -> list[dict]:
@@ -248,6 +253,7 @@ class AIEditor:
 
         if source_text:
             comparison_output = source_comparison_output or f"{headline}\n{body}"
+            body_source = source_body or source_text
             missing_contacts = detect_missing_source_contacts(
                 source_text,
                 comparison_output,
@@ -289,6 +295,35 @@ class AIEditor:
                 add(
                     "preserve_event_title_case",
                     f"Official or branded source name(s) changed or removed: {listed}",
+                )
+
+            for organization in detect_missing_protected_organizations(
+                body_source,
+                body,
+            ):
+                add(
+                    "preserve_organizational_context",
+                    f"Source organization missing from AI-edited body: '{organization}'",
+                )
+
+            missing_titles = detect_missing_contact_titles(body_source, body)
+            if missing_titles:
+                listed = ", ".join(f"'{title}'" for title in missing_titles[:5])
+                add(
+                    "preserve_purpose_contact_titles",
+                    f"Source contact title(s) missing from AI edit: {listed}",
+                )
+
+            for option in detect_missing_information_options(body_source, body):
+                add(
+                    "preserve_information_options",
+                    f"Source information-seeking option missing from AI edit: '{option}'",
+                )
+
+            for requirement in detect_missing_anchored_requirements(body_source, body):
+                add(
+                    "preserve_action_deadlines",
+                    f"Source requirement missing from AI edit: '{requirement}'",
                 )
 
         return flags
@@ -395,6 +430,7 @@ class AIEditor:
             submission.Category,
             style_rules,
             source_text="\n".join(source_parts),
+            source_body=submission.Original_Body,
             source_comparison_output="\n".join(comparison_output_parts),
             reference_date=date.today(),
         )

--- a/backend/app/utils/style_checks.py
+++ b/backend/app/utils/style_checks.py
@@ -6,8 +6,10 @@ feedback (issues #299 and #300) showed the model violating rules that were
 active in the prompt at the time. The detectors here cover the subset of those
 rules that can be verified mechanically — AP month abbreviation, a.m./p.m.
 formatting, platform names, undefined acronyms, repeated calls to action and
-the Jobs single-line contract — so a violation surfaces as a flag on the AI
-version regardless of whether the model honored the prompt.
+the Jobs single-line contract, plus high-confidence source contacts,
+organizations, titles, information paths and anchored requirements — so a
+violation surfaces as a flag on the AI version regardless of whether the model
+honored the prompt.
 
 Each detector is a pure function over edited text and returns the offending
 fragments. Mapping findings to flags (and gating on whether the corresponding
@@ -51,6 +53,41 @@ _CONTACT_NAME = re.compile(
     r"\b(?i:contact|email|call|reach)\s+(?:the\s+)?"
     r"([A-Z][A-Za-z'’.-]+(?:\s+[A-Z][A-Za-z'’.-]+){1,3})\b",
 )
+_PROTECTED_ORGANIZATION_NAME = (
+    r"[A-Z][A-Za-z0-9&'’.-]*"
+    r"(?:\s+(?:(?:and|of|for|the|in)\s+)?[A-Z][A-Za-z0-9&'’.-]*){1,12}"
+)
+_SPONSORING_ORGANIZATION = re.compile(
+    rf"\b(?P<name>{_PROTECTED_ORGANIZATION_NAME})(?:['’]s)?\s+"
+    r"(?:offers?|provides?|administers?|sponsors?|presents?|hosts?|manages?|oversees?)\b"
+)
+_DESIGNATION_ORGANIZATION = re.compile(
+    rf"\b(?:an?|the)\s+(?P<name>{_PROTECTED_ORGANIZATION_NAME})\s+"
+    r"(?=(?:STARS\b|[^.!?]{0,30}\b(?:award|ranking|rating|certification|"
+    r"accreditation|recognition|designation)\b))"
+)
+_RECOGNITION_FROM_ORGANIZATION = re.compile(
+    r"\b(?:award|ranking|rating|certification|accreditation|recognition|designation)\b"
+    rf"[^.!?]{{0,80}}\b(?:from|by|through)\s+(?P<name>{_PROTECTED_ORGANIZATION_NAME})"
+)
+_PARENTHETICAL_CONTACT_TITLE = re.compile(
+    r"\b(?P<name>[A-Z][A-Za-z'’.-]+"
+    r"(?:\s+[A-Z][A-Za-z'’.-]+){1,3})\s*"
+    r"\((?P<title>[A-Za-z][A-Za-z'’&/.-]*"
+    r"(?:\s+[A-Za-z'’&/.-]+){0,8})\)"
+)
+_INFORMATION_OPTION = re.compile(
+    r"\b(?:learn\s+more|more\s+information|additional\s+information|"
+    r"(?:get|request|find)\s+(?:more|additional)\s+information|"
+    r"(?:get|view|see|find)\s+(?:the\s+)?details?|questions?)\b",
+    re.IGNORECASE,
+)
+_REQUIREMENT_MARKER = re.compile(
+    r"\b(?:must|required(?:\s+to)?|requires?|eligible|eligibility|certified|"
+    r"certification|licensed|may\s+only|cannot|prohibited)\b",
+    re.IGNORECASE,
+)
+_REQUIREMENT_ANCHOR = re.compile(r"\b[A-Z]{2,}\b|\b\d+(?:\.\d+)?\+?")
 _ORGANIZATION_SUFFIXES = {
     "Center", "Centre", "Clinic", "College", "Department", "Division", "Ensemble",
     "Entertainment", "Foundation", "Institute", "Office", "Program",
@@ -203,8 +240,134 @@ def detect_new_contact_names(source_text: str, edited_text: str) -> list[str]:
     return findings
 
 
+def _normalized_visible_text(text: str) -> str:
+    """Collapse visible text for case-insensitive source-fidelity comparisons."""
+    return re.sub(r"\s+", " ", strip_html(text)).strip().casefold()
+
+
+def detect_missing_protected_organizations(
+    source_text: str,
+    edited_body: str,
+) -> list[str]:
+    """Find source sponsors or awarding bodies omitted from the edited body.
+
+    Each candidate must be tied to an organizational role verb or to
+    award/designation context. This keeps the detector narrower than a generic
+    proper-name comparison while covering the sponsor and accreditor losses
+    reported in issue #312.
+    """
+    source = strip_html(source_text)
+    edited = _normalized_visible_text(edited_body)
+    candidates: list[str] = []
+
+    for pattern in (
+        _SPONSORING_ORGANIZATION,
+        _DESIGNATION_ORGANIZATION,
+        _RECOGNITION_FROM_ORGANIZATION,
+    ):
+        for match in pattern.finditer(source):
+            candidate = re.sub(r"\s+", " ", match.group("name")).strip(" ,.;:")
+            if candidate.casefold().startswith("university of idaho"):
+                # The managed campus-name rule intentionally permits "U of I."
+                continue
+            if candidate not in candidates:
+                candidates.append(candidate)
+
+    return [candidate for candidate in candidates if candidate.casefold() not in edited]
+
+
+def detect_missing_contact_titles(source_text: str, edited_text: str) -> list[str]:
+    """Find parenthetical source contact titles missing after the contact name."""
+    source = strip_html(source_text)
+    edited = re.sub(r"\s+", " ", strip_html(edited_text)).strip()
+    findings: list[str] = []
+
+    for match in _PARENTHETICAL_CONTACT_TITLE.finditer(source):
+        nearby_before = source[max(0, match.start() - 80):match.start()]
+        nearby_after = source[match.end():match.end() + 160]
+        name_with_cue = match.group("name")
+        is_contact_context = bool(
+            re.search(r"\b(?:contact|email|call|reach)\b", nearby_before, re.IGNORECASE)
+            or re.match(r"(?:Contact|Email|Call|Reach)\b", name_with_cue)
+            or _EMAIL.search(nearby_after)
+            or _PHONE.search(nearby_after)
+        )
+        if not is_contact_context:
+            continue
+        name = re.sub(
+            r"^(?:Contact|Email|Call|Reach)\s+",
+            "",
+            name_with_cue,
+        ).strip()
+        title = match.group("title").strip()
+        if title.isupper() and len(title) <= 10:
+            # Parenthetical acronyms are definitions, not contact titles.
+            continue
+        name_pattern = r"\s+".join(re.escape(word) for word in name.split())
+        title_pattern = r"\s+".join(re.escape(word) for word in title.split())
+        if re.search(
+            rf"\b{name_pattern}\b[^.!?]{{0,120}}\b{title_pattern}\b",
+            edited,
+            re.IGNORECASE,
+        ):
+            continue
+        display = f"{name}, {title.lower()}"
+        if display not in findings:
+            findings.append(display)
+
+    return findings
+
+
+def detect_missing_information_options(source_text: str, edited_text: str) -> list[str]:
+    """Find an explicit information-seeking option removed from edited copy."""
+    source_matches = [
+        re.sub(r"\s+", " ", match.group()).strip()
+        for match in _INFORMATION_OPTION.finditer(strip_html(source_text))
+    ]
+    if not source_matches or _INFORMATION_OPTION.search(strip_html(edited_text)):
+        return []
+    return list(dict.fromkeys(source_matches))
+
+
+def detect_missing_anchored_requirements(
+    source_text: str,
+    edited_text: str,
+) -> list[str]:
+    """Find mandatory source clauses whose objective anchors disappeared.
+
+    Only clauses with stable anchors such as an age, GPA or certification
+    acronym are checked. Requirements without those anchors remain prompt-only
+    protections instead of relying on a noisy semantic guess.
+    """
+    edited = strip_html(edited_text)
+    edited_anchors = {
+        anchor.rstrip("+").casefold()
+        for anchor in _REQUIREMENT_ANCHOR.findall(edited)
+    }
+    edited_has_requirement = bool(_REQUIREMENT_MARKER.search(edited))
+    findings: list[str] = []
+
+    for sentence in re.split(r"(?<=[.!?])\s+|\n+", strip_html(source_text)):
+        sentence = sentence.strip()
+        if not sentence or not _REQUIREMENT_MARKER.search(sentence):
+            continue
+        anchors = {
+            anchor.rstrip("+").casefold()
+            for anchor in _REQUIREMENT_ANCHOR.findall(sentence)
+        }
+        if not anchors:
+            continue
+        if not edited_has_requirement or not anchors.issubset(edited_anchors):
+            findings.append(sentence)
+
+    return findings
+
+
 def _official_name_candidates(source_text: str) -> list[str]:
-    text = strip_html(source_text)
+    # Source components are newline-delimited. Treat those boundaries as
+    # sentence breaks so a headline-ending phrase cannot merge with a
+    # body-opening phrase into a fabricated official name.
+    text = re.sub(r"[\r\n]+", " | ", strip_html(source_text))
     candidates: list[tuple[int, str]] = []
 
     for match in _OFFICIAL_NAME.finditer(text):

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -314,7 +314,19 @@
   {
     "category": "content_filtering",
     "rule_key": "preserve_action_deadlines",
-    "rule_text": "Preserve every deadline and actionable date from the original submission: registration, application, abstract, proposal, nomination and submission deadlines, event dates and times, application periods, registration requirements and eligibility information. Keep multiple deadlines when they serve different purposes. Never replace a specific deadline with a generic call to action such as 'Learn more and register'. When editing for conciseness, shorten the surrounding prose instead of removing deadlines. Example: 'Registration closes Oct. 23. Abstract submissions are due Oct. 16. Learn more and register.' is correct; dropping either date is not.",
+    "rule_text": "Preserve every deadline, actionable date and mandatory requirement from the original submission: registration, application, abstract, proposal, nomination and submission deadlines; event dates and times; application periods; eligibility, age and enrollment conditions; regulatory requirements; and required licenses or certifications. Keep mandatory language mandatory and never shorten a requirement until it appears optional or less important. Keep multiple deadlines when they serve different purposes. Never replace a specific deadline with a generic call to action such as 'Learn more and register'. When editing for conciseness, shorten the surrounding prose instead of removing deadlines or requirements. Example: 'Registration closes Oct. 23. Abstract submissions are due Oct. 16. Applicants must be TIPS certified. Learn more and register.' is correct; dropping any deadline or requirement is not.",
+    "severity": "error"
+  },
+  {
+    "category": "content_filtering",
+    "rule_key": "preserve_organizational_context",
+    "rule_text": "Preserve the specific organization that grants, administers or oversees an award, ranking, rating, certification, accreditation, recognition or designation. Also preserve the university program, office, department or initiative that offers, sponsors or administers an opportunity, service, event, grant, program or activity. When that entity is central to understanding the opportunity, name it early in the body; retaining it only in the headline is not sufficient. Shorten surrounding wording, not the identity or role of the awarding or sponsoring entity. Example: keep 'Association for Advancement in Sustainability in Higher Education STARS Gold-rated university,' not only 'STARS Gold-rated university,' and keep 'raise funds through Idaho Eats,' not only 'raise funds.'",
+    "severity": "error"
+  },
+  {
+    "category": "content_filtering",
+    "rule_key": "preserve_information_options",
+    "rule_text": "Preserve every distinct action and information-seeking option offered by the source. If readers may sign up or learn more, retain both options; do not narrow a general invitation to contact or reach out into registration-only language unless registration is the source's sole purpose. A request for more information is not a duplicate call to action and takes precedence over the single-CTA rule. Shorten surrounding wording instead of deleting the information path.",
     "severity": "error"
   },
   {
@@ -326,8 +338,8 @@
   {
     "category": "content_filtering",
     "rule_key": "preserve_event_context",
-    "rule_text": "When condensing, distinguish unnecessary repetition from meaningful context. Preserve traditions and ceremonies, participant activities, routes, locations and event logistics, notable event features, and details that help readers visualize or understand the event. Achieve conciseness by tightening wording, not by deleting these details. Example: 'Sororities will open bids at 11:15 a.m. and run home to their chapters down Idaho Avenue.' is correct; shortening it to 'Sororities will open bids at 11:15 a.m.' removes a meaningful part of the event and is not.",
-    "severity": "warning"
+    "rule_text": "When condensing, distinguish unnecessary repetition from meaningful context. Preserve participant responsibilities and operational details explaining what volunteers, attendees or other participants will actually do. Also preserve traditions and ceremonies, participant activities, routes, locations and event logistics, notable event features, and details that help readers visualize or understand the event or opportunity. Achieve conciseness by tightening wording, not by deleting these details. Example: 'Sororities will open bids at 11:15 a.m. and run home to their chapters down Idaho Avenue.' is correct; shortening it to 'Sororities will open bids at 11:15 a.m.' removes meaningful participant activity and is not.",
+    "severity": "error"
   },
   {
     "category": "voice",
@@ -362,7 +374,7 @@
   {
     "category": "content_filtering",
     "rule_key": "preserve_purpose_contact_titles",
-    "rule_text": "Preserve the purpose, value and context that explain why an event, service or opportunity is offered. Preserve contact information and official contact titles. Capitalize a title immediately before a person's name; lowercase a title after a name or when it stands alone. Shorten wording, not meaning.",
+    "rule_text": "Preserve the purpose, value and context that explain why an event, service or opportunity is offered. Preserve contact information and every official contact title supplied by the source; never remove a title solely for brevity. Capitalize a title immediately before a person's name. Prefer placing it after the name in AP-style lowercase, such as 'Danny Conklin, concessions manager,' and keep each title associated with the correct person. Shorten wording, not meaning or credentials.",
     "severity": "error"
   }
 ]

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -1286,6 +1286,152 @@ class TestDeterministicPostValidation:
             }
         ]
 
+    async def test_missing_accreditor_from_reported_edit_is_flagged(self):
+        flags = AIEditor(SuccessfulProvider()).post_analyze(
+            "Explore campus sustainability resources",
+            (
+                "Visit the Office of Sustainability's Inside U of I homepage to "
+                "explore sustainable solutions at the U of I. Discover the "
+                "initiatives that make the institution a STARS Gold-rated university."
+            ),
+            "faculty_staff",
+            [
+                {
+                    "category": "content_filtering",
+                    "rule_key": "preserve_organizational_context",
+                    "rule_text": "Managed organizational-context rule.",
+                    "severity": "error",
+                }
+            ],
+            source_text=(
+                "Learn More About Sustainability on Campus\n"
+                "Visit the Office of Sustainability's Inside U of I homepage and "
+                "explore sustainable solutions at the University of Idaho. Discover "
+                "the initiatives that make our institution an Association for "
+                "Advancement in Sustainability in Higher Education STARS Gold rated "
+                "university in sustainability excellence."
+            ),
+            source_body=(
+                "Visit the Office of Sustainability's Inside U of I homepage and "
+                "explore sustainable solutions at the University of Idaho. Discover "
+                "the initiatives that make our institution an Association for "
+                "Advancement in Sustainability in Higher Education STARS Gold rated "
+                "university in sustainability excellence."
+            ),
+        )
+
+        assert flags == [
+            {
+                "type": "error",
+                "rule_key": "preserve_organizational_context",
+                "message": (
+                    "Source organization missing from AI-edited body: "
+                    "'Association for Advancement in Sustainability in Higher Education'"
+                ),
+            }
+        ]
+
+    async def test_reported_edit_flags_sponsor_and_contact_titles_only(self):
+        flags = AIEditor(SuccessfulProvider()).post_analyze(
+            "Earn money for nonprofit with Idaho Eats",
+            (
+                "Nonprofit organizations can earn money for their cause by volunteering "
+                "at concessions during sporting events and concerts on campus. Volunteers "
+                "receive a donation equal to a percentage of net sales, which varies by "
+                "event type and attendance. Opportunities are available throughout the "
+                "school year and offer flexibility. Orientation and training are provided. "
+                "In Idaho, cashiers serving alcohol must be 21 or older and TIPS certified. "
+                "To sign up, contact <a href=\"mailto:dconklin@uidaho.edu\">Danny "
+                "Conklin</a> or <a href=\"mailto:pwenzel@uidaho.edu\">Perry Wenzel</a> "
+                "with the number of group members over 21 and a representative's contact "
+                "information."
+            ),
+            "faculty_staff",
+            [
+                {
+                    "category": "content_filtering",
+                    "rule_key": "preserve_organizational_context",
+                    "rule_text": "Managed organizational-context rule.",
+                    "severity": "error",
+                },
+                {
+                    "category": "formatting",
+                    "rule_key": "preserve_purpose_contact_titles",
+                    "rule_text": "Managed contact-title rule.",
+                    "severity": "error",
+                },
+                {
+                    "category": "content_filtering",
+                    "rule_key": "preserve_action_deadlines",
+                    "rule_text": "Managed requirement rule.",
+                    "severity": "error",
+                },
+            ],
+            source_text=(
+                "Non-Profit Organization Opportunity with Idaho Eats\n"
+                "Idaho Eats offers an opportunity for non-profit organizations to earn "
+                "money for their cause through volunteer events on campus. Volunteers "
+                "assist in concessions operations during sporting events and concerts for "
+                "a donation equal to a percentage of net sales. Orientation and training "
+                "will be provided. In Idaho, all cashiers serving alcohol must be 21+ and "
+                "TIPS certified. Contact Danny Conklin (Concessions Manager) at "
+                "dconklin@uidaho.edu or Perry Wenzel (Director of Retail Dining) at "
+                "pwenzel@uidaho.edu."
+            ),
+            source_body=(
+                "Idaho Eats offers an opportunity for non-profit organizations to earn "
+                "money for their cause through volunteer events on campus. Volunteers "
+                "assist in concessions operations during sporting events and concerts for "
+                "a donation equal to a percentage of net sales. Orientation and training "
+                "will be provided. In Idaho, all cashiers serving alcohol must be 21+ and "
+                "TIPS certified. Contact Danny Conklin (Concessions Manager) at "
+                "dconklin@uidaho.edu or Perry Wenzel (Director of Retail Dining) at "
+                "pwenzel@uidaho.edu."
+            ),
+        )
+
+        assert {flag["rule_key"] for flag in flags} == {
+            "preserve_organizational_context",
+            "preserve_purpose_contact_titles",
+        }
+        assert [
+            flag["message"]
+            for flag in flags
+            if flag["rule_key"] == "preserve_organizational_context"
+        ] == ["Source organization missing from AI-edited body: 'Idaho Eats'"]
+        assert any("Danny Conklin, concessions manager" in flag["message"] for flag in flags)
+        assert any("Perry Wenzel, director of retail dining" in flag["message"] for flag in flags)
+
+    async def test_removed_information_option_and_requirement_are_flagged(self):
+        flags = AIEditor(SuccessfulProvider()).post_analyze(
+            "Apply for the program",
+            "Sign up by emailing the program office.",
+            "faculty_staff",
+            [
+                {
+                    "category": "content_filtering",
+                    "rule_key": "preserve_information_options",
+                    "rule_text": "Managed information-option rule.",
+                    "severity": "error",
+                },
+                {
+                    "category": "content_filtering",
+                    "rule_key": "preserve_action_deadlines",
+                    "rule_text": "Managed requirement rule.",
+                    "severity": "error",
+                },
+            ],
+            source_text=(
+                "Sign up or learn more by emailing the program office. "
+                "Applicants must have a 3.0 GPA."
+            ),
+        )
+
+        assert {flag["rule_key"] for flag in flags} == {
+            "preserve_information_options",
+            "preserve_action_deadlines",
+        }
+
     async def test_compliant_output_produces_no_post_validation_flags(
         self,
         client: AsyncClient,

--- a/backend/tests/test_august_10_joy_style_rules.py
+++ b/backend/tests/test_august_10_joy_style_rules.py
@@ -87,9 +87,13 @@ def test_migration_is_idempotent_and_matches_shared_seed():
 
     seeded = seeded_rules()
     assert len(rows) == len(migration.STYLE_RULE_UPDATES)
-    # The rule-conflict resolution migration supersedes these two texts;
-    # test_editorial_rule_conflicts_migration verifies their latest seed values.
-    superseded = {"no_fabricated_content", "composition_title_format"}
+    # Later focused migrations supersede these original texts; their own
+    # migration tests verify the latest seed values.
+    superseded = {
+        "no_fabricated_content",
+        "composition_title_format",
+        "preserve_purpose_contact_titles",
+    }
     for row in rows:
         seed = seeded[row["Rule_Key"]]
         if row["Rule_Key"] in superseded:

--- a/backend/tests/test_preserve_deadlines_rule_migration.py
+++ b/backend/tests/test_preserve_deadlines_rule_migration.py
@@ -99,6 +99,9 @@ def test_migration_values_match_style_rule_seeds():
         for rule in json.loads((seed_dir / "shared_rules.json").read_text())
     }
 
-    assert seeded_shared["preserve_action_deadlines"]["rule_text"] == migration.PRESERVE_DEADLINES_RULE_TEXT
+    # The source-context migration extends this original deadline wording to
+    # mandatory eligibility, regulatory and certification requirements.
+    assert seeded_shared["preserve_action_deadlines"]["rule_text"] != migration.PRESERVE_DEADLINES_RULE_TEXT
+    assert "mandatory requirement" in seeded_shared["preserve_action_deadlines"]["rule_text"]
     assert seeded_shared["preserve_action_deadlines"]["severity"] == "error"
     assert seeded_shared["preserve_action_deadlines"]["category"] == "content_filtering"

--- a/backend/tests/test_source_context_rule_migration.py
+++ b/backend/tests/test_source_context_rule_migration.py
@@ -1,4 +1,4 @@
-"""Regression coverage for the add preserve event context rule migration."""
+"""Regression coverage for Joy's source-context fidelity rule migration."""
 
 import importlib.util
 import json
@@ -12,12 +12,12 @@ MIGRATION_PATH = (
     Path(__file__).parents[1]
     / "alembic"
     / "versions"
-    / "c7d9a1b3e5f8_add_preserve_event_context_rule.py"
+    / "f3d5b7c9e1a2_preserve_source_context.py"
 )
 
 
 def load_migration() -> ModuleType:
-    spec = importlib.util.spec_from_file_location("preserve_event_context_rule", MIGRATION_PATH)
+    spec = importlib.util.spec_from_file_location("preserve_source_context", MIGRATION_PATH)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -52,11 +52,11 @@ def test_rule_upserts_are_idempotent_and_preserve_unrelated_rules():
                 {
                     "Id": "stale",
                     "Rule_Set": "shared",
-                    "Category": "voice",
+                    "Category": "content_filtering",
                     "Rule_Key": "preserve_event_context",
-                    "Rule_Text": "Old wording.",
+                    "Rule_Text": "Events only.",
                     "Is_Active": False,
-                    "Severity": "info",
+                    "Severity": "warning",
                 },
                 {
                     "Id": "custom",
@@ -70,38 +70,28 @@ def test_rule_upserts_are_idempotent_and_preserve_unrelated_rules():
             ],
         )
 
-        for _ in range(2):
-            migration._upsert_rule(
-                connection,
-                rule_set="shared",
-                rule_key="preserve_event_context",
-                category="content_filtering",
-                rule_text=migration.PRESERVE_EVENT_CONTEXT_RULE_TEXT,
-                severity="warning",
-            )
-
+        migration._upsert_rules(connection)
+        migration._upsert_rules(connection)
         rows = connection.execute(sa.select(rules)).mappings().all()
 
     by_key = {row["Rule_Key"]: row for row in rows}
-    assert by_key["preserve_event_context"]["Rule_Text"] == migration.PRESERVE_EVENT_CONTEXT_RULE_TEXT
-    assert by_key["preserve_event_context"]["Category"] == "content_filtering"
-    assert by_key["preserve_event_context"]["Severity"] == "warning"
-    assert by_key["preserve_event_context"]["Is_Active"] is True
+    assert len(rows) == len(migration.RULES) + 1
     assert by_key["staff_custom"]["Rule_Text"] == "Keep this staff rule."
-    assert len(rows) == 2
+    for category, rule_key, rule_text, severity in migration.RULES:
+        updated = by_key[rule_key]
+        assert updated["Category"] == category
+        assert updated["Rule_Text"] == rule_text
+        assert updated["Severity"] == severity
+        assert updated["Is_Active"] is True
 
 
-def test_migration_values_match_style_rule_seeds():
+def test_migration_matches_seeded_rules():
     migration = load_migration()
-    seed_dir = Path(__file__).parents[1] / "data" / "style_rules"
-    seeded_shared = {
-        rule["rule_key"]: rule
-        for rule in json.loads((seed_dir / "shared_rules.json").read_text())
-    }
+    seed_path = Path(__file__).parents[1] / "data" / "style_rules" / "shared_rules.json"
+    seeded = {rule["rule_key"]: rule for rule in json.loads(seed_path.read_text())}
 
-    # The source-context migration supersedes this original wording and makes
-    # participant responsibilities a mandatory preservation contract.
-    assert seeded_shared["preserve_event_context"]["rule_text"] != migration.PRESERVE_EVENT_CONTEXT_RULE_TEXT
-    assert "participant responsibilities" in seeded_shared["preserve_event_context"]["rule_text"]
-    assert seeded_shared["preserve_event_context"]["severity"] == "error"
-    assert seeded_shared["preserve_event_context"]["category"] == "content_filtering"
+    for category, rule_key, rule_text, severity in migration.RULES:
+        rule = seeded[rule_key]
+        assert rule["category"] == category
+        assert rule["rule_text"] == rule_text
+        assert rule["severity"] == severity

--- a/backend/tests/test_style_checks.py
+++ b/backend/tests/test_style_checks.py
@@ -11,6 +11,10 @@ from app.utils.style_checks import (
     detect_platform_names,
     detect_undefined_acronyms,
     detect_repeated_cta_phrases,
+    detect_missing_anchored_requirements,
+    detect_missing_contact_titles,
+    detect_missing_information_options,
+    detect_missing_protected_organizations,
     detect_missing_source_contacts,
     detect_new_contact_channels,
     detect_new_contact_names,
@@ -140,6 +144,98 @@ class TestSourceFidelity:
         text = "Audition for UIdaho Dance Ensemble and manage details in VandalStar."
 
         assert detect_changed_official_names(text, text) == []
+
+    def test_official_names_do_not_merge_across_headline_body_boundary(self):
+        source = (
+            "Learn More About Sustainability on Campus\n"
+            "Visit the Office of Sustainability's Inside U of I homepage."
+        )
+        edited = (
+            "Explore campus sustainability resources\n"
+            "Visit the Office of Sustainability's Inside U of I homepage."
+        )
+
+        assert detect_changed_official_names(source, edited) == []
+
+    def test_flags_missing_sponsor_and_accrediting_organization(self):
+        source = (
+            "Idaho Eats offers nonprofit groups a fundraising opportunity. "
+            "U of I is an Association for Advancement in Sustainability in Higher "
+            "Education STARS Gold-rated university."
+        )
+
+        assert detect_missing_protected_organizations(
+            source,
+            "Nonprofit groups can raise funds. U of I is STARS Gold-rated.",
+        ) == [
+            "Idaho Eats",
+            "Association for Advancement in Sustainability in Higher Education",
+        ]
+
+    def test_accepts_sponsor_and_accreditor_preserved_in_body(self):
+        source = (
+            "Idaho Eats offers nonprofit groups a fundraising opportunity. "
+            "The designation is administered by National Science Foundation."
+        )
+        edited = (
+            "Nonprofit groups can raise funds through Idaho Eats. The designation "
+            "is administered by the National Science Foundation."
+        )
+
+        assert detect_missing_protected_organizations(source, edited) == []
+
+    def test_flags_parenthetical_contact_titles_removed_from_linked_names(self):
+        source = (
+            "Contact Danny Conklin (Concessions Manager) at dconklin@uidaho.edu or "
+            "Perry Wenzel (Director of Retail Dining) at pwenzel@uidaho.edu."
+        )
+        edited = (
+            'Contact <a href="mailto:dconklin@uidaho.edu">Danny Conklin</a> or '
+            '<a href="mailto:pwenzel@uidaho.edu">Perry Wenzel</a>.'
+        )
+
+        assert detect_missing_contact_titles(source, edited) == [
+            "Danny Conklin, concessions manager",
+            "Perry Wenzel, director of retail dining",
+        ]
+
+    def test_accepts_contact_titles_rendered_after_names_in_ap_style(self):
+        source = "Contact Danny Conklin (Concessions Manager) at dconklin@uidaho.edu."
+        edited = (
+            'Contact <a href="mailto:dconklin@uidaho.edu">Danny Conklin</a>, '
+            "concessions manager."
+        )
+
+        assert detect_missing_contact_titles(source, edited) == []
+
+    def test_does_not_treat_parenthetical_name_or_acronym_as_contact_title(self):
+        source = "The University of Idaho (U of I) hosts the event."
+
+        assert detect_missing_contact_titles(source, "U of I hosts the event.") == []
+
+    def test_flags_removed_learn_more_option(self):
+        assert detect_missing_information_options(
+            "Sign up or learn more by emailing the office.",
+            "Sign up by emailing the office.",
+        ) == ["learn more"]
+
+    def test_accepts_reworded_information_option(self):
+        assert detect_missing_information_options(
+            "Sign up or learn more by emailing the office.",
+            "Sign up or view details by emailing the office.",
+        ) == []
+
+    def test_flags_removed_requirement_with_stable_anchors(self):
+        assert detect_missing_anchored_requirements(
+            "Applicants must have a 3.0 GPA.",
+            "Applications are now open.",
+        ) == ["Applicants must have a 3.0 GPA."]
+
+    def test_accepts_reworded_age_and_certification_requirement(self):
+        assert detect_missing_anchored_requirements(
+            "Cashiers serving alcohol must be 21+ and TIPS certified.",
+            "Cashiers serving alcohol are required to be 21 or older and TIPS certified.",
+        ) == []
 
 
 class TestWeekdayDateConsistency:


### PR DESCRIPTION
## Summary

- preserve awarding, accrediting, sponsoring and administering organizations in AI-edited bodies
- preserve official contact titles, information-seeking options and anchored eligibility or certification requirements
- strengthen the managed requirement, participant-context and contact-title rules and add explicit organizational-context and information-option rules
- add an idempotent migration and production-derived regression coverage for Joy's six reports

## Root cause and impact

The prompt contained broad preservation guidance, but it did not explicitly establish the reported organizational roles, contact-title formatting, information paths and participant responsibilities as mandatory contracts that take precedence over concision.

Deterministic source-fidelity validation also received the headline, body, notes and links as one comparison string. This allowed names at component boundaries to merge into false candidates while the narrow official-name detector missed organizations such as Idaho Eats and the Association for Advancement in Sustainability in Higher Education. There were no deterministic checks for source contact titles, information options or objective requirement anchors.

The validator now receives the original body separately for body-specific checks, flags the high-confidence loss patterns, and avoids merging headline and body phrases. The exact stored dev edits now identify the missing accreditor, body sponsor and contact titles without incorrectly flagging the requirement and volunteer details those edits preserved.

## Validation

- 256 backend tests passed
- backend Ruff checks passed
- style-rule JSON validated
- Alembic reports a single head at `f3d5b7c9e1a2`
- exact dev source/edit replay passed
- staged diff whitespace check passed

Fixes #312
