### PR TITLE
Fix newsletter-specific editor scheduling

### DIFF
--- a/backend/app/api/v1/submissions.py
+++ b/backend/app/api/v1/submissions.py
@@ -112,7 +112,12 @@ async def _validate_schedule_request(
             )
             if error:
                 raise HTTPException(status_code=422, detail=error)
-    elif schedule_request.Requested_Date:
+    elif not schedule_request.Requested_Date:
+        raise HTTPException(
+            status_code=422,
+            detail="Requested_Date is required for this newsletter.",
+        )
+    else:
         error = await schedule_service.validate_requested_date(
             db, schedule_request.Requested_Date, target_newsletter
         )

--- a/backend/app/schemas/submission.py
+++ b/backend/app/schemas/submission.py
@@ -59,7 +59,7 @@ class LinkResponse(BaseModel):
 
 
 class ScheduleRequestCreate(BaseModel):
-    Requested_Date: date
+    Requested_Date: date | None = None
     Second_Requested_Date: date | None = None
     Repeat_Count: int = Field(1, ge=1, le=2)
     Repeat_Note: str | None = None
@@ -75,8 +75,22 @@ class ScheduleRequestCreate(BaseModel):
 
     @model_validator(mode="after")
     def validate_recurrence_range(self) -> "ScheduleRequestCreate":
-        if self.Recurrence_End_Date and self.Recurrence_End_Date < self.Requested_Date:
-            raise ValueError("Recurrence_End_Date cannot be before Requested_Date")
+        requested_dates = [
+            requested_date
+            for requested_date in (self.Requested_Date, self.Second_Requested_Date)
+            if requested_date is not None
+        ]
+        if not requested_dates:
+            raise ValueError("At least one requested publication date is required")
+        recurrence_anchor = self.Requested_Date or self.Second_Requested_Date
+        if (
+            self.Recurrence_End_Date
+            and recurrence_anchor
+            and self.Recurrence_End_Date < recurrence_anchor
+        ):
+            raise ValueError(
+                "Recurrence_End_Date cannot be before the recurrence start date"
+            )
         return self
 
 
@@ -122,6 +136,15 @@ class SubmissionCreate(BaseModel):
     Event_Classification: str | None = Field(None, pattern=r"^(strategic|signature)$")
     Links: list[LinkCreate] = Field(default_factory=list, max_length=3)
     Schedule_Requests: list[ScheduleRequestCreate] = Field(..., min_length=1)
+
+    @model_validator(mode="after")
+    def require_primary_dates_on_submission(self) -> "SubmissionCreate":
+        if any(
+            schedule_request.Requested_Date is None
+            for schedule_request in self.Schedule_Requests
+        ):
+            raise ValueError("Requested_Date is required when creating a submission")
+        return self
 
 
 class SubmissionUpdate(BaseModel):

--- a/backend/app/services/recurrence_service.py
+++ b/backend/app/services/recurrence_service.py
@@ -13,10 +13,13 @@ def expand_schedule_request(
     to_date: date,
 ) -> list[date]:
     """Return occurrence dates for a schedule request within a range."""
-    if schedule_request.Requested_Date is None:
+    second_date = getattr(schedule_request, "Second_Requested_Date", None)
+    recurrence_anchor = schedule_request.Requested_Date or second_date
+    if recurrence_anchor is None:
         return []
