### PR TITLE
Preserve specific audience language in AI edits

### DIFF
--- a/backend/alembic/versions/a4c6e8f0b2d3_preserve_specific_audience_language.py
+++ b/backend/alembic/versions/a4c6e8f0b2d3_preserve_specific_audience_language.py
@@ -1,0 +1,142 @@
+"""preserve specific audience and action-focused language
+
+Revision ID: a4c6e8f0b2d3
+Revises: f3d5b7c9e1a2
+Create Date: 2026-08-18 12:15:00.000000
+
+Joy's feedback identified a conflict in the research template and clarified
+that promotional leads, precise audience descriptions and direct contact
+language take precedence over generic phrasing. The focused upsert preserves
+unrelated staff-managed rules.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "a4c6e8f0b2d3"
+down_revision: str | Sequence[str] | None = "f3d5b7c9e1a2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+RESEARCH_STUDY_RULE_TEXT = (
+    "Research recruitment announcements must begin with the most specific accurate "
+    "audience description supplied by the source, followed by the study topic. Never "
+    "default to generic words such as 'participants,' 'individuals' or 'people' when "
+    "the source identifies breastfeeding or lactating women, donors, volunteers, "
+    "faculty members, first-year students, alumni or another precise group. Include "
+    "important eligibility qualifiers, such as an age range, in the first sentence "
+    "whenever concise. Example: 'Researchers are seeking breastfeeding women ages "
+    "18-50 for a study on human milk composition,' not 'Researchers are recruiting "
+    "participants for a study.' Follow with compensation and participation details."
+)
+CTA_STRUCTURE_RULE_TEXT = (
+    "Structure announcements around one clear call to action and supporting context. "
+    "Replace vague instructions with an explicit action, but do not repeat that action "
+    "elsewhere in the item. Use direct information-first contact language such as 'For "
+    "more information, contact Betsy Church,' never 'Interested participants should "
+    "contact Betsy Church.' Edit user-supplied linked text when needed for clarity, "
+    "concision and editorial style; linked text is not immutable. Replace generic "
+    "unlinked references such as 'landing page,' 'webpage,' 'here' or 'click here' with "
+    "descriptive linked text that names the action or destination. Do not introduce "
+    "audience qualifiers that are not in the original submission. When the submission "
+    "provides a contact's full name, use it rather than a bare email address. Link the "
+    "action verb or object: 'Sign up', 'Register for the workshop', 'Apply for the "
+    "scholarship' or 'Review the promotion details'."
+)
+PROMOTIONAL_LEAD_RULE_TEXT = (
+    "Promotional announcements must lead with the action readers should take and the "
+    "benefit they can receive. Put important qualifying details early when they define "
+    "the offer. Avoid passive, circular or redundant introductions such as 'The last "
+    "week to have a permit reimbursed is this week.' Prefer 'This is the final week to "
+    "enroll in a qualifying meal plan for a chance to have a commuter parking permit "
+    "reimbursed in full.' Remove audience references that do not affect eligibility. "
+    "Consolidate repeated actions into one descriptive linked call to action and shorten "
+    "supporting wording rather than repeating the offer."
+)
+PRESERVE_AUDIENCE_RULE_TEXT = (
+    "Do not narrow, broaden or genericize the intended audience. Preserve broad audience "
+    "meaning such as 'all are welcome,' 'everyone is invited' or 'the public is welcome.' "
+    "Also preserve the most specific accurate source description, such as donors, "
+    "breastfeeding or lactating women, volunteers, faculty members, first-year students "
+    "or alumni, instead of replacing it with 'participants,' 'individuals' or 'people.' "
+    "For recruitment announcements, include the specific group in the first sentence "
+    "whenever possible and surface important eligibility qualifiers early enough that "
+    "the offer is not misleading. For concise event invitations, replace broad wording "
+    "with a direct invitation such as 'Attend the workshop,' never with a narrower group "
+    "unless the original explicitly limits attendance."
+)
+
+
+RULES = (
+    ("formatting", "research_study_format", RESEARCH_STUDY_RULE_TEXT, "error"),
+    ("voice", "cta_structure", CTA_STRUCTURE_RULE_TEXT, "error"),
+    (
+        "voice",
+        "promotional_action_benefit_lead",
+        PROMOTIONAL_LEAD_RULE_TEXT,
+        "error",
+    ),
+    (
+        "content_filtering",
+        "preserve_audience_scope",
+        PRESERVE_AUDIENCE_RULE_TEXT,
+        "error",
+    ),
+)
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _upsert_rules(connection: sa.Connection) -> None:
+    for category, rule_key, rule_text, severity in RULES:
+        existing_id = connection.execute(
+            sa.select(style_rules.c.Id).where(
+                style_rules.c.Rule_Set == "shared",
+                style_rules.c.Rule_Key == rule_key,
+            )
+        ).scalar_one_or_none()
+        values = {
+            "Category": category,
+            "Rule_Text": rule_text,
+            "Is_Active": True,
+            "Severity": severity,
+        }
+        if existing_id:
+            connection.execute(
+                style_rules.update()
+                .where(style_rules.c.Id == existing_id)
+                .values(**values)
+            )
+        else:
+            connection.execute(
+                style_rules.insert().values(
+                    Id=str(uuid.uuid4()),
+                    Rule_Set="shared",
+                    Rule_Key=rule_key,
+                    **values,
+                )
+            )
+
+
+def upgrade() -> None:
+    _upsert_rules(op.get_bind())
+
+
+def downgrade() -> None:
+    # Text-only revisions of managed rules are not automatically reverted.
+    pass

--- a/backend/app/services/ai/editor.py
+++ b/backend/app/services/ai/editor.py
@@ -32,6 +32,9 @@ from app.utils.style_checks import (
     detect_platform_names,
     detect_undefined_acronyms,
     detect_repeated_cta_phrases,
+    detect_redundant_promotional_leads,
+    detect_generic_destination_references,
+    detect_indirect_contact_language,
     detect_missing_source_contacts,
     detect_new_contact_channels,
     detect_new_contact_names,
@@ -41,6 +44,7 @@ from app.utils.style_checks import (
     detect_missing_information_options,
     detect_missing_near_term_weekdays,
     detect_missing_protected_organizations,
+    detect_missing_specific_audience_lead,
     detect_weekday_date_mismatches,
 )
 
@@ -243,6 +247,24 @@ class AIEditor:
                 heuristic=True,
             )
 
+        for lead in detect_redundant_promotional_leads(body):
+            add(
+                "promotional_action_benefit_lead",
+                f"Promotional lead is passive or redundant: '{lead}'",
+            )
+
+        for reference in detect_generic_destination_references(body):
+            add(
+                "cta_structure",
+                f"Replace generic destination reference with descriptive linked text: '{reference}'",
+            )
+
+        for phrase in detect_indirect_contact_language(body):
+            add(
+                "cta_structure",
+                f"Use direct information-first contact language instead of '{phrase}'",
+            )
+
         if category == "job_opportunity":
             if headline.strip():
                 add("job_posting_format", "Jobs listing includes a headline — keep it body-only")
@@ -324,6 +346,19 @@ class AIEditor:
                 add(
                     "preserve_action_deadlines",
                     f"Source requirement missing from AI edit: '{requirement}'",
+                )
+
+            missing_audience_context = detect_missing_specific_audience_lead(
+                body_source,
+                body,
+            )
+            if missing_audience_context:
+                listed = ", ".join(
+                    f"'{detail}'" for detail in missing_audience_context[:5]
+                )
+                add(
+                    "preserve_audience_scope",
+                    f"Specific source audience context missing from first sentence: {listed}",
                 )
 
         return flags

--- a/backend/app/utils/style_checks.py
+++ b/backend/app/utils/style_checks.py
@@ -7,9 +7,9 @@ active in the prompt at the time. The detectors here cover the subset of those
 rules that can be verified mechanically — AP month abbreviation, a.m./p.m.
 formatting, platform names, undefined acronyms, repeated calls to action and
 the Jobs single-line contract, plus high-confidence source contacts,
-organizations, titles, information paths and anchored requirements — so a
-violation surfaces as a flag on the AI version regardless of whether the model
-honored the prompt.
+organizations, titles, audience qualifiers, information paths, promotional
+leads and anchored requirements — so a violation surfaces as a flag on the AI
+version regardless of whether the model honored the prompt.
 
 Each detector is a pure function over edited text and returns the offending
 fragments. Mapping findings to flags (and gating on whether the corresponding
@@ -43,7 +43,55 @@ _KNOWN_ACRONYMS = {
     "TV", "AV", "GED", "ADA", "FYI", "AM", "PM",
 }
 
-_CTA_PHRASES = ("register", "sign up", "rsvp", "apply", "learn more")
+_CTA_PHRASES = ("register", "sign up", "enroll", "rsvp", "apply", "learn more")
+
+_ANCHOR_ELEMENT = re.compile(r"<a\b[^>]*>.*?</a>", re.IGNORECASE | re.DOTALL)
+_GENERIC_DESTINATION_REFERENCE = re.compile(
+    r"\b(?:landing\s+page|this\s+page|web\s*page)\b",
+    re.IGNORECASE,
+)
+_INDIRECT_CONTACT_LANGUAGE = re.compile(
+    r"\b(?:interested\s+)?(?:participants?|individuals?|people|applicants?)\s+"
+    r"should\s+contact\b",
+    re.IGNORECASE,
+)
+_REDUNDANT_PROMOTIONAL_LEAD = re.compile(
+    r"^\s*The\s+last\s+week\s+to\b[^.!?]*\bis\s+this\s+week\b",
+    re.IGNORECASE,
+)
+_RECRUITMENT_CONTEXT = re.compile(
+    r"\b(?:seeking|recruiting|recruit|inviting|invites?|looking\s+for|open\s+to|"
+    r"eligible|opportunity\s+for|needed|wanted)\b",
+    re.IGNORECASE,
+)
+_SPECIFIC_AUDIENCE_GROUPS = (
+    (
+        "breastfeeding/lactating women",
+        re.compile(r"\b(?:breastfeeding|lactating)\s+women\b", re.IGNORECASE),
+    ),
+    ("donors", re.compile(r"\bdonors?\b", re.IGNORECASE)),
+    ("volunteers", re.compile(r"\bvolunteers?\b", re.IGNORECASE)),
+    ("faculty members", re.compile(r"\bfaculty\s+members?\b", re.IGNORECASE)),
+    (
+        "first-year students",
+        re.compile(r"\bfirst[\s-]+year\s+students?\b", re.IGNORECASE),
+    ),
+    ("alumni", re.compile(r"\balumni\b", re.IGNORECASE)),
+)
+_AGE_RANGE_PATTERNS = (
+    re.compile(
+        r"\bbetween\s+(?:the\s+)?ages?\s+of\s+(\d{1,3})\s+and\s+(\d{1,3})\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bages?\s+(\d{1,3})\s*(?:-|–|—|to)\s*(\d{1,3})\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(\d{1,3})\s*(?:-|–|—|to)\s*(\d{1,3})\s+years?\s+old\b",
+        re.IGNORECASE,
+    ),
+)
 
 _EMAIL = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
 _PHONE = re.compile(
@@ -190,6 +238,76 @@ def detect_repeated_cta_phrases(text: str) -> list[str]:
         for phrase in _CTA_PHRASES
         if len(re.findall(rf"\b{phrase}\b", lowered)) >= 2
     ]
+
+
+def _first_sentence(text: str) -> str:
+    """Return the first visible sentence from edited copy."""
+    visible = re.sub(r"\s+", " ", strip_html(text)).strip()
+    return re.split(r"(?<=[.!?])\s+", visible, maxsplit=1)[0]
+
+
+def detect_redundant_promotional_leads(text: str) -> list[str]:
+    """Find narrow, high-confidence passive or circular promotional leads."""
+    first_sentence = _first_sentence(text)
+    if _REDUNDANT_PROMOTIONAL_LEAD.search(first_sentence):
+        return [first_sentence]
+    return []
+
+
+def detect_generic_destination_references(text: str) -> list[str]:
+    """Find generic page references that are not themselves descriptive links."""
+    without_links = _ANCHOR_ELEMENT.sub(" ", text)
+    return [match.group() for match in _GENERIC_DESTINATION_REFERENCE.finditer(without_links)]
+
+
+def detect_indirect_contact_language(text: str) -> list[str]:
+    """Find wordy audience-prefixed contact constructions."""
+    return [match.group() for match in _INDIRECT_CONTACT_LANGUAGE.finditer(strip_html(text))]
+
+
+def detect_missing_specific_audience_lead(
+    source_body: str,
+    edited_body: str,
+) -> list[str]:
+    """Find source-specific recruitment audience details missing from the lead.
+
+    A group is protected only when it appears in a source sentence with a
+    recruitment or eligibility cue. This prevents incidental references to
+    volunteers or alumni later in an announcement from being misclassified as
+    the target audience.
+    """
+    source = strip_html(source_body)
+    source_sentences = re.split(r"(?<=[.!?])\s+|\n+", source)
+    edited_lead = _first_sentence(edited_body)
+    protected_groups: list[tuple[str, re.Pattern[str]]] = []
+
+    for display, pattern in _SPECIFIC_AUDIENCE_GROUPS:
+        if any(
+            pattern.search(sentence) and _RECRUITMENT_CONTEXT.search(sentence)
+            for sentence in source_sentences
+        ):
+            protected_groups.append((display, pattern))
+
+    findings = [
+        display
+        for display, pattern in protected_groups
+        if not pattern.search(edited_lead)
+    ]
+
+    if protected_groups:
+        for pattern in _AGE_RANGE_PATTERNS:
+            match = pattern.search(source)
+            if match is None:
+                continue
+            lower_age, upper_age = match.groups()
+            if not (
+                re.search(rf"\b{re.escape(lower_age)}\b", edited_lead)
+                and re.search(rf"\b{re.escape(upper_age)}\b", edited_lead)
+            ):
+                findings.append(f"ages {lower_age}-{upper_age}")
+            break
+
+    return findings
 
 
 def _contact_channels(text: str) -> dict[str, str]:

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -260,8 +260,8 @@
   {
     "category": "formatting",
     "rule_key": "research_study_format",
-    "rule_text": "Research participant recruitment announcements should begin with 'Researchers are recruiting participants for a study...' followed by a brief description of the study topic and compensation details.",
-    "severity": "info"
+    "rule_text": "Research recruitment announcements must begin with the most specific accurate audience description supplied by the source, followed by the study topic. Never default to generic words such as 'participants,' 'individuals' or 'people' when the source identifies breastfeeding or lactating women, donors, volunteers, faculty members, first-year students, alumni or another precise group. Include important eligibility qualifiers, such as an age range, in the first sentence whenever concise. Example: 'Researchers are seeking breastfeeding women ages 18-50 for a study on human milk composition,' not 'Researchers are recruiting participants for a study.' Follow with compensation and participation details.",
+    "severity": "error"
   },
   {
     "category": "headlines",
@@ -302,7 +302,13 @@
   {
     "category": "voice",
     "rule_key": "cta_structure",
-    "rule_text": "Structure announcements around one clear call to action and supporting context. Replace vague instructions with an explicit action, but do not repeat that action elsewhere in the item. Edit user-supplied linked text when needed for clarity, concision and editorial style; linked text is not immutable. Do not introduce audience qualifiers that are not in the original submission. When the submission provides a contact's full name, use it rather than a bare email address. Never build a call to action on filler words such as 'here' or 'click here'. Link the action verb or object: 'Sign up', 'Register for the workshop' or 'Apply for the scholarship'.",
+    "rule_text": "Structure announcements around one clear call to action and supporting context. Replace vague instructions with an explicit action, but do not repeat that action elsewhere in the item. Use direct information-first contact language such as 'For more information, contact Betsy Church,' never 'Interested participants should contact Betsy Church.' Edit user-supplied linked text when needed for clarity, concision and editorial style; linked text is not immutable. Replace generic unlinked references such as 'landing page,' 'webpage,' 'here' or 'click here' with descriptive linked text that names the action or destination. Do not introduce audience qualifiers that are not in the original submission. When the submission provides a contact's full name, use it rather than a bare email address. Link the action verb or object: 'Sign up', 'Register for the workshop', 'Apply for the scholarship' or 'Review the promotion details'.",
+    "severity": "error"
+  },
+  {
+    "category": "voice",
+    "rule_key": "promotional_action_benefit_lead",
+    "rule_text": "Promotional announcements must lead with the action readers should take and the benefit they can receive. Put important qualifying details early when they define the offer. Avoid passive, circular or redundant introductions such as 'The last week to have a permit reimbursed is this week.' Prefer 'This is the final week to enroll in a qualifying meal plan for a chance to have a commuter parking permit reimbursed in full.' Remove audience references that do not affect eligibility. Consolidate repeated actions into one descriptive linked call to action and shorten supporting wording rather than repeating the offer.",
     "severity": "error"
   },
   {
@@ -350,7 +356,7 @@
   {
     "category": "content_filtering",
     "rule_key": "preserve_audience_scope",
-    "rule_text": "Do not narrow the intended audience. Preserve broad audience meaning such as 'all are welcome,' 'everyone is invited' or 'the public is welcome.' For concise event invitations, replace that wording with a direct invitation such as 'Attend the workshop,' never with a narrower group such as employees, students, faculty, staff or campus community unless the original explicitly limits attendance.",
+    "rule_text": "Do not narrow, broaden or genericize the intended audience. Preserve broad audience meaning such as 'all are welcome,' 'everyone is invited' or 'the public is welcome.' Also preserve the most specific accurate source description, such as donors, breastfeeding or lactating women, volunteers, faculty members, first-year students or alumni, instead of replacing it with 'participants,' 'individuals' or 'people.' For recruitment announcements, include the specific group in the first sentence whenever possible and surface important eligibility qualifiers early enough that the offer is not misleading. For concise event invitations, replace broad wording with a direct invitation such as 'Attend the workshop,' never with a narrower group unless the original explicitly limits attendance.",
     "severity": "error"
   },
   {

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -1432,6 +1432,106 @@ class TestDeterministicPostValidation:
             "preserve_action_deadlines",
         }
 
+    async def test_reported_promotional_edit_flags_weak_lead_and_cta_problems(self):
+        source_body = (
+            "Last week to get your commuter parking permit reimbursed in full through "
+            "IdahoEats. Enroll in a qualifying meal plan by August 22 to enter the random "
+            "drawing for one faculty or staff winner. Enroll here before the window "
+            "closes. Terms and conditions apply, see landing page for full details."
+        )
+        edited_body = (
+            "The last week to have a commuter parking permit reimbursed in full through "
+            "IdahoEats is this week. Employees who enroll in a qualifying meal plan by "
+            "Aug. 22 will be entered in a random drawing for one faculty or staff winner. "
+            "<a href='https://example.com/promotion'>Enroll now</a>. Terms and conditions "
+            "apply. See the landing page for full details."
+        )
+        flags = AIEditor(SuccessfulProvider()).post_analyze(
+            "Buy early and park for free",
+            edited_body,
+            "faculty_staff",
+            [
+                {
+                    "category": "voice",
+                    "rule_key": "promotional_action_benefit_lead",
+                    "rule_text": "Managed promotional-lead rule.",
+                    "severity": "error",
+                },
+                {
+                    "category": "voice",
+                    "rule_key": "cta_structure",
+                    "rule_text": "Managed CTA structure rule.",
+                    "severity": "error",
+                },
+                {
+                    "category": "voice",
+                    "rule_key": "single_cta",
+                    "rule_text": "Managed single-CTA rule.",
+                    "severity": "error",
+                },
+            ],
+            source_text=source_body,
+            source_body=source_body,
+        )
+
+        assert {flag["rule_key"] for flag in flags} == {
+            "promotional_action_benefit_lead",
+            "cta_structure",
+            "single_cta",
+        }
+        assert any("landing page" in flag["message"] for flag in flags)
+        assert any("'enroll'" in flag["message"] for flag in flags)
+
+    async def test_reported_research_edit_flags_generic_lead_and_indirect_contact(self):
+        source_body = (
+            "Researchers at the Margaret Ritchie School of Family and Consumer Sciences "
+            "are currently seeking lactating women interested in donating milk for a "
+            "research project at the University of Idaho. Participants must be between "
+            "the ages of 18 and 50 and currently breastfeeding or pumping for an infant "
+            "at least 2 weeks old. Each participant is requested to donate up to 10 oz of "
+            "milk and will receive a $25 gift card for every 2 oz donated. If you are "
+            "interested, please contact Betsy Church at betsychurch@uidaho.edu for more "
+            "information."
+        )
+        edited_body = (
+            "Researchers are recruiting participants for a study on human milk composition "
+            "at the Margaret Ritchie School of Family and Consumer Sciences, U of I. "
+            "Participants must be 18 to 50 years old and currently breastfeeding or pumping "
+            "for an infant at least two weeks old. Each donor may provide up to 10 oz of "
+            "milk and will receive a $25 gift card for every 2 oz donated. Interested "
+            "participants should contact <a href='mailto:betsychurch@uidaho.edu'>Betsy "
+            "Church</a> for more information."
+        )
+        flags = AIEditor(SuccessfulProvider()).post_analyze(
+            "Participate in human milk composition study",
+            edited_body,
+            "faculty_staff",
+            [
+                {
+                    "category": "content_filtering",
+                    "rule_key": "preserve_audience_scope",
+                    "rule_text": "Managed audience rule.",
+                    "severity": "error",
+                },
+                {
+                    "category": "voice",
+                    "rule_key": "cta_structure",
+                    "rule_text": "Managed CTA structure rule.",
+                    "severity": "error",
+                },
+            ],
+            source_text=source_body,
+            source_body=source_body,
+        )
+
+        assert {flag["rule_key"] for flag in flags} == {
+            "preserve_audience_scope",
+            "cta_structure",
+        }
+        assert any("breastfeeding/lactating women" in flag["message"] for flag in flags)
+        assert any("ages 18-50" in flag["message"] for flag in flags)
+        assert any("Interested participants should contact" in flag["message"] for flag in flags)
+
     async def test_compliant_output_produces_no_post_validation_flags(
         self,
         client: AsyncClient,

--- a/backend/tests/test_august_10_joy_style_rules.py
+++ b/backend/tests/test_august_10_joy_style_rules.py
@@ -37,7 +37,7 @@ def test_august_10_rules_are_seeded_as_mandatory_contracts():
         "ap_style_times": "lowercase a.m. and p.m. with periods",
         "single_cta": "Each call to action must appear only once",
         "online_not_platform": "Use the word 'online' instead of platform names",
-        "preserve_audience_scope": "Do not narrow the intended audience",
+        "preserve_audience_scope": "Do not narrow, broaden or genericize",
         "composition_title_format": "single quotation marks in headlines",
         "building_room_order": "building name first",
         "approved_off_campus_addresses": "Kenworthy Performing Arts Centre, 508 S. Main St.",
@@ -90,8 +90,10 @@ def test_migration_is_idempotent_and_matches_shared_seed():
     # Later focused migrations supersede these original texts; their own
     # migration tests verify the latest seed values.
     superseded = {
+        "cta_structure",
         "no_fabricated_content",
         "composition_title_format",
+        "preserve_audience_scope",
         "preserve_purpose_contact_titles",
     }
     for row in rows:

--- a/backend/tests/test_specific_audience_rule_migration.py
+++ b/backend/tests/test_specific_audience_rule_migration.py
@@ -1,0 +1,99 @@
+"""Regression coverage for the specific-audience language rule migration."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "a4c6e8f0b2d3_preserve_specific_audience_language.py"
+)
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "preserve_specific_audience_language", MIGRATION_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def style_rules_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+
+
+def test_rule_upserts_are_idempotent_and_preserve_unrelated_rules():
+    migration = load_migration()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    rules = style_rules_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert(),
+            [
+                {
+                    "Id": "stale",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "cta_structure",
+                    "Rule_Text": "Old wording.",
+                    "Is_Active": False,
+                    "Severity": "warning",
+                },
+                {
+                    "Id": "custom",
+                    "Rule_Set": "shared",
+                    "Category": "voice",
+                    "Rule_Key": "staff_custom",
+                    "Rule_Text": "Keep this staff rule.",
+                    "Is_Active": True,
+                    "Severity": "info",
+                },
+            ],
+        )
+
+        migration._upsert_rules(connection)
+        migration._upsert_rules(connection)
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    by_key = {row["Rule_Key"]: row for row in rows}
+    assert len(rows) == len(migration.RULES) + 1
+    assert by_key["staff_custom"]["Rule_Text"] == "Keep this staff rule."
+    for category, rule_key, rule_text, severity in migration.RULES:
+        updated = by_key[rule_key]
+        assert updated["Category"] == category
+        assert updated["Rule_Text"] == rule_text
+        assert updated["Severity"] == severity
+        assert updated["Is_Active"] is True
+
+
+def test_migration_matches_seeded_rules():
+    migration = load_migration()
+    seed_path = Path(__file__).parents[1] / "data" / "style_rules" / "shared_rules.json"
+    seeded = {rule["rule_key"]: rule for rule in json.loads(seed_path.read_text())}
+
+    for category, rule_key, rule_text, severity in migration.RULES:
+        rule = seeded[rule_key]
+        assert rule["category"] == category
+        assert rule["rule_text"] == rule_text
+        assert rule["severity"] == severity

