### PR TITLE
Add Student newsletter option to Faculty/Staff submissions

### DIFF
--- a/backend/app/services/submission_service.py
+++ b/backend/app/services/submission_service.py
@@ -402,10 +402,12 @@ async def get_submission_occurrence_dates(
     candidate_dates: set[date] = set()
     for schedule_request in submission.Schedule_Requests:
         candidate_dates.update(
-            recurrence_service.expand_schedule_request(
+            _expand_schedule_request_for_newsletter(
+                submission,
                 schedule_request,
                 from_date,
                 to_date,
+                newsletter_type,
             )
         )
 
@@ -435,10 +437,12 @@ async def hydrate_submission_occurrences(
     """Attach occurrence previews to a submission and each schedule request."""
     all_occurrences: list[date] = []
     for schedule_request in submission.Schedule_Requests:
-        occurrences = recurrence_service.expand_schedule_request(
+        occurrences = _expand_schedule_request_for_newsletter(
+            submission,
             schedule_request,
             from_date,
             to_date,
+            newsletter_type,
         )
         valid_occurrences = await get_submission_occurrence_dates_for_request(
             db,
@@ -464,6 +468,46 @@ async def hydrate_submission_occurrences(
         occurrence.isoformat() for occurrence in unique_occurrences
     ]
     return submission
+
+
+def _expand_schedule_request_for_newsletter(
+    submission: Submission,
+    schedule_request: SubmissionScheduleRequest,
+    from_date: date,
+    to_date: date,
+    newsletter_type: str | None,
+) -> list[date]:
+    """Expand the newsletter-specific date field for a ``both`` submission."""
+    if (
+        submission.Target_Newsletter != "both"
+        or newsletter_type not in {"tdr", "myui"}
+    ):
+        return recurrence_service.expand_schedule_request(
+            schedule_request,
+            from_date,
+            to_date,
+        )
+
+    if newsletter_type == "myui":
+        student_date = schedule_request.Second_Requested_Date
+        if student_date is None or not from_date <= student_date <= to_date:
+            return []
+        if student_date.isoformat() in (schedule_request.Excluded_Dates or []):
+            return []
+        return [student_date]
+
+    if newsletter_type == "tdr" and schedule_request.Requested_Date is not None:
+        return recurrence_service.expand_recurrence(
+            anchor=schedule_request.Requested_Date,
+            recurrence_type=schedule_request.Recurrence_Type or "once",
+            interval=max(schedule_request.Recurrence_Interval or 1, 1),
+            from_date=from_date,
+            to_date=to_date,
+            until=schedule_request.Recurrence_End_Date,
+            excluded_dates=schedule_request.Excluded_Dates or [],
+        )
+
+    return []
 
 
 async def get_submission_occurrence_dates_for_request(

--- a/backend/tests/test_submission_service.py
+++ b/backend/tests/test_submission_service.py
@@ -35,6 +35,62 @@ async def test_create_submission_persists_second_requested_date(db):
 
 
 @pytest.mark.asyncio
+async def test_both_submission_uses_newsletter_specific_date_fields(db):
+    submission = await submission_service.create_submission(
+        db,
+        SubmissionCreate(
+            Category="faculty_staff",
+            Target_Newsletter="both",
+            Original_Headline="Two-newsletter announcement",
+            Original_Body="Body text for both newsletters.",
+            Submitter_Name="Test User",
+            Submitter_Email="test@uidaho.edu",
+            Links=[],
+            Schedule_Requests=[
+                {
+                    "Requested_Date": "2026-04-06",
+                    "Second_Requested_Date": "2026-04-13",
+                },
+                {
+                    "Requested_Date": "2026-04-06",
+                    "Second_Requested_Date": "2026-04-20",
+                },
+            ],
+        ),
+    )
+
+    tdr_dates = await submission_service.get_submission_occurrence_dates(
+        db,
+        submission,
+        date(2026, 4, 1),
+        date(2026, 4, 30),
+        newsletter_type="tdr",
+    )
+    student_dates = await submission_service.get_submission_occurrence_dates(
+        db,
+        submission,
+        date(2026, 4, 1),
+        date(2026, 4, 30),
+        newsletter_type="myui",
+    )
+    combined_dates = await submission_service.get_submission_occurrence_dates(
+        db,
+        submission,
+        date(2026, 4, 1),
+        date(2026, 4, 30),
+        newsletter_type="both",
+    )
+
+    assert tdr_dates == [date(2026, 4, 6)]
+    assert student_dates == [date(2026, 4, 13), date(2026, 4, 20)]
+    assert combined_dates == [
+        date(2026, 4, 6),
+        date(2026, 4, 13),
+        date(2026, 4, 20),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_date_range_listing_caches_publication_dates_per_request(
     db,
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/tests/test_submissions.py
+++ b/backend/tests/test_submissions.py
@@ -6,6 +6,7 @@ import pytest
 from freezegun import freeze_time
 from httpx import AsyncClient
 
+from app.db import seed
 from tests.conftest import make_submission_data
 
 
@@ -93,6 +94,25 @@ class TestSubmissionCRUD:
         schedule = resp.json()["Schedule_Requests"][0]
         assert schedule["Repeat_Count"] == 2
         assert schedule["Second_Requested_Date"] == "2026-03-16"
+
+    async def test_create_both_submission_rejects_invalid_student_date(
+        self, client: AsyncClient, db
+    ):
+        await seed.seed_schedule_configs(db)
+        data = make_submission_data(
+            Target_Newsletter="both",
+            Schedule_Requests=[
+                {
+                    "Requested_Date": "2026-03-13",
+                    "Second_Requested_Date": "2026-03-17",
+                }
+            ],
+        )
+
+        resp = await client.post("/api/v1/submissions/", json=data)
+
+        assert resp.status_code == 422
+        assert "MYUI publishes on Mondays only" in resp.json()["detail"]
 
     async def test_create_submission_persists_survey_end_date(self, client: AsyncClient):
         data = make_submission_data(

--- a/frontend/src/components/submission/CategorySelect.tsx
+++ b/frontend/src/components/submission/CategorySelect.tsx
@@ -6,6 +6,7 @@ interface Props {
   isLoading?: boolean;
   value: SubmissionCategory;
   onChange: (value: SubmissionCategory) => void;
+  helperText?: string;
 }
 
 export default function CategorySelect({
@@ -13,6 +14,7 @@ export default function CategorySelect({
   isLoading = false,
   value,
   onChange,
+  helperText = 'Options vary by target newsletter.',
 }: Props) {
   return (
     <div>
@@ -38,7 +40,7 @@ export default function CategorySelect({
       <p className="mt-1 text-xs text-gray-400">
         {isLoading
           ? 'Loading available announcement types...'
-          : 'Options vary by target newsletter.'}
+          : helperText}
       </p>
     </div>
   );

--- a/frontend/src/components/submission/SchedulePrefs.tsx
+++ b/frontend/src/components/submission/SchedulePrefs.tsx
@@ -20,6 +20,9 @@ interface Props {
   validDates?: Set<string>;
   secondaryValidDates?: Set<string>;
   showRecurrenceControls?: boolean;
+  heading?: string;
+  preferredDateLabel?: string;
+  secondDateLabel?: string;
 }
 
 function validateDate(
@@ -71,6 +74,9 @@ export default function SchedulePrefs({
   validDates,
   secondaryValidDates,
   showRecurrenceControls = false,
+  heading = 'Scheduling Preferences',
+  preferredDateLabel = 'Preferred run date',
+  secondDateLabel = 'Second run date',
 }: Props) {
   const update = (field: keyof ScheduleEntry, value: string | number | boolean) => {
     onChange({ ...schedule, [field]: value });
@@ -98,7 +104,7 @@ export default function SchedulePrefs({
   return (
     <div>
       <label className="block text-sm font-medium text-gray-700 mb-2">
-        Scheduling Preferences
+        {heading}
       </label>
 
       {isBoth ? (
@@ -169,7 +175,7 @@ export default function SchedulePrefs({
                 htmlFor="submission-preferred-run-date"
                 className="block text-xs text-gray-500 mb-1"
               >
-                Preferred run date
+                {preferredDateLabel}
               </label>
               <input
                 id="submission-preferred-run-date"
@@ -219,7 +225,7 @@ export default function SchedulePrefs({
                 htmlFor="submission-second-run-date"
                 className="block text-xs text-gray-500 mb-1"
               >
-                Second run date
+                {secondDateLabel}
               </label>
               <input
                 id="submission-second-run-date"

--- a/frontend/src/components/submission/SubmissionForm.test.tsx
+++ b/frontend/src/components/submission/SubmissionForm.test.tsx
@@ -37,7 +37,7 @@ const allowedCategories: AllowedValue[] = [
     Id: 'faculty_staff',
     Value_Group: 'Submission_Category',
     Code: 'faculty_staff',
-    Label: 'Faculty or Staff Announcement',
+    Label: 'Faculty/Staff',
     Display_Order: 1,
     Is_Active: true,
     Visibility_Role: 'public',
@@ -139,17 +139,19 @@ describe('SubmissionForm', () => {
   it('does not expose staff-only Builder sections as announcement types', async () => {
     render(<SubmissionForm />);
 
-    await screen.findByRole('option', { name: 'Faculty or Staff Announcement' });
+    await screen.findByRole('option', { name: 'Faculty/Staff and Student' });
     expect(
       screen.queryByRole('option', { name: 'Reminders for your students' }),
     ).not.toBeInTheDocument();
   });
 
-  it('submits a standard announcement with links and scheduling notes', async () => {
+  it('keeps a Faculty/Staff submission Daily Register-only when the Student checkbox is unchecked', async () => {
     const user = userEvent.setup();
     render(<SubmissionForm />);
 
-    await screen.findByRole('option', { name: 'Faculty or Staff Announcement' });
+    await screen.findByRole('option', { name: 'Faculty/Staff and Student' });
+    expect(screen.getByRole('checkbox', { name: 'Also publish in Student newsletter' })).not.toBeChecked();
+    expect(screen.queryByLabelText('Preferred Student newsletter publication date')).not.toBeInTheDocument();
     await fillStandardAnnouncement(user);
     await user.click(screen.getByRole('button', { name: /submit announcement/i }));
 
@@ -191,7 +193,7 @@ describe('SubmissionForm', () => {
     const user = userEvent.setup();
     render(<SubmissionForm />);
 
-    await screen.findByRole('option', { name: 'Faculty or Staff Announcement' });
+    await screen.findByRole('option', { name: 'Faculty/Staff and Student' });
     await user.selectOptions(screen.getByLabelText('Announcement Type'), 'survey');
     await user.type(screen.getByLabelText(/survey \/ event end date/i), '2026-05-30');
     await fillStandardAnnouncement(user);
@@ -205,16 +207,27 @@ describe('SubmissionForm', () => {
     expect(screen.getByLabelText('Your Name')).toHaveValue('Jane Submitter');
   });
 
-  it('submits separate TDR and My UI run dates when both newsletters are selected', async () => {
+  it('targets both newsletters and requests a Student date when the checkbox is checked', async () => {
     const user = userEvent.setup();
     render(<SubmissionForm />);
 
-    await screen.findByRole('option', { name: 'Faculty or Staff Announcement' });
-    await user.click(screen.getByRole('button', { name: /both newsletters/i }));
+    await screen.findByRole('option', { name: 'Faculty/Staff and Student' });
+    await user.click(screen.getByRole('checkbox', { name: 'Also publish in Student newsletter' }));
+    expect(screen.getByLabelText('Preferred Student newsletter publication date')).toHaveValue('');
+    await waitFor(() => {
+      expect(getValidDatesMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        'myui',
+      );
+    });
+    expect(screen.getByText(
+      'Student newsletter submissions generally run once, during the week the event or opportunity occurs. Submissions may run twice when advance notice is needed, such as for registration, RSVP deadlines, ticket sales, reservations, applications or other time-sensitive deadlines. Staff will review and determine final publication dates.',
+    )).toBeInTheDocument();
     await user.type(screen.getByLabelText('Headline'), 'Campus forum');
     await user.type(screen.getByLabelText('Body Text'), 'Join us for a campus-wide forum.');
-    await user.type(screen.getByLabelText(/daily register run date/i), '2026-05-05');
-    await user.type(screen.getByLabelText(/my ui run date/i), '2026-05-04');
+    await user.type(screen.getByLabelText('Preferred Daily Register publication date'), '2026-05-05');
+    await user.type(screen.getByLabelText('Preferred Student newsletter publication date'), '2026-05-04');
     await user.type(screen.getByLabelText('Your Name'), 'Jane Submitter');
     await user.type(screen.getByLabelText('Email Address'), 'jane@example.edu');
     await user.click(screen.getByRole('button', { name: /submit announcement/i }));
@@ -227,7 +240,91 @@ describe('SubmissionForm', () => {
             expect.objectContaining({
               Requested_Date: '2026-05-05',
               Second_Requested_Date: '2026-05-04',
-              Repeat_Count: 2,
+              Repeat_Count: 1,
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
+  it('targets My UI when the public submitter chooses Student Announcement', async () => {
+    const user = userEvent.setup();
+    render(<SubmissionForm />);
+
+    await screen.findByRole('option', { name: 'Student Announcement' });
+    await user.selectOptions(screen.getByLabelText('Announcement Type'), 'student');
+    await user.type(screen.getByLabelText('Headline'), 'Student forum');
+    await user.type(screen.getByLabelText('Body Text'), 'Join the student forum.');
+    await user.type(screen.getByLabelText('Preferred run date'), '2026-05-04');
+    await user.type(screen.getByLabelText('Your Name'), 'Jane Submitter');
+    await user.type(screen.getByLabelText('Email Address'), 'jane@example.edu');
+    await user.click(screen.getByRole('button', { name: /submit announcement/i }));
+
+    await waitFor(() => {
+      expect(createSubmissionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Category: 'student',
+          Target_Newsletter: 'myui',
+        }),
+      );
+    });
+  });
+
+  it('blocks submission when a preferred Student newsletter date is invalid', async () => {
+    const user = userEvent.setup();
+    render(<SubmissionForm />);
+
+    await screen.findByRole('option', { name: 'Faculty/Staff and Student' });
+    await user.click(screen.getByRole('checkbox', { name: 'Also publish in Student newsletter' }));
+    await user.type(screen.getByLabelText('Headline'), 'Campus forum');
+    await user.type(screen.getByLabelText('Body Text'), 'Join us for a campus-wide forum.');
+    await user.type(screen.getByLabelText('Preferred Daily Register publication date'), '2026-05-05');
+    await user.type(screen.getByLabelText('Preferred Student newsletter publication date'), '2026-05-05');
+    await user.type(screen.getByLabelText('Your Name'), 'Jane Submitter');
+    await user.type(screen.getByLabelText('Email Address'), 'jane@example.edu');
+    await user.click(screen.getByRole('button', { name: /submit announcement/i }));
+
+    expect(await screen.findAllByText('Please select a valid Student newsletter publication date.')).toHaveLength(2);
+    expect(createSubmissionMock).not.toHaveBeenCalled();
+  });
+
+  it('submits multiple preferred Student newsletter dates through the existing both contract', async () => {
+    getValidDatesMock.mockResolvedValue({
+      dates: [
+        { date: '2026-05-04', newsletters: ['myui'] },
+        { date: '2026-05-05', newsletters: ['tdr'] },
+        { date: '2026-05-11', newsletters: ['myui'] },
+      ],
+      blackout_dates: [],
+    });
+    const user = userEvent.setup();
+    render(<SubmissionForm />);
+
+    await screen.findByRole('option', { name: 'Faculty/Staff and Student' });
+    await user.click(screen.getByRole('checkbox', { name: 'Also publish in Student newsletter' }));
+    await user.type(screen.getByLabelText('Headline'), 'Campus forum');
+    await user.type(screen.getByLabelText('Body Text'), 'Join us for a campus-wide forum.');
+    await user.type(screen.getByLabelText('Preferred Daily Register publication date'), '2026-05-05');
+    await user.type(screen.getByLabelText('Preferred Student newsletter publication date'), '2026-05-04');
+    await user.click(screen.getByRole('button', { name: '+ Add another Student newsletter date' }));
+    await user.type(screen.getByLabelText('Additional preferred Student date 2'), '2026-05-11');
+    await user.type(screen.getByLabelText('Your Name'), 'Jane Submitter');
+    await user.type(screen.getByLabelText('Email Address'), 'jane@example.edu');
+    await user.click(screen.getByRole('button', { name: /submit announcement/i }));
+
+    await waitFor(() => {
+      expect(createSubmissionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Target_Newsletter: 'both',
+          Schedule_Requests: [
+            expect.objectContaining({
+              Requested_Date: '2026-05-05',
+              Second_Requested_Date: '2026-05-04',
+            }),
+            expect.objectContaining({
+              Requested_Date: '2026-05-05',
+              Second_Requested_Date: '2026-05-11',
             }),
           ],
         }),
@@ -239,7 +336,7 @@ describe('SubmissionForm', () => {
     const user = userEvent.setup();
     render(<SubmissionForm />);
 
-    await screen.findByRole('option', { name: 'Faculty or Staff Announcement' });
+    await screen.findByRole('option', { name: 'Faculty/Staff and Student' });
     await user.type(screen.getByLabelText('Headline'), 'Campus forum');
     await user.type(screen.getByLabelText('Body Text'), 'Join us for a campus-wide forum.');
     await user.type(screen.getByLabelText('Preferred run date'), '2026-05-03');
@@ -257,7 +354,7 @@ describe('SubmissionForm', () => {
 
     await screen.findByRole('option', { name: 'Job Opportunity' });
     await user.selectOptions(screen.getByLabelText('Announcement Type'), 'job_opportunity');
-    expect(screen.getByRole('button', { name: /my ui/i })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /my ui/i })).not.toBeInTheDocument();
 
     await user.type(screen.getByLabelText('Job Posting URL'), 'https://uidaho.peopleadmin.com/postings/123');
     await user.type(screen.getByLabelText('Position Title'), 'Program Coordinator');

--- a/frontend/src/components/submission/SubmissionForm.tsx
+++ b/frontend/src/components/submission/SubmissionForm.tsx
@@ -24,6 +24,15 @@ const NEWSLETTER_CATEGORY_CODES: Record<TargetNewsletter, Set<string>> = {
   none: new Set<string>(),
 };
 
+const STUDENT_NEWSLETTER_GUIDANCE = 'Student newsletter submissions generally run once, during the week the event or opportunity occurs. Submissions may run twice when advance notice is needed, such as for registration, RSVP deadlines, ticket sales, reservations, applications or other time-sensitive deadlines. Staff will review and determine final publication dates.';
+
+const PUBLIC_TDR_ONLY_CATEGORY_CODES = new Set([
+  'employee_announcement',
+  'in_memoriam',
+  'job_opportunity',
+  'kudos',
+]);
+
 interface LinkEntry {
   Url: string;
   Anchor_Text: string;
@@ -126,6 +135,8 @@ export default function SubmissionForm() {
   const [submitterEmail, setSubmitterEmail] = useState('');
   const [notes, setNotes] = useState('');
   const [surveyEndDate, setSurveyEndDate] = useState('');
+  const [alsoPublishInStudentNewsletter, setAlsoPublishInStudentNewsletter] = useState(false);
+  const [preferredStudentDates, setPreferredStudentDates] = useState<string[]>(['']);
   const getMinDate = (): string => addDaysISO(1);
 
   // Job Opportunity fields
@@ -155,7 +166,16 @@ export default function SubmissionForm() {
   const [error, setError] = useState<string | null>(null);
   const successRef = useRef<HTMLDivElement>(null);
   const isJobOpportunity = category === 'job_opportunity';
-  const effectiveTargetNewsletter: TargetNewsletter = isJobOpportunity ? 'tdr' : targetNewsletter;
+  const isPublicFacultyStaffFlow = !isStaff && category === 'faculty_staff';
+  const effectiveTargetNewsletter: TargetNewsletter = isJobOpportunity
+    ? 'tdr'
+    : isPublicFacultyStaffFlow
+      ? alsoPublishInStudentNewsletter ? 'both' : 'tdr'
+      : targetNewsletter;
+  const scheduleTargetNewsletter: TargetNewsletter = isPublicFacultyStaffFlow
+    && alsoPublishInStudentNewsletter
+      ? 'tdr'
+      : effectiveTargetNewsletter;
 
   useEffect(() => {
     let cancelled = false;
@@ -211,14 +231,17 @@ export default function SubmissionForm() {
         const from = todayISO();
         const to = addMonthsISO(3);
         if (effectiveTargetNewsletter === 'both') {
-          const data = await getValidDates(from, to);
+          const [tdrData, myUIData] = await Promise.all([
+            getValidDates(from, to, 'tdr'),
+            getValidDates(from, to, 'myui'),
+          ]);
           setValidDates(new Set(
-            data.dates
+            tdrData.dates
               .filter((d) => d.newsletters.includes('tdr'))
               .map((d) => d.date),
           ));
           setSecondaryValidDates(new Set(
-            data.dates
+            myUIData.dates
               .filter((d) => d.newsletters.includes('myui'))
               .map((d) => d.date),
           ));
@@ -237,33 +260,43 @@ export default function SubmissionForm() {
     fetchDates();
   }, [effectiveTargetNewsletter]);
 
-  // Filter categories by newsletter target; staff-visibility categories
-  // (already gated by backend) always pass through.
-  // When "Both Newsletters" is selected, relabel "Faculty/Staff" as
-  // "News and Updates" so the dropdown matches the My UI section name.
+  // Public submitters choose an announcement type first. Newsletter targeting
+  // follows from that choice, except surveys, which retain the audience picker.
+  // Staff retain the existing target-first workflow and category filtering.
   const filteredCategories = categories
     .filter(
       (cat) =>
-        cat.Visibility_Role === 'staff' ||
-        NEWSLETTER_CATEGORY_CODES[effectiveTargetNewsletter]?.has(cat.Code),
+        isStaff
+          ? cat.Visibility_Role === 'staff'
+            || NEWSLETTER_CATEGORY_CODES[effectiveTargetNewsletter]?.has(cat.Code)
+          : cat.Visibility_Role === 'public',
     )
     .map((cat) =>
-      effectiveTargetNewsletter === 'both' && cat.Code === 'faculty_staff'
-        ? { ...cat, Label: 'News and Updates' }
-        : cat,
+      cat.Code === 'faculty_staff'
+        ? {
+            ...cat,
+            Label: isStaff
+              ? effectiveTargetNewsletter === 'both' ? 'News and Updates' : cat.Label
+              : 'Faculty/Staff and Student',
+          }
+        : cat
     );
+
+  const resetDatesForTarget = (nextTarget: TargetNewsletter) => {
+    setSchedule((current) => ({
+      ...current,
+      Requested_Date: '',
+      Second_Requested_Date: '',
+      Repeat_Count: nextTarget === 'both' ? 2 : 1,
+    }));
+  };
 
   // Clear date and reset category when newsletter target changes
   const handleTargetChange = (target: TargetNewsletter) => {
     const nextTarget = isJobOpportunity ? 'tdr' : target;
     setTargetNewsletter(nextTarget);
     // validDates will be re-fetched via useEffect; clear dates and adjust repeat count
-    setSchedule({
-      ...schedule,
-      Requested_Date: '',
-      Second_Requested_Date: '',
-      Repeat_Count: nextTarget === 'both' ? 2 : schedule.Repeat_Count,
-    });
+    resetDatesForTarget(nextTarget);
     // Reset category if current selection isn't valid for the new newsletter
     // (staff categories are always valid so they won't trigger a reset)
     const allowed = NEWSLETTER_CATEGORY_CODES[nextTarget];
@@ -275,6 +308,34 @@ export default function SubmissionForm() {
     }
   };
 
+  const handleCategoryChange = (nextCategory: SubmissionCategory) => {
+    setCategory(nextCategory);
+    if (isStaff) {
+      return;
+    }
+
+    setAlsoPublishInStudentNewsletter(false);
+    setPreferredStudentDates(['']);
+
+    let nextTarget = targetNewsletter;
+    if (nextCategory === 'faculty_staff' || PUBLIC_TDR_ONLY_CATEGORY_CODES.has(nextCategory)) {
+      nextTarget = 'tdr';
+    } else if (nextCategory === 'student') {
+      nextTarget = 'myui';
+    }
+
+    if (nextTarget !== targetNewsletter) {
+      setTargetNewsletter(nextTarget);
+      resetDatesForTarget(nextTarget);
+    }
+  };
+
+  const handleStudentNewsletterChange = (checked: boolean) => {
+    setAlsoPublishInStudentNewsletter(checked);
+    setPreferredStudentDates(['']);
+    setTargetNewsletter(checked ? 'both' : 'tdr');
+  };
+
   const hasDateError = (): boolean => {
     if (!schedule.Requested_Date) return false;
     if (validDates.size > 0) {
@@ -283,13 +344,13 @@ export default function SubmissionForm() {
     // Fallback client-side check
     const d = parseISODate(schedule.Requested_Date);
     const day = d.getDay();
-    if (effectiveTargetNewsletter === 'myui' || effectiveTargetNewsletter === 'both') return day !== 1;
-    if (effectiveTargetNewsletter === 'tdr') return day === 0 || day === 6;
+    if (scheduleTargetNewsletter === 'myui') return day !== 1;
+    if (scheduleTargetNewsletter === 'tdr' || scheduleTargetNewsletter === 'both') return day === 0 || day === 6;
     return false;
   };
 
   const getSecondDateError = (): string | null => {
-    if (effectiveTargetNewsletter === 'both') {
+    if (scheduleTargetNewsletter === 'both') {
       if (!schedule.Second_Requested_Date) {
         return 'Please select a valid My UI run date.';
       }
@@ -312,11 +373,24 @@ export default function SubmissionForm() {
 
     const d = parseISODate(schedule.Second_Requested_Date);
     const day = d.getDay();
-    if (effectiveTargetNewsletter === 'myui' && day !== 1) {
+    if (scheduleTargetNewsletter === 'myui' && day !== 1) {
       return 'Please select a valid second run date for the chosen newsletter.';
     }
-    if (effectiveTargetNewsletter === 'tdr' && (day === 0 || day === 6)) {
+    if (scheduleTargetNewsletter === 'tdr' && (day === 0 || day === 6)) {
       return 'Please select a valid second run date for the chosen newsletter.';
+    }
+    return null;
+  };
+
+  const getStudentDateError = (studentDate: string): string | null => {
+    if (!studentDate) {
+      return 'Please select a preferred Student newsletter publication date.';
+    }
+    if (secondaryValidDates.size > 0 && !secondaryValidDates.has(studentDate)) {
+      return 'Please select a valid Student newsletter publication date.';
+    }
+    if (parseISODate(studentDate).getDay() !== 1) {
+      return 'Please select a valid Student newsletter publication date.';
     }
     return null;
   };
@@ -338,6 +412,19 @@ export default function SubmissionForm() {
     if (secondDateError) {
       setError(secondDateError);
       return;
+    }
+    if (alsoPublishInStudentNewsletter) {
+      const studentDateError = preferredStudentDates
+        .map(getStudentDateError)
+        .find((dateError) => dateError !== null);
+      if (studentDateError) {
+        setError(studentDateError);
+        return;
+      }
+      if (new Set(preferredStudentDates).size !== preferredStudentDates.length) {
+        setError('Please choose different Student newsletter publication dates.');
+        return;
+      }
     }
     if (hasRecurrenceEndError()) {
       setError('Please choose a recurrence end date on or after the first run date.');
@@ -364,6 +451,38 @@ export default function SubmissionForm() {
         ? (jobUrl.trim() ? [{ Url: jobUrl, Anchor_Text: jobAnchorText || undefined }] : [])
         : links.filter((l) => l.Url.trim()).map((l) => ({ Url: l.Url, Anchor_Text: l.Anchor_Text || undefined }));
 
+      const baseScheduleRequest = {
+        Repeat_Note: schedule.Repeat_Note || undefined,
+        Is_Flexible: schedule.Is_Flexible || undefined,
+        Flexible_Deadline: schedule.Flexible_Deadline || undefined,
+        Recurrence_Type: isStaff ? schedule.Recurrence_Type : 'once' as const,
+        Recurrence_Interval: isStaff ? schedule.Recurrence_Interval : 1,
+        Recurrence_End_Date: isStaff ? schedule.Recurrence_End_Date || undefined : undefined,
+      };
+      const tdrDates = [
+        schedule.Requested_Date,
+        ...(schedule.Repeat_Count >= 2 && schedule.Second_Requested_Date
+          ? [schedule.Second_Requested_Date]
+          : []),
+      ];
+      const combinedScheduleCount = Math.max(tdrDates.length, preferredStudentDates.length);
+      const scheduleRequests: NonNullable<SubmissionCreate['Schedule_Requests']> =
+        isPublicFacultyStaffFlow && alsoPublishInStudentNewsletter
+          ? Array.from({ length: combinedScheduleCount }, (_, index) => ({
+              ...baseScheduleRequest,
+              Requested_Date: tdrDates[index] ?? tdrDates[0],
+              Second_Requested_Date: preferredStudentDates[index] || undefined,
+              Repeat_Count: 1,
+            }))
+          : [
+              {
+                ...baseScheduleRequest,
+                Requested_Date: schedule.Requested_Date,
+                Second_Requested_Date: schedule.Second_Requested_Date || undefined,
+                Repeat_Count: schedule.Repeat_Count,
+              },
+            ];
+
       const data: SubmissionCreate = {
         Category: category,
         Target_Newsletter: effectiveTargetNewsletter,
@@ -374,19 +493,7 @@ export default function SubmissionForm() {
         Submitter_Notes: notes || undefined,
         Survey_End_Date: category === 'survey' && surveyEndDate ? surveyEndDate : undefined,
         Links: effectiveLinks,
-        Schedule_Requests: [
-          {
-            Requested_Date: schedule.Requested_Date,
-            Second_Requested_Date: schedule.Second_Requested_Date || undefined,
-            Repeat_Count: schedule.Repeat_Count,
-            Repeat_Note: schedule.Repeat_Note || undefined,
-            Is_Flexible: schedule.Is_Flexible || undefined,
-            Flexible_Deadline: schedule.Flexible_Deadline || undefined,
-            Recurrence_Type: isStaff ? schedule.Recurrence_Type : 'once',
-            Recurrence_Interval: isStaff ? schedule.Recurrence_Interval : 1,
-            Recurrence_End_Date: isStaff ? schedule.Recurrence_End_Date || undefined : undefined,
-          },
-        ],
+        Schedule_Requests: scheduleRequests,
       };
 
       await createSubmission(data);
@@ -404,6 +511,9 @@ export default function SubmissionForm() {
       setJobLocation('');
       setJobRemoveDate('');
       setLinks([]);
+      setAlsoPublishInStudentNewsletter(false);
+      setPreferredStudentDates(['']);
+      setTargetNewsletter('tdr');
       setCategory((filteredCategories[0]?.Code ?? 'faculty_staff') as SubmissionCategory);
       setSchedule({
         Requested_Date: '',
@@ -450,17 +560,51 @@ export default function SubmissionForm() {
             Job postings run in The Daily Register only.
           </p>
         )}
-        <NewsletterTargetSelect
-          value={effectiveTargetNewsletter}
-          onChange={handleTargetChange}
-          disabledTargets={isJobOpportunity ? ['myui', 'both'] : undefined}
-        />
+        {isStaff && (
+          <NewsletterTargetSelect
+            value={effectiveTargetNewsletter}
+            onChange={handleTargetChange}
+            disabledTargets={isJobOpportunity ? ['myui', 'both'] : undefined}
+          />
+        )}
         <CategorySelect
           categories={filteredCategories}
           isLoading={categoriesLoading}
           value={category}
-          onChange={setCategory}
+          onChange={handleCategoryChange}
+          helperText={isStaff
+            ? 'Options vary by target newsletter.'
+            : 'Select the announcement type that best matches your content.'}
         />
+        {!isStaff && category === 'survey' && (
+          <NewsletterTargetSelect
+            value={effectiveTargetNewsletter}
+            onChange={handleTargetChange}
+            disabledTargets={isJobOpportunity ? ['myui', 'both'] : undefined}
+          />
+        )}
+        {isPublicFacultyStaffFlow && (
+          <div className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3">
+            <label
+              htmlFor="submission-also-student-newsletter"
+              className="flex items-start gap-3 text-sm font-medium text-gray-800"
+            >
+              <input
+                id="submission-also-student-newsletter"
+                type="checkbox"
+                checked={alsoPublishInStudentNewsletter}
+                onChange={(event) => handleStudentNewsletterChange(event.target.checked)}
+                className="mt-0.5 h-4 w-4 rounded border-gray-300 text-ui-gold-600 focus:ring-ui-gold-500"
+              />
+              <span>Also publish in Student newsletter</span>
+            </label>
+            {alsoPublishInStudentNewsletter && (
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-gray-600">
+                {STUDENT_NEWSLETTER_GUIDANCE}
+              </p>
+            )}
+          </div>
+        )}
         {category === 'survey' && (
           <div>
             <label htmlFor="submission-survey-end-date" className="block text-sm font-medium text-gray-700 mb-1">
@@ -630,11 +774,87 @@ export default function SubmissionForm() {
         <SchedulePrefs
           schedule={schedule}
           onChange={setSchedule}
-          targetNewsletter={effectiveTargetNewsletter}
+          targetNewsletter={scheduleTargetNewsletter}
           validDates={validDates.size > 0 ? validDates : undefined}
           secondaryValidDates={secondaryValidDates.size > 0 ? secondaryValidDates : undefined}
           showRecurrenceControls={isStaff}
+          heading={isPublicFacultyStaffFlow && alsoPublishInStudentNewsletter
+            ? 'Daily Register publication preferences'
+            : undefined}
+          preferredDateLabel={isPublicFacultyStaffFlow && alsoPublishInStudentNewsletter
+            ? 'Preferred Daily Register publication date'
+            : undefined}
+          secondDateLabel={isPublicFacultyStaffFlow && alsoPublishInStudentNewsletter
+            ? 'Second Daily Register publication date'
+            : undefined}
         />
+        {isPublicFacultyStaffFlow && alsoPublishInStudentNewsletter && (
+          <fieldset className="space-y-3 rounded-md border border-gray-200 px-4 py-4">
+            <legend className="px-1 text-sm font-medium text-gray-700">
+              Preferred Student newsletter publication dates
+            </legend>
+            {preferredStudentDates.map((studentDate, index) => {
+              const studentDateError = studentDate ? getStudentDateError(studentDate) : null;
+              return (
+                <div key={index} className="flex flex-col gap-2 sm:flex-row sm:items-start">
+                  <div className="w-full max-w-xs">
+                    <label
+                      htmlFor={`submission-student-date-${index}`}
+                      className="block text-xs text-gray-500 mb-1"
+                    >
+                      {index === 0
+                        ? 'Preferred Student newsletter publication date'
+                        : `Additional preferred Student date ${index + 1}`}
+                    </label>
+                    <input
+                      id={`submission-student-date-${index}`}
+                      type="date"
+                      value={studentDate}
+                      onChange={(event) => setPreferredStudentDates((current) => (
+                        current.map((dateValue, dateIndex) => (
+                          dateIndex === index ? event.target.value : dateValue
+                        ))
+                      ))}
+                      required
+                      min={getMinDate()}
+                      aria-invalid={studentDateError ? true : undefined}
+                      className={`w-full rounded-md border px-3 py-2 text-sm focus:ring-1 ${
+                        studentDateError
+                          ? 'border-red-400 focus:border-red-500 focus:ring-red-500'
+                          : 'border-gray-300 focus:border-ui-gold-500 focus:ring-ui-gold-500'
+                      }`}
+                    />
+                    {studentDateError && (
+                      <p className="mt-1 text-xs text-red-600">{studentDateError}</p>
+                    )}
+                    <p className="mt-1 text-xs text-gray-400">
+                      Select a valid Student newsletter publication date.
+                    </p>
+                  </div>
+                  {preferredStudentDates.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => setPreferredStudentDates((current) => (
+                        current.filter((_, dateIndex) => dateIndex !== index)
+                      ))}
+                      className="mt-0 text-sm text-red-700 hover:text-red-800 sm:mt-6"
+                      aria-label={`Remove preferred Student date ${index + 1}`}
+                    >
+                      Remove
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+            <button
+              type="button"
+              onClick={() => setPreferredStudentDates((current) => [...current, ''])}
+              className="text-sm font-medium text-ui-clearwater-700 hover:text-ui-clearwater-800"
+            >
+              + Add another Student newsletter date
+            </button>
+          </fieldset>
+        )}
         <div>
           <label htmlFor="submission-editor-notes" className="block text-sm font-medium text-gray-700 mb-1">
             Additional Notes for Editors


### PR DESCRIPTION
## Summary

- rename the public Faculty/Staff submission type to **Faculty/Staff and Student**
- add an opt-in **Also publish in Student newsletter** checkbox with the requested scheduling guidance
- collect one or more explicit preferred Student publication dates and validate them through the existing My UI schedule service
- preserve Daily Register-only behavior when the checkbox is clear and use the existing `Target_Newsletter: "both"` contract when selected
- keep newsletter-specific occurrence dates separated so Daily Register dates cannot become unintended Student runs

## User impact

Public submitters can request Student newsletter publication from the Faculty/Staff flow without navigating the separate newsletter target selector. Student dates remain preferences, are never auto-selected, and the form makes clear that staff determine final publication dates.

## Validation

- `npm run lint`
- `npm run build`
- `npm test -- --run` — 74 tests passed
- `./.venv/bin/ruff check .`
- `./.venv/bin/pytest -q` — 272 tests passed
- live public-form browser inspection
- `git diff --check`

Closes #314