+
     occurrences = expand_recurrence(
-        anchor=schedule_request.Requested_Date,
+        anchor=recurrence_anchor,
         recurrence_type=schedule_request.Recurrence_Type or "once",
         interval=max(schedule_request.Recurrence_Interval or 1, 1),
         from_date=from_date,
@@ -24,13 +27,15 @@ def expand_schedule_request(
         until=schedule_request.Recurrence_End_Date,
         excluded_dates=schedule_request.Excluded_Dates or [],
     )
-    # Include the second requested date when running twice
-    second_date = getattr(schedule_request, "Second_Requested_Date", None)
-    if second_date and from_date <= second_date <= to_date:
-        excluded = {d for d in (schedule_request.Excluded_Dates or []) if isinstance(d, str)}
-        if second_date.isoformat() not in excluded and second_date not in occurrences:
-            occurrences.append(second_date)
-            occurrences.sort()
+    if (
+        schedule_request.Requested_Date is not None
+        and second_date is not None
+        and from_date <= second_date <= to_date
+        and second_date.isoformat() not in (schedule_request.Excluded_Dates or [])
+        and second_date not in occurrences
+    ):
+        occurrences.append(second_date)
+        occurrences.sort()
     return occurrences
 
 

--- a/backend/app/services/submission_service.py
+++ b/backend/app/services/submission_service.py
@@ -171,7 +171,10 @@ async def list_submissions(
                     effective_to,
                 ),
                 sa.and_(
-                    SubmissionScheduleRequest.Requested_Date <= effective_to,
+                    sa.or_(
+                        SubmissionScheduleRequest.Requested_Date <= effective_to,
+                        SubmissionScheduleRequest.Second_Requested_Date <= effective_to,
+                    ),
                     SubmissionScheduleRequest.Recurrence_Type != "once",
                     sa.or_(
                         SubmissionScheduleRequest.Recurrence_End_Date.is_(None),
@@ -488,17 +491,14 @@ def _expand_schedule_request_for_newsletter(
             to_date,
         )
 
-    if newsletter_type == "myui":
-        student_date = schedule_request.Second_Requested_Date
-        if student_date is None or not from_date <= student_date <= to_date:
-            return []
-        if student_date.isoformat() in (schedule_request.Excluded_Dates or []):
-            return []
-        return [student_date]
-
-    if newsletter_type == "tdr" and schedule_request.Requested_Date is not None:
+    anchor = (
+        schedule_request.Second_Requested_Date
+        if newsletter_type == "myui"
+        else schedule_request.Requested_Date
+    )
+    if anchor is not None:
         return recurrence_service.expand_recurrence(
-            anchor=schedule_request.Requested_Date,
+            anchor=anchor,
             recurrence_type=schedule_request.Recurrence_Type or "once",
             interval=max(schedule_request.Recurrence_Interval or 1, 1),
             from_date=from_date,

--- a/backend/tests/test_submissions.py
+++ b/backend/tests/test_submissions.py
@@ -114,6 +114,19 @@ class TestSubmissionCRUD:
         assert resp.status_code == 422
         assert "MYUI publishes on Mondays only" in resp.json()["detail"]
 
+    async def test_create_submission_still_requires_primary_requested_date(
+        self, client: AsyncClient
+    ):
+        data = make_submission_data(
+            Target_Newsletter="both",
+            Schedule_Requests=[{"Second_Requested_Date": "2026-03-16"}],
+        )
+
+        resp = await client.post("/api/v1/submissions/", json=data)
+
+        assert resp.status_code == 422
+        assert "Requested_Date is required" in resp.text
+
     async def test_create_submission_persists_survey_end_date(self, client: AsyncClient):
         data = make_submission_data(
             Category="survey",
@@ -441,6 +454,129 @@ class TestSubmissionSchedule:
         )
         assert resp.status_code == 201
         assert resp.json()["Repeat_Count"] == 2
+
+    async def test_add_myui_schedule_request_to_both_submission(
+        self,
+        client: AsyncClient,
+        db,
+        staff_headers: dict[str, str],
+    ):
+        await seed.seed_schedule_configs(db)
+        create_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Target_Newsletter="both",
+                Schedule_Requests=[{"Requested_Date": "2026-04-01"}],
+            ),
+        )
+        sub_id = create_resp.json()["Id"]
+
+        resp = await client.post(
+            f"/api/v1/submissions/{sub_id}/schedule",
+            headers=staff_headers,
+            json={
+                "Requested_Date": None,
+                "Second_Requested_Date": "2026-04-06",
+            },
+        )
+
+        assert resp.status_code == 201
+        assert resp.json()["Requested_Date"] is None
+        assert resp.json()["Second_Requested_Date"] == "2026-04-06"
+        assert resp.json()["Occurrence_Dates"] == ["2026-04-06"]
+
+    async def test_add_myui_schedule_request_rejects_non_monday(
+        self,
+        client: AsyncClient,
+        db,
+        staff_headers: dict[str, str],
+    ):
+        await seed.seed_schedule_configs(db)
+        create_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Target_Newsletter="both",
+                Schedule_Requests=[{"Requested_Date": "2026-04-01"}],
+            ),
+        )
+        sub_id = create_resp.json()["Id"]
+
+        resp = await client.post(
+            f"/api/v1/submissions/{sub_id}/schedule",
+            headers=staff_headers,
+            json={
+                "Requested_Date": None,
+                "Second_Requested_Date": "2026-04-07",
+            },
+        )
+
+        assert resp.status_code == 422
+        assert "MYUI publishes on Mondays only" in resp.json()["detail"]
+
+    async def test_add_recurring_myui_schedule_request_uses_secondary_anchor(
+        self,
+        client: AsyncClient,
+        db,
+        staff_headers: dict[str, str],
+    ):
+        await seed.seed_schedule_configs(db)
+        create_resp = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Target_Newsletter="both",
+                Schedule_Requests=[{"Requested_Date": "2026-04-01"}],
+            ),
+        )
+        sub_id = create_resp.json()["Id"]
+
+        resp = await client.post(
+            f"/api/v1/submissions/{sub_id}/schedule",
+            headers=staff_headers,
+            json={
+                "Requested_Date": None,
+                "Second_Requested_Date": "2026-04-06",
+                "Recurrence_Type": "weekly",
+                "Recurrence_Interval": 1,
+                "Recurrence_End_Date": "2026-04-20",
+            },
+        )
+
+        assert resp.status_code == 201
+        assert resp.json()["Occurrence_Dates"] == [
+            "2026-04-06",
+            "2026-04-13",
+            "2026-04-20",
+        ]
+
+    async def test_single_newsletter_second_date_remains_a_one_time_run(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+    ):
+        resp = await client.post(
+            "/api/v1/submissions/",
+            headers=staff_headers,
+            json=make_submission_data(
+                Schedule_Requests=[
+                    {
+                        "Requested_Date": "2026-04-06",
+                        "Second_Requested_Date": "2026-04-08",
+                        "Repeat_Count": 2,
+                        "Recurrence_Type": "weekly",
+                        "Recurrence_Interval": 1,
+                        "Recurrence_End_Date": "2026-04-20",
+                    }
+                ],
+            ),
+        )
+
+        assert resp.status_code == 201
+        assert resp.json()["Occurrence_Dates"] == [
+            "2026-04-06",
+            "2026-04-08",
+            "2026-04-13",
+            "2026-04-20",
+        ]
 
     async def test_public_submitter_cannot_add_recurring_schedule_request(
         self, client: AsyncClient

--- a/frontend/src/api/submissions.ts
+++ b/frontend/src/api/submissions.ts
@@ -88,8 +88,8 @@ export async function rescheduleScheduleOccurrence(
 }
 
 export interface AddScheduleRequestData {
-  Requested_Date: string;
-  Second_Requested_Date?: string;
+  Requested_Date?: string | null;
+  Second_Requested_Date?: string | null;
   Recurrence_Type?: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday';
   Recurrence_Interval?: number;
   Recurrence_End_Date?: string;

--- a/frontend/src/components/editor/SubmissionMeta.test.tsx
+++ b/frontend/src/components/editor/SubmissionMeta.test.tsx
@@ -98,6 +98,83 @@ describe('SubmissionMeta schedule management', () => {
     });
   });
 