--- a/backend/tests/test_style_checks.py
+++ b/backend/tests/test_style_checks.py
@@ -11,10 +11,14 @@ from app.utils.style_checks import (
     detect_platform_names,
     detect_undefined_acronyms,
     detect_repeated_cta_phrases,
+    detect_redundant_promotional_leads,
+    detect_generic_destination_references,
+    detect_indirect_contact_language,
     detect_missing_anchored_requirements,
     detect_missing_contact_titles,
     detect_missing_information_options,
     detect_missing_protected_organizations,
+    detect_missing_specific_audience_lead,
     detect_missing_source_contacts,
     detect_new_contact_channels,
     detect_new_contact_names,
@@ -95,6 +99,43 @@ class TestRepeatedCta:
 
     def test_accepts_single_cta(self):
         assert detect_repeated_cta_phrases("Sign up for the training.") == []
+
+    def test_flags_repeated_enrollment_cta(self):
+        text = "Employees who enroll qualify. Enroll now."
+
+        assert detect_repeated_cta_phrases(text) == ["enroll"]
+
+
+class TestActionAndContactLanguage:
+    def test_flags_redundant_passive_promotional_lead(self):
+        lead = "The last week to have a parking permit reimbursed is this week."
+
+        assert detect_redundant_promotional_leads(lead) == [lead]
+
+    def test_accepts_action_and_benefit_promotional_lead(self):
+        assert detect_redundant_promotional_leads(
+            "Enroll this week for a chance to have your parking permit reimbursed."
+        ) == []
+
+    def test_flags_generic_unlinked_destination_reference(self):
+        assert detect_generic_destination_references(
+            "Enroll now. See the landing page for details."
+        ) == ["landing page"]
+
+    def test_accepts_descriptive_linked_destination(self):
+        assert detect_generic_destination_references(
+            'Review the <a href="https://example.com">promotion page</a> and enroll.'
+        ) == []
+
+    def test_flags_indirect_audience_prefixed_contact_language(self):
+        assert detect_indirect_contact_language(
+            "Interested participants should contact Betsy Church."
+        ) == ["Interested participants should contact"]
+
+    def test_accepts_direct_information_first_contact_language(self):
+        assert detect_indirect_contact_language(
+            "For more information, contact Betsy Church."
+        ) == []
 
 
 def test_strip_html_removes_tags_but_keeps_anchor_text():
@@ -236,6 +277,36 @@ class TestSourceFidelity:
             "Cashiers serving alcohol must be 21+ and TIPS certified.",
             "Cashiers serving alcohol are required to be 21 or older and TIPS certified.",
         ) == []