+  it('adds a valid My UI date to a both-newsletters submission', async () => {
+    const user = userEvent.setup();
+    const onAddScheduleDate = vi.fn().mockResolvedValue(undefined);
+    getValidDatesMock.mockResolvedValue({
+      dates: [{ date: '2026-05-04', newsletters: ['myui'] }],
+      blackout_dates: [],
+    });
+    render(
+      <SubmissionMeta
+        submission={makeSubmission({ Target_Newsletter: 'both' })}
+        onAddScheduleDate={onAddScheduleDate}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /add run date/i }));
+    await user.click(screen.getByRole('radio', { name: 'My UI' }));
+    await waitFor(() => {
+      expect(getValidDatesMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        'myui',
+      );
+    });
+    await user.type(screen.getByLabelText('Run date'), '2026-05-04');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(onAddScheduleDate).toHaveBeenCalledWith('myui', '2026-05-04', undefined);
+    });
+  });
+
+  it('rejects a My UI date that is not in the valid-date service response', async () => {
+    const user = userEvent.setup();
+    const onAddScheduleDate = vi.fn().mockResolvedValue(undefined);
+    getValidDatesMock.mockResolvedValue({
+      dates: [{ date: '2026-05-04', newsletters: ['myui'] }],
+      blackout_dates: [],
+    });
+    render(
+      <SubmissionMeta
+        submission={makeSubmission({ Target_Newsletter: 'both' })}
+        onAddScheduleDate={onAddScheduleDate}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /add run date/i }));
+    await user.click(screen.getByRole('radio', { name: 'My UI' }));
+    await user.type(screen.getByLabelText('Run date'), '2026-05-05');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(
+      await screen.findByText('Not a valid publication date for My UI (Mondays only).'),
+    ).toBeInTheDocument();
+    expect(onAddScheduleDate).not.toHaveBeenCalled();
+  });
+
+  it('labels separate Daily Register and My UI dates', () => {
+    render(
+      <SubmissionMeta
+        submission={makeSubmission({
+          Target_Newsletter: 'both',
+          Schedule_Requests: [
+            makeScheduleRequest({
+              Requested_Date: '2026-05-05',
+              Second_Requested_Date: '2026-05-04',
+            }),
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Daily Register:')).toBeInTheDocument();
+    expect(screen.getByText('My UI:')).toBeInTheDocument();
+    expect(screen.getByText(/Mon, May 4, 2026/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Tue, May 5, 2026/)).not.toHaveLength(0);
+  });
+
   it('adds a recurring run date with interval and end date', async () => {
     const user = userEvent.setup();
     const onAddScheduleDate = vi.fn().mockResolvedValue(undefined);

--- a/frontend/src/components/editor/SubmissionMeta.tsx
+++ b/frontend/src/components/editor/SubmissionMeta.tsx
@@ -19,7 +19,7 @@ interface SubmissionMetaProps {
     newDate: string,
   ) => Promise<void>;
   onAddScheduleDate?: (
-    newsletter: string,
+    newsletter: 'tdr' | 'myui',
     date: string,
     recurrence?: ScheduleRecurrence,
   ) => Promise<void>;
@@ -52,6 +52,15 @@ const RECURRENCE_LABELS: Record<string, string> = {
   monthly_nth_weekday: 'Monthly (nth weekday)',
 };
 
+function formatPublicationDate(value: string): string {
+  return parseISODate(value).toLocaleDateString(undefined, {
+    weekday: 'short',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
 export default function SubmissionMeta({
   submission,
   onChangeNewsletter,
@@ -68,7 +77,7 @@ export default function SubmissionMeta({
   const [replacementDate, setReplacementDate] = useState('');
 
   const [showAddDate, setShowAddDate] = useState(false);
-  const [addDateNewsletter, setAddDateNewsletter] = useState('');
+  const [addDateNewsletter, setAddDateNewsletter] = useState<'tdr' | 'myui' | ''>('');
   const [addDateValue, setAddDateValue] = useState('');
   const [addDateLoading, setAddDateLoading] = useState(false);
   const [addDateError, setAddDateError] = useState('');
@@ -84,9 +93,12 @@ export default function SubmissionMeta({
 
   const getMaxDate = () => addDaysISO(90);
 
-  const resolveNewsletter = useCallback(() => {
+  const resolveNewsletter = useCallback((): 'tdr' | 'myui' | '' => {
     if (submission.Target_Newsletter === 'both') return addDateNewsletter;
-    return submission.Target_Newsletter;
+    if (submission.Target_Newsletter === 'tdr' || submission.Target_Newsletter === 'myui') {
+      return submission.Target_Newsletter;
+    }
+    return '';
   }, [submission.Target_Newsletter, addDateNewsletter]);
 
   useEffect(() => {
@@ -112,7 +124,11 @@ export default function SubmissionMeta({
     setAddRecurrenceType('once');
     setAddRecurrenceInterval(1);
     setAddRecurrenceEnd('');
-    setAddDateNewsletter(submission.Target_Newsletter === 'both' ? '' : submission.Target_Newsletter);
+    setAddDateNewsletter(
+      submission.Target_Newsletter === 'tdr' || submission.Target_Newsletter === 'myui'
+        ? submission.Target_Newsletter
+        : '',
+    );
   };
 
   const handleCancelAddDate = () => {
@@ -240,18 +256,33 @@ export default function SubmissionMeta({
         )}
         {submission.Schedule_Requests.length > 0 && (
           <div>
-            <dt className="text-xs text-gray-500">Requested Run Date</dt>
+            <dt className="text-xs text-gray-500">
+              Requested Run Date{submission.Target_Newsletter === 'both' ? 's' : ''}
+            </dt>
             {submission.Schedule_Requests.map((req) => (
               <dd key={req.Id} className="mt-1 text-gray-900 font-medium">
                 <div>
-                  {req.Requested_Date
-                    ? parseISODate(req.Requested_Date).toLocaleDateString(undefined, {
-                        weekday: 'short',
-                        year: 'numeric',
-                        month: 'short',
-                        day: 'numeric',
-                      })
-                    : 'No specific date'}
+                  {submission.Target_Newsletter === 'both' ? (
+                    <div className="space-y-0.5">
+                      {req.Requested_Date && (
+                        <div>
+                          <span className="font-normal text-gray-500">Daily Register: </span>
+                          {formatPublicationDate(req.Requested_Date)}
+                        </div>
+                      )}
+                      {req.Second_Requested_Date && (
+                        <div>
+                          <span className="font-normal text-gray-500">My UI: </span>
+                          {formatPublicationDate(req.Second_Requested_Date)}
+                        </div>
+                      )}
+                      {!req.Requested_Date && !req.Second_Requested_Date && 'No specific date'}
+                    </div>
+                  ) : req.Requested_Date ? (
+                    formatPublicationDate(req.Requested_Date)
+                  ) : (
+                    'No specific date'
+                  )}
                   {req.Repeat_Count > 1 && (
                     <span className="font-normal text-gray-500"> &middot; Run {req.Repeat_Count}x</span>
                   )}
@@ -380,7 +411,7 @@ export default function SubmissionMeta({
             ))}
           </div>
         )}
-        {onAddScheduleDate && !showAddDate && (
+        {onAddScheduleDate && submission.Target_Newsletter !== 'none' && !showAddDate && (
           <div>
             <button
               type="button"

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -27,6 +27,7 @@ import {
   normalizedBodyLinks,
   prepareBodyForEditing,
 } from '../utils/bodyLinks';
+import { buildEditorScheduleRequest } from '../utils/editorSchedule';
 import { Button, SegmentedToggle, Toast, useToast } from '../components/common';
 
 type Tab = 'original' | 'ai_edit' | 'editor';
@@ -405,7 +406,7 @@ export default function EditPage() {
   };
 
   const handleAddScheduleDate = async (
-    newsletter: string,
+    newsletter: 'tdr' | 'myui',
     date: string,
     recurrence?: {
       Recurrence_Type: 'weekly' | 'monthly_date' | 'monthly_nth_weekday';
@@ -413,8 +414,16 @@ export default function EditPage() {
       Recurrence_End_Date?: string;
     },
   ) => {
-    if (!id) return;
-    await addScheduleRequest(id, { Requested_Date: date, ...(recurrence ?? {}) });
+    if (!id || !submission) return;
+    await addScheduleRequest(
+      id,
+      buildEditorScheduleRequest(
+        submission.Target_Newsletter,
+        newsletter,
+        date,
+        recurrence,
+      ),
+    );
     const dateLabel = new Date(`${date}T12:00:00`).toLocaleDateString();
     const newsletterLabel = newsletter === 'tdr' ? 'Daily Register' : 'My UI';
     showToast(

--- a/frontend/src/utils/editorSchedule.test.ts
+++ b/frontend/src/utils/editorSchedule.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { buildEditorScheduleRequest } from './editorSchedule';
+
+describe('buildEditorScheduleRequest', () => {
+  it('stores a Daily Register date in the primary date field', () => {
+    expect(buildEditorScheduleRequest('both', 'tdr', '2026-05-05')).toEqual({
+      Requested_Date: '2026-05-05',
+    });
+  });
+
+  it('stores a My UI date for a both-newsletters submission in the secondary field', () => {
+    expect(buildEditorScheduleRequest('both', 'myui', '2026-05-04')).toEqual({
+      Requested_Date: null,
+      Second_Requested_Date: '2026-05-04',
+    });
+  });
+
+  it('keeps the primary field contract for a My UI-only submission', () => {
+    expect(buildEditorScheduleRequest('myui', 'myui', '2026-05-04')).toEqual({
+      Requested_Date: '2026-05-04',
+    });
+  });
+
+  it('preserves recurrence settings for the selected newsletter', () => {
+    expect(
+      buildEditorScheduleRequest('both', 'myui', '2026-05-04', {
+        Recurrence_Type: 'weekly',
+        Recurrence_Interval: 2,
+        Recurrence_End_Date: '2026-06-29',
+      }),
+    ).toEqual({
+      Requested_Date: null,
+      Second_Requested_Date: '2026-05-04',
+      Recurrence_Type: 'weekly',
+      Recurrence_Interval: 2,
+      Recurrence_End_Date: '2026-06-29',
+    });
+  });
+});

--- a/frontend/src/utils/editorSchedule.ts
+++ b/frontend/src/utils/editorSchedule.ts
@@ -1,0 +1,30 @@
+import type { AddScheduleRequestData } from '../api/submissions';
+import type { TargetNewsletter } from '../types/submission';
+
+type ScheduledNewsletter = Extract<TargetNewsletter, 'tdr' | 'myui'>;
+
+type RecurrenceData = Pick<
+  AddScheduleRequestData,
+  'Recurrence_Type' | 'Recurrence_Interval' | 'Recurrence_End_Date'
+>;
+
+/** Map an editor's newsletter choice onto the existing two-date backend contract. */
+export function buildEditorScheduleRequest(
+  targetNewsletter: TargetNewsletter,
+  newsletter: ScheduledNewsletter,
+  date: string,
+  recurrence?: RecurrenceData,
+): AddScheduleRequestData {
+  if (targetNewsletter === 'both' && newsletter === 'myui') {
+    return {
+      Requested_Date: null,
+      Second_Requested_Date: date,
+      ...(recurrence ?? {}),
+    };
+  }
+
+  return {
+    Requested_Date: date,
+    ...(recurrence ?? {}),
+  };
+}


### PR DESCRIPTION
## Summary

- honor the editor's Daily Register/My UI selection when adding run dates to a submission targeting both newsletters
- store My UI-only editor dates in `Second_Requested_Date` while preserving the existing primary-date contract for Daily Register and single-newsletter submissions
- label newsletter-specific requested dates in Submission Info and keep SLC-only items from showing newsletter scheduling controls
- expand and validate recurrence from the correct newsletter-specific date without changing existing one-time second-run behavior

## Root cause

The editor date picker already passed the selected newsletter to `EditPage`, but the handler ignored it and always submitted the chosen date as `Requested_Date`. After the both-newsletters contract was clarified, that field schedules the Daily Register side, so choosing My UI did not create an independent student-newsletter schedule.

This completes the outstanding acceptance behavior described in #65. The issue itself was previously closed by #86.

## Impact

Editors can now choose separate publication dates for Daily Register and My UI when a submission targets both newsletters. My UI selections continue to use the existing valid-date service and Monday-only schedule. No database migration is required.

## Validation

- backend: `277 passed`
- backend lint: `ruff check .`
- frontend: `81 passed`
- frontend build: `npm run build`
- frontend lint: `npm run lint`