+
+    def test_flags_specific_recruitment_group_and_age_range_missing_from_lead(self):
+        source = (
+            "Researchers are seeking lactating women for a study. Participants must be "
+            "between the ages of 18 and 50."
+        )
+        edited = (
+            "Researchers are recruiting participants for a study. Participants must be "
+            "18 to 50 years old."
+        )
+
+        assert detect_missing_specific_audience_lead(source, edited) == [
+            "breastfeeding/lactating women",
+            "ages 18-50",
+        ]
+
+    def test_accepts_specific_recruitment_group_and_age_range_in_lead(self):
+        source = (
+            "Researchers are seeking lactating women for a study. Participants must be "
+            "between the ages of 18 and 50."
+        )
+        edited = "Researchers are seeking breastfeeding women ages 18-50 for a study."
+
+        assert detect_missing_specific_audience_lead(source, edited) == []
+
+    def test_ignores_incidental_participant_group_without_recruitment_context(self):
+        source = "Volunteers assist participants during the event."
+        edited = "Event staff assist participants."
+
+        assert detect_missing_specific_audience_lead(source, edited) == []
 
 
 class TestWeekdayDateConsistency:


### PR DESCRIPTION
## Summary

- preserve specific recruitment audiences and eligibility qualifiers in AI-edited leads
- enforce action-and-benefit promotional leads, direct contact language, descriptive links and single enrollment CTAs
- migrate existing style rules and add production-derived regression coverage for both reported edits

## Root cause

The research-study prompt explicitly encouraged generic “participants” language, while the audience rule only protected against narrowing. CTA checks also omitted enrollment language, indirect contact phrasing and generic unlinked destinations.

## Impact

AI edits now retain source-specific audience language such as breastfeeding or lactating women and surface key eligibility details early. Promotional copy is flagged when it uses circular leads, duplicate enrollment actions or vague destination references.

## Validation

- `cd backend && .venv/bin/pytest -q` — 270 passed
- `cd backend && .venv/bin/ruff check .`
- shared style-rule JSON validation
- Alembic single-head check

Closes #313
