### PR TITLE
Fix AI enforcement of Joy's Aug. 10 editorial rules

### DIFF
--- a/backend/app/services/ai/editor.py
+++ b/backend/app/services/ai/editor.py
@@ -12,7 +12,11 @@ from app.models.style_rule import StyleRule
 from app.models.submission import Submission
 from app.models.edit_history import EditVersion
 from app.services.ai.provider import LLMProvider
-from app.services.ai.prompts import build_system_prompt, build_edit_user_prompt
+from app.services.ai.prompts import (
+    build_compliance_repair_prompt,
+    build_edit_user_prompt,
+    build_system_prompt,
+)
 from app.services.ai.diff_generator import generate_word_diff, diff_to_dict
 from app.utils.text import (
     to_sentence_case,
@@ -45,6 +49,10 @@ from app.utils.style_checks import (
     detect_missing_near_term_weekdays,
     detect_missing_protected_organizations,
     detect_missing_specific_audience_lead,
+    detect_missing_broad_audience,
+    detect_unformatted_composition_titles,
+    detect_noncanonical_campus_locations,
+    detect_missing_approved_venue_addresses,
     detect_weekday_date_mismatches,
 )
 
@@ -361,6 +369,37 @@ class AIEditor:
                     f"Specific source audience context missing from first sentence: {listed}",
                 )
 
+            for broad_audience in detect_missing_broad_audience(body_source, body):
+                add(
+                    "preserve_audience_scope",
+                    f"Broad source invitation was narrowed or removed: '{broad_audience}'",
+                )
+
+            for title in detect_unformatted_composition_titles(
+                source_text,
+                headline,
+                body,
+            ):
+                add(
+                    "composition_title_format",
+                    f"Composition title needs AP quotation formatting: '{title}'",
+                )
+
+            for location in detect_noncanonical_campus_locations(body):
+                add(
+                    "building_room_order",
+                    f"Use canonical building-before-room location: '{location}'",
+                )
+
+            for venue in detect_missing_approved_venue_addresses(
+                source_text,
+                body,
+            ):
+                add(
+                    "approved_off_campus_addresses",
+                    f"Approved venue is missing its canonical address: '{venue}'",
+                )
+
         return flags
 
     async def edit_submission(
@@ -440,13 +479,6 @@ class AIEditor:
         else:
             edited_headline = to_title_case(edited_headline)
 
-        headline_diff = diff_to_dict(
-            generate_word_diff(submission.Original_Headline, edited_headline)
-        )
-        body_diff = diff_to_dict(
-            generate_word_diff(submission.Original_Body, edited_body)
-        )
-
         source_parts = [
             submission.Original_Headline,
             submission.Original_Body,
@@ -468,6 +500,93 @@ class AIEditor:
             source_body=submission.Original_Body,
             source_comparison_output="\n".join(comparison_output_parts),
             reference_date=date.today(),
+        )
+
+        mandatory_rule_keys = {
+            rule["rule_key"]
+            for rule in style_rules
+            if rule["severity"] == "error"
+        }
+        repair_findings = [
+            flag for flag in post_flags if flag["rule_key"] in mandatory_rule_keys
+        ]
+        if repair_findings:
+            repair_prompt = build_compliance_repair_prompt(
+                user_prompt,
+                edited_headline,
+                edited_body,
+                repair_findings,
+            )
+            try:
+                repair_result = await self.llm.complete_json(
+                    system_prompt=system_prompt,
+                    user_prompt=repair_prompt,
+                    temperature=0.0,
+                    max_tokens=3000,
+                )
+            except Exception as error:
+                logger.warning(
+                    "Compliance repair failed for submission %s: %s",
+                    submission.Id,
+                    error,
+                )
+            else:
+                edited_headline = repair_result.get(
+                    "edited_headline",
+                    edited_headline,
+                )
+                edited_body = repair_result.get("edited_body", edited_body)
+                for change in repair_result.get("changes_made", []) or []:
+                    if change not in changes_made:
+                        changes_made.append(change)
+                repair_description = (
+                    "Revised draft after deterministic style-rule validation"
+                )
+                if repair_description not in changes_made:
+                    changes_made.append(repair_description)
+                ai_flags = repair_result.get("flags", [])
+                embedded_links = repair_result.get("embedded_links", [])
+                confidence = repair_result.get("confidence", confidence)
+
+                edited_body, replaced_semicolons = (
+                    enforce_no_semicolons_in_prose(edited_body)
+                    if short_sentence_rule_active
+                    else (edited_body, False)
+                )
+                if replaced_semicolons:
+                    cleanup_description = (
+                        "Replaced semicolons with periods to enforce the "
+                        "short-sentence rule"
+                    )
+                    if cleanup_description not in changes_made:
+                        changes_made.append(cleanup_description)
+
+                if headline_case == "sentence_case":
+                    edited_headline = to_sentence_case(edited_headline)
+                else:
+                    edited_headline = to_title_case(edited_headline)
+
+                comparison_output_parts = [edited_headline, edited_body]
+                for link in embedded_links:
+                    comparison_output_parts.extend(
+                        [str(link.get("url", "")), str(link.get("anchor_text", ""))]
+                    )
+                post_flags = self.post_analyze(
+                    edited_headline,
+                    edited_body,
+                    submission.Category,
+                    style_rules,
+                    source_text="\n".join(source_parts),
+                    source_body=submission.Original_Body,
+                    source_comparison_output="\n".join(comparison_output_parts),
+                    reference_date=date.today(),
+                )
+
+        headline_diff = diff_to_dict(
+            generate_word_diff(submission.Original_Headline, edited_headline)
+        )
+        body_diff = diff_to_dict(
+            generate_word_diff(submission.Original_Body, edited_body)
         )
 
         all_flags = pre_flags + ai_flags + post_flags

--- a/backend/app/services/ai/prompts.py
+++ b/backend/app/services/ai/prompts.py
@@ -216,3 +216,39 @@ Notes on the response:
 """
 
     return prompt
+
+
+def build_compliance_repair_prompt(
+    original_user_prompt: str,
+    edited_headline: str,
+    edited_body: str,
+    findings: list[dict],
+) -> str:
+    """Build one constrained repair request from deterministic rule findings."""
+    finding_lines = "\n".join(
+        f"- [{finding['rule_key']}] {finding['message']}"
+        for finding in findings
+    )
+    return f"""{original_user_prompt}
+
+## Deterministic compliance findings
+
+Your first draft was checked against active mandatory style rules and needs one
+repair pass.
+
+**Draft headline:** {edited_headline}
+
+**Draft body:**
+{edited_body}
+
+Correct every finding below while preserving all source facts, links, audience,
+purpose, contact information and official titles. Do not add facts except the
+canonical expansions or addresses explicitly authorized by an active rule.
+
+{finding_lines}
+
+Return the complete corrected JSON object in the required response format. Do
+not discuss the findings outside the JSON. If a finding cannot be corrected
+without inventing a fact, preserve the source wording and return a flag naming
+that rule.
+"""

--- a/backend/app/utils/style_checks.py
+++ b/backend/app/utils/style_checks.py
@@ -7,9 +7,10 @@ active in the prompt at the time. The detectors here cover the subset of those
 rules that can be verified mechanically — AP month abbreviation, a.m./p.m.
 formatting, platform names, undefined acronyms, repeated calls to action and
 the Jobs single-line contract, plus high-confidence source contacts,
-organizations, titles, audience qualifiers, information paths, promotional
-leads and anchored requirements — so a violation surfaces as a flag on the AI
-version regardless of whether the model honored the prompt.
+organizations, titles, audience qualifiers, composition titles, canonical
+locations, information paths, promotional leads and anchored requirements —
+so a violation surfaces as a flag on the AI version regardless of whether the
+model honored the prompt.
 
 Each detector is a pure function over edited text and returns the offending
 fragments. Mapping findings to flags (and gating on whether the corresponding
@@ -40,7 +41,7 @@ _ROMAN_NUMERAL = re.compile(r"^[IVXLCDM]+$")
 # Acronyms AP or campus usage treats as standing on their own.
 _KNOWN_ACRONYMS = {
     "AP", "US", "USA", "TDR", "RSVP", "GPA", "ID", "PDF", "FAQ", "HR", "IT",
-    "TV", "AV", "GED", "ADA", "FYI", "AM", "PM",
+    "TV", "AV", "GED", "ADA", "FYI", "AM", "PM", "ISUB", "IRIC",
 }
 
 _CTA_PHRASES = ("register", "sign up", "enroll", "rsvp", "apply", "learn more")
@@ -124,6 +125,52 @@ _PARENTHETICAL_CONTACT_TITLE = re.compile(
     r"\((?P<title>[A-Za-z][A-Za-z'’&/.-]*"
     r"(?:\s+[A-Za-z'’&/.-]+){0,8})\)"
 )
+_COMMA_CONTACT_TITLE = re.compile(
+    r"\b(?P<name>[A-Z][A-Za-z'’.-]+"
+    r"(?:\s+[A-Z][A-Za-z'’.-]+){1,3})\s*,\s*"
+    r"(?P<title>[A-Z][A-Za-z'’/-]*"
+    r"(?:\s+(?:&|[A-Z][A-Za-z'’&/-]*)){1,10})"
+)
+_BROAD_AUDIENCE_PHRASES = (
+    ("all are welcome", re.compile(r"\ball\s+are\s+welcome\b", re.IGNORECASE)),
+    (
+        "everyone is invited",
+        re.compile(r"\beveryone\s+is\s+invited\b", re.IGNORECASE),
+    ),
+    (
+        "the public is welcome",
+        re.compile(r"\bthe\s+public\s+is\s+welcome\b", re.IGNORECASE),
+    ),
+)
+_DIRECT_INVITATION_LEAD = re.compile(
+    r"^(?:Attend|Join|Visit|Watch|Come|Participate|Register|Explore|Learn)\b",
+    re.IGNORECASE,
+)
+_COMPOSITION_CUE = re.compile(
+    r"\b(?:book|exhibit|exhibition|film|horror|lecture|movie|opera|play|poem|"
+    r"reading|screening|song|speech|work\s+of\s+art)\b",
+    re.IGNORECASE,
+)
+_QUOTED_TEXT = re.compile(r"[\"“](?P<title>[^\"”]{2,100})[\"”]")
+_TITLE_CASE_SPAN = re.compile(
+    r"\b[A-Z][A-Za-z0-9'’.-]*(?:\s+(?:in|of|the|and|&)?\s*"
+    r"[A-Z][A-Za-z0-9'’.-]*){0,5}\b"
+)
+_CANONICAL_CAMPUS_LOCATIONS = (
+    "ISUB Reflections Gallery",
+    "Bruce M. Pitman Center International Ballroom",
+    "IRIC 352",
+)
+_APPROVED_VENUE_ADDRESSES = {
+    "Kenworthy Performing Arts Centre": "508 S. Main St.",
+    "1912 Center": "412 E. Third St.",
+    "One World Cafe": "840 W. Seventh St.",
+    "Hunga Dunga Brewing Co.": "333 N. Jackson St.",
+    "Moscow Public Library": "110 S. Jefferson St.",
+    "Palouse-Clearwater Environmental Institute": "1040 Rodeo Drive",
+    "Best Western Plus University Inn": "1516 W. Pullman Road",
+    "East City Park": "900 E. Third St.",
+}
 _INFORMATION_OPTION = re.compile(
     r"\b(?:learn\s+more|more\s+information|additional\s+information|"
     r"(?:get|request|find)\s+(?:more|additional)\s+information|"
@@ -310,6 +357,108 @@ def detect_missing_specific_audience_lead(
     return findings
 
 
+def detect_missing_broad_audience(source_body: str, edited_body: str) -> list[str]:
+    """Find a broad invitation narrowed or removed from the edited lead.
+
+    A direct imperative such as ``Attend the reception`` preserves open access
+    without repeating ``all are welcome``. Audience-prefixed rewrites such as
+    ``Employees are invited`` do not.
+    """
+    source = strip_html(source_body)
+    edited_lead = _first_sentence(edited_body)
+    findings: list[str] = []
+
+    for display, pattern in _BROAD_AUDIENCE_PHRASES:
+        if not pattern.search(source):
+            continue
+        if pattern.search(edited_lead) or _DIRECT_INVITATION_LEAD.search(edited_lead):
+            continue
+        findings.append(display)
+
+    return findings
+
+
+def _composition_titles(source_text: str) -> list[str]:
+    """Extract high-confidence composition titles from source copy."""
+    source = strip_html(source_text)
+    titles: list[str] = []
+
+    for match in _QUOTED_TEXT.finditer(source):
+        context = source[max(0, match.start() - 100):match.end() + 100]
+        if not _COMPOSITION_CUE.search(context):
+            continue
+        title = match.group("title").strip().rstrip(",.;:!?")
+        if title and title not in titles:
+            titles.append(title)
+
+    for match in _TITLE_CASE_SPAN.finditer(source):
+        title = match.group().strip()
+        if title in titles or len(title) < 3:
+            continue
+        context = source[max(0, match.start() - 45):match.start()]
+        if not _COMPOSITION_CUE.search(context):
+            continue
+        if len(re.findall(rf"\b{re.escape(title)}\b", source)) < 2:
+            continue
+        titles.append(title)
+
+    return titles
+
+
+def detect_unformatted_composition_titles(
+    source_text: str,
+    edited_headline: str,
+    edited_body: str,
+) -> list[str]:
+    """Find source composition titles lacking AP quotation treatment."""
+    findings: list[str] = []
+    for title in _composition_titles(source_text):
+        escaped = re.escape(title)
+        headline_quoted = re.search(
+            rf"(?:'{escaped}'|‘{escaped}’)",
+            edited_headline,
+            re.IGNORECASE,
+        )
+        body_quoted = re.search(
+            rf'(?:"{escaped}"|“{escaped}”)',
+            strip_html(edited_body),
+            re.IGNORECASE,
+        )
+        if not headline_quoted or not body_quoted:
+            findings.append(title)
+    return findings
+
+
+def detect_noncanonical_campus_locations(edited_text: str) -> list[str]:
+    """Find known campus locations whose building/room order is not canonical."""
+    visible = re.sub(r"[^a-z0-9]+", " ", strip_html(edited_text).casefold()).strip()
+    findings: list[str] = []
+    for canonical in _CANONICAL_CAMPUS_LOCATIONS:
+        normalized = re.sub(r"[^a-z0-9]+", " ", canonical.casefold()).strip()
+        tokens = normalized.split()
+        if all(re.search(rf"\b{re.escape(token)}\b", visible) for token in tokens):
+            if normalized not in visible:
+                findings.append(canonical)
+    return findings
+
+
+def detect_missing_approved_venue_addresses(
+    source_text: str,
+    edited_text: str,
+) -> list[str]:
+    """Find approved venues whose canonical address is absent from the edit."""
+    source = strip_html(source_text)
+    edited = strip_html(edited_text)
+    findings: list[str] = []
+    for venue, address in _APPROVED_VENUE_ADDRESSES.items():
+        if venue not in source and venue not in edited:
+            continue
+        canonical = f"{venue}, {address}"
+        if canonical not in edited:
+            findings.append(canonical)
+    return findings
+
+
 def _contact_channels(text: str) -> dict[str, str]:
     """Return normalized contact channels while preserving report-friendly text."""
     channels = {match.group().lower(): match.group() for match in _EMAIL.finditer(text)}
@@ -395,12 +544,16 @@ def detect_missing_protected_organizations(
 
 
 def detect_missing_contact_titles(source_text: str, edited_text: str) -> list[str]:
-    """Find parenthetical source contact titles missing after the contact name."""
+    """Find parenthetical or comma-style source contact titles missing in edits."""
     source = strip_html(source_text)
     edited = re.sub(r"\s+", " ", strip_html(edited_text)).strip()
     findings: list[str] = []
 
-    for match in _PARENTHETICAL_CONTACT_TITLE.finditer(source):
+    matches = [
+        *_PARENTHETICAL_CONTACT_TITLE.finditer(source),
+        *_COMMA_CONTACT_TITLE.finditer(source),
+    ]
+    for match in matches:
         nearby_before = source[max(0, match.start() - 80):match.start()]
         nearby_after = source[match.end():match.end() + 160]
         name_with_cue = match.group("name")

--- a/backend/tests/fixtures/joy_august_10_editorial.json
+++ b/backend/tests/fixtures/joy_august_10_editorial.json
@@ -1,0 +1,64 @@
+[
+  {
+    "id": "e51952c7-ae0f-48ab-ba97-88ec18fc401a",
+    "name": "nnsa_fellowship",
+    "category": "faculty_staff",
+    "source_headline": "NNSA Graduate Fellowship Info Session",
+    "source_body": "The Nuclear Engineering and Industrial Management department invites graduate students and interested faculty and staff to attend an information session about the prestigious National Nuclear Security Administration Graduate Fellowship Program. The session will be held on Wednesday, September 2 at 11am (PT). The fellowship offers real world experience and specialized training for the next generation of national security leaders. The deadline to apply for the fellowships which begin in June 2027, is October 2, 2026. To register for the session and receive the Zoom link, go to https://pnnl.zoomgov.com/webinar/register/WN_4vED_kG5TvCYcQhqsE20RQ",
+    "edited_headline": "Register for NNSA Graduate Fellowship Info Session",
+    "edited_body": "Register for the NNSA Graduate Fellowship Info Session at 11 a.m. Wednesday, Sept. 2, online. The Nuclear Engineering and Industrial Management department invites graduate students, faculty and staff to learn about the National Nuclear Security Administration Graduate Fellowship Program. The fellowship provides real-world experience and specialized training for the next generation of national security leaders. Applications open for fellowships beginning June 2027 and must be submitted by October 2. To register and receive the Zoom link, <a href=\"https://example.com/register\">Register</a>.",
+    "compliant_headline": "Learn about the NNSA graduate fellowship",
+    "compliant_body": "The Nuclear Engineering and Industrial Management department invites graduate students, faculty and staff to learn about the National Nuclear Security Administration (NNSA) Graduate Fellowship Program at 11 a.m. Wednesday, Sept. 2, online. The fellowship provides real-world experience and specialized training for the next generation of national security leaders. Applications for fellowships beginning June 2027 must be submitted by Oct. 2. <a href=\"https://example.com/register\">Register for the information session</a>.",
+    "expected_rule_keys": [
+      "ap_style_dates",
+      "online_not_platform",
+      "spell_out_acronyms",
+      "single_cta"
+    ]
+  },
+  {
+    "id": "6634446a-b615-49a5-b3f3-9a7f94d386a1",
+    "name": "echoes_in_black",
+    "category": "faculty_staff",
+    "source_headline": "Join the Opening Reception for Jung Min's Echoes in Black Exhibit",
+    "source_body": "All are welcome to attend the opening reception for Las Vegas-based Korean artist Jung Min's exhibit \"Echoes in Black,\" from 4-6 PM, on Wednesday, August 26, in Reflections Gallery, ISUB. The exhibit is a part of the Habib Institute for Asian Studies' AsiaPOP! Dark symposium. Refreshments will be served and an artist's talk begins about 5 PM.",
+    "edited_headline": "Attend opening reception for Jung Min's Echoes in Black exhibit",
+    "edited_body": "Employees are invited to attend the opening reception for Jung Min's Echoes in Black exhibit. The reception runs 4-6 p.m. Wednesday, Aug. 26, in Reflections Gallery, ISUB. The exhibit is part of the Habib Institute for Asian Studies' AsiaPOP! Dark symposium. Refreshments will be served. An artist talk begins at 5 p.m.",
+    "compliant_headline": "Attend opening reception for Jung Min's 'Echoes in Black' exhibit",
+    "compliant_body": "Attend the opening reception for Jung Min's \"Echoes in Black\" exhibit. The reception runs 4-6 p.m. Wednesday, Aug. 26, in the ISUB Reflections Gallery. The exhibit is part of the Habib Institute for Asian Studies' AsiaPOP! Dark symposium. Refreshments will be served. An artist talk begins at 5 p.m.",
+    "expected_rule_keys": [
+      "preserve_audience_scope",
+      "composition_title_format",
+      "building_room_order"
+    ]
+  },
+  {
+    "id": "4b2ebe88-9aa1-45fe-bc41-002921b07016",
+    "name": "tumbbad_screening",
+    "category": "student",
+    "source_headline": "Attend a free screening of the Indian folk horror Tumbbad",
+    "source_body": "Come, if you dare, to see the hit folk horror Tumbbad (Barve and Gandhi, 2018) when it shows for free at the Kenworthy Performing Arts Centre at 7 PM on Tuesday, August 25, as a part of the AsiaPOP! Dark symposium. When Vinayak Rao learns how to extract treasure buried deep in a temple to a cursed god, he thinks he is destined for a life of ease. Will his greed and the curse destroy his family in the process? Atmospheric throughout and punctuated with strikingly horrific images, Tumbbad premiered to much acclaim at the Venice International Film Festival. In Hindi with English subtitles.",
+    "edited_headline": "Watch free screening of Tumbbad",
+    "edited_body": "Watch the free screening of the Indian folk horror Tumbbad at 7 p.m. Tuesday, Aug. 25, in the Kenworthy Performing Arts Centre as part of the AsiaPOP! Dark symposium. The film follows Vinayak Rao as he learns to extract treasure from a cursed god's temple and faces the consequences of his greed. The movie, which premiered at the Venice International Film Festival, is presented in Hindi with English subtitles.",
+    "compliant_headline": "Watch free screening of 'Tumbbad'",
+    "compliant_body": "Watch the free screening of the Indian folk horror film \"Tumbbad\" at 7 p.m. Tuesday, Aug. 25, in the Kenworthy Performing Arts Centre, 508 S. Main St., as part of the AsiaPOP! Dark symposium. The film follows Vinayak Rao as he learns to extract treasure from a cursed god's temple and faces the consequences of his greed. The movie, which premiered to acclaim at the Venice International Film Festival, is presented in Hindi with English subtitles.",
+    "expected_rule_keys": [
+      "composition_title_format",
+      "approved_off_campus_addresses"
+    ]
+  },
+  {
+    "id": "ca96b8fd-a934-4e5d-8b30-b8af0caf17f0",
+    "name": "education_abroad_classroom_visit",
+    "category": "faculty_staff",
+    "source_headline": "Request a Classroom Visit from Education Abroad",
+    "source_body": "The International Programs Office is offering classroom visits ahead of the Education Abroad Fair on Sept. 9 to promote the event and study abroad opportunities in general. Faculty are encouraged to schedule class time for a representative to come and share information with students. To schedule a time, email Laurel Meyer, Education Abroad Advisor & Outreach/Marketing Coordinator. Email: laurelm@uidaho.edu",
+    "edited_headline": "Request a classroom visit from Education Abroad",
+    "edited_body": "Faculty can request a classroom visit from the International Programs Office to promote the Education Abroad Fair on Sept. 9. The visit allows a representative to share study-abroad information with students. To schedule, email <a href='mailto:laurelm@uidaho.edu'>Laurel Meyer</a>.",
+    "compliant_headline": "Request a classroom visit from Education Abroad",
+    "compliant_body": "The International Programs Office offers classroom visits ahead of the Education Abroad Fair on Wednesday, Sept. 9, to promote the event and study-abroad opportunities. Faculty can schedule class time for a representative to share information with students. To schedule, email <a href='mailto:laurelm@uidaho.edu'>Laurel Meyer</a>, education abroad advisor & outreach/marketing coordinator.",
+    "expected_rule_keys": [
+      "preserve_purpose_contact_titles"
+    ]
+  }
+]

--- a/backend/tests/test_ai_prompts.py
+++ b/backend/tests/test_ai_prompts.py
@@ -1,6 +1,6 @@
 """Focused tests for deterministic AI system-prompt contracts."""
 
-from app.services.ai.prompts import build_system_prompt
+from app.services.ai.prompts import build_compliance_repair_prompt, build_system_prompt
 
 
 def test_system_prompt_requires_a_final_rule_compliance_audit():
@@ -78,3 +78,24 @@ def test_jobs_guidance_line_is_embedded_cleanly_for_jobs_submissions():
     )
 
     assert "precedence over generic length and structure guidance.\n- Collapse bullet lists" in prompt
+
+
+def test_compliance_repair_prompt_includes_draft_and_deterministic_findings():
+    prompt = build_compliance_repair_prompt(
+        "Original editing request",
+        "Attend Tumbbad",
+        "Watch Tumbbad at the Kenworthy.",
+        [
+            {
+                "rule_key": "composition_title_format",
+                "message": "Composition title needs AP quotation formatting: 'Tumbbad'",
+            }
+        ],
+    )
+
+    assert "Original editing request" in prompt
+    assert "Deterministic compliance findings" in prompt
+    assert "**Draft headline:** Attend Tumbbad" in prompt
+    assert "[composition_title_format]" in prompt
+    assert "needs one" in prompt
+    assert "repair pass" in prompt

--- a/backend/tests/test_issue_300_production_fixtures.py
+++ b/backend/tests/test_issue_300_production_fixtures.py
@@ -1,0 +1,228 @@
+"""Production-derived regression fixtures for Joy's Aug. 10 feedback (#300)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.models.submission import Submission
+from app.services.ai.editor import AIEditor
+
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "joy_august_10_editorial.json"
+SEED_PATH = Path(__file__).parents[1] / "data" / "style_rules" / "shared_rules.json"
+
+
+class UnusedProvider:
+    """Provider placeholder for exercising deterministic post-validation."""
+
+
+class RepairSequenceProvider:
+    """Return a reported bad draft, then the corresponding compliant repair."""
+
+    model = "fixture-model"
+
+    def __init__(self, fixture: dict):
+        self.fixture = fixture
+        self.prompts: list[str] = []
+
+    async def complete_json(self, **kwargs):
+        self.prompts.append(kwargs["user_prompt"])
+        prefix = "edited" if len(self.prompts) == 1 else "compliant"
+        return {
+            "edited_headline": self.fixture[f"{prefix}_headline"],
+            "edited_body": self.fixture[f"{prefix}_body"],
+            "changes_made": [],
+            "flags": [],
+            "embedded_links": [],
+            "confidence": 0.9,
+        }
+
+
+class FailedRepairProvider(RepairSequenceProvider):
+    """Return the reported bad draft, then simulate a provider failure."""
+
+    async def complete_json(self, **kwargs):
+        if self.prompts:
+            self.prompts.append(kwargs["user_prompt"])
+            raise RuntimeError("repair unavailable")
+        return await super().complete_json(**kwargs)
+
+
+class StubbornProvider(RepairSequenceProvider):
+    """Return the same noncompliant draft for the initial and repair calls."""
+
+    async def complete_json(self, **kwargs):
+        self.prompts.append(kwargs["user_prompt"])
+        return {
+            "edited_headline": self.fixture["edited_headline"],
+            "edited_body": self.fixture["edited_body"],
+            "changes_made": [],
+            "flags": [],
+            "embedded_links": [],
+            "confidence": 0.5,
+        }
+
+
+def load_fixtures() -> list[dict]:
+    return json.loads(FIXTURE_PATH.read_text())
+
+
+def load_active_rules() -> list[dict]:
+    return [
+        {
+            "category": rule["category"],
+            "rule_key": rule["rule_key"],
+            "rule_text": rule["rule_text"],
+            "severity": rule["severity"],
+        }
+        for rule in json.loads(SEED_PATH.read_text())
+    ]
+
+
+@pytest.mark.parametrize("fixture", load_fixtures(), ids=lambda item: item["name"])
+def test_reported_noncompliant_edits_are_detected(fixture: dict):
+    editor = AIEditor(UnusedProvider())
+    flags = editor.post_analyze(
+        fixture["edited_headline"],
+        fixture["edited_body"],
+        fixture["category"],
+        load_active_rules(),
+        source_text=f'{fixture["source_headline"]}\n{fixture["source_body"]}',
+        source_body=fixture["source_body"],
+    )
+
+    flagged_rules = {flag["rule_key"] for flag in flags}
+    assert set(fixture["expected_rule_keys"]).issubset(flagged_rules)
+
+
+def test_ignored_active_rule_is_distinct_from_missing_rule():
+    fixture = next(
+        item for item in load_fixtures() if item["name"] == "tumbbad_screening"
+    )
+    active_rules = load_active_rules()
+    editor = AIEditor(UnusedProvider())
+
+    active_flags = editor.post_analyze(
+        fixture["edited_headline"],
+        fixture["edited_body"],
+        fixture["category"],
+        active_rules,
+        source_text=f'{fixture["source_headline"]}\n{fixture["source_body"]}',
+        source_body=fixture["source_body"],
+    )
+    without_address_rule = [
+        rule
+        for rule in active_rules
+        if rule["rule_key"] != "approved_off_campus_addresses"
+    ]
+    missing_rule_flags = editor.post_analyze(
+        fixture["edited_headline"],
+        fixture["edited_body"],
+        fixture["category"],
+        without_address_rule,
+        source_text=f'{fixture["source_headline"]}\n{fixture["source_body"]}',
+        source_body=fixture["source_body"],
+    )
+
+    assert "approved_off_campus_addresses" in {
+        flag["rule_key"] for flag in active_flags
+    }
+    assert "approved_off_campus_addresses" not in {
+        flag["rule_key"] for flag in missing_rule_flags
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fixture", load_fixtures(), ids=lambda item: item["name"])
+async def test_active_must_rule_violations_trigger_one_compliance_repair(fixture: dict):
+    provider = RepairSequenceProvider(fixture)
+    editor = AIEditor(provider)
+
+    async def load_fixture_rules(*_args, **_kwargs):
+        return load_active_rules()
+
+    editor.load_style_rules = load_fixture_rules
+    submission = Submission(
+        Id=fixture["id"],
+        Category=fixture["category"],
+        Target_Newsletter="myui" if fixture["category"] == "student" else "tdr",
+        Original_Headline=fixture["source_headline"],
+        Original_Body=fixture["source_body"],
+        Submitter_Name="Production fixture",
+        Submitter_Email="fixture@example.edu",
+        Links=[],
+    )
+
+    result = await editor.edit_submission(
+        None,
+        submission,
+        submission.Target_Newsletter,
+    )
+
+    assert len(provider.prompts) == 2
+    assert "Deterministic compliance findings" in provider.prompts[1]
+    assert result.edited_headline == fixture["compliant_headline"]
+    assert result.edited_body == fixture["compliant_body"]
+    assert not (
+        set(fixture["expected_rule_keys"])
+        & {flag["rule_key"] for flag in result.flags}
+    )
+
+
+def make_submission(fixture: dict) -> Submission:
+    return Submission(
+        Id=fixture["id"],
+        Category=fixture["category"],
+        Target_Newsletter="myui" if fixture["category"] == "student" else "tdr",
+        Original_Headline=fixture["source_headline"],
+        Original_Body=fixture["source_body"],
+        Submitter_Name="Production fixture",
+        Submitter_Email="fixture@example.edu",
+        Links=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_repair_preserves_initial_draft_and_findings():
+    fixture = load_fixtures()[0]
+    provider = FailedRepairProvider(fixture)
+    editor = AIEditor(provider)
+
+    async def load_fixture_rules(*_args, **_kwargs):
+        return load_active_rules()
+
+    editor.load_style_rules = load_fixture_rules
+    result = await editor.edit_submission(
+        None,
+        make_submission(fixture),
+        "tdr",
+    )
+
+    assert len(provider.prompts) == 2
+    assert result.edited_body == fixture["edited_body"]
+    assert set(fixture["expected_rule_keys"]).issubset(
+        {flag["rule_key"] for flag in result.flags}
+    )
+
+
+@pytest.mark.asyncio
+async def test_noncompliant_repair_is_not_retried_indefinitely():
+    fixture = load_fixtures()[0]
+    provider = StubbornProvider(fixture)
+    editor = AIEditor(provider)
+
+    async def load_fixture_rules(*_args, **_kwargs):
+        return load_active_rules()
+
+    editor.load_style_rules = load_fixture_rules
+    result = await editor.edit_submission(
+        None,
+        make_submission(fixture),
+        "tdr",
+    )
+
+    assert len(provider.prompts) == 2
+    assert set(fixture["expected_rule_keys"]).issubset(
+        {flag["rule_key"] for flag in result.flags}
+    )

--- a/backend/tests/test_style_checks.py
+++ b/backend/tests/test_style_checks.py
@@ -18,6 +18,10 @@ from app.utils.style_checks import (
     detect_missing_contact_titles,
     detect_missing_information_options,
     detect_missing_protected_organizations,
+    detect_missing_broad_audience,
+    detect_unformatted_composition_titles,
+    detect_noncanonical_campus_locations,
+    detect_missing_approved_venue_addresses,
     detect_missing_specific_audience_lead,
     detect_missing_source_contacts,
     detect_new_contact_channels,
@@ -249,6 +253,29 @@ class TestSourceFidelity:
 
         assert detect_missing_contact_titles(source, edited) == []
 
+    def test_flags_removed_comma_style_contact_title(self):
+        source = (
+            "To schedule, email Laurel Meyer, Education Abroad Advisor & "
+            "Outreach/Marketing Coordinator. Email: laurelm@uidaho.edu"
+        )
+        edited = "To schedule, email Laurel Meyer at laurelm@uidaho.edu."
+
+        assert detect_missing_contact_titles(source, edited) == [
+            "Laurel Meyer, education abroad advisor & outreach/marketing coordinator"
+        ]
+
+    def test_accepts_comma_style_contact_title_preserved_after_name(self):
+        source = (
+            "Email Laurel Meyer, Education Abroad Advisor & Outreach/Marketing "
+            "Coordinator, at laurelm@uidaho.edu."
+        )
+        edited = (
+            "Email Laurel Meyer, education abroad advisor & outreach/marketing "
+            "coordinator, at laurelm@uidaho.edu."
+        )
+
+        assert detect_missing_contact_titles(source, edited) == []
+
     def test_does_not_treat_parenthetical_name_or_acronym_as_contact_title(self):
         source = "The University of Idaho (U of I) hosts the event."
 
@@ -307,6 +334,65 @@ class TestSourceFidelity:
         edited = "Event staff assist participants."
 
         assert detect_missing_specific_audience_lead(source, edited) == []
+
+    def test_flags_broad_invitation_narrowed_to_employees(self):
+        source = "All are welcome to attend the gallery reception."
+        edited = "Employees are invited to attend the gallery reception."
+
+        assert detect_missing_broad_audience(source, edited) == ["all are welcome"]
+
+    def test_accepts_direct_invitation_for_broad_audience(self):
+        source = "All are welcome to attend the gallery reception."
+        edited = "Attend the gallery reception from 4-6 p.m. Wednesday."
+
+        assert detect_missing_broad_audience(source, edited) == []
+
+
+class TestCompositionAndLocations:
+    def test_flags_unquoted_composition_title_in_headline_and_body(self):
+        source = 'Attend a screening of the film "Tumbbad."'
+
+        assert detect_unformatted_composition_titles(
+            source,
+            "Watch a screening of Tumbbad",
+            "Watch the film Tumbbad at 7 p.m.",
+        ) == ["Tumbbad"]
+
+    def test_accepts_ap_quotes_for_composition_title(self):
+        source = 'Attend a screening of the film "Tumbbad."'
+
+        assert detect_unformatted_composition_titles(
+            source,
+            "Watch a screening of 'Tumbbad'",
+            'Watch the film "Tumbbad" at 7 p.m.',
+        ) == []
+
+    def test_flags_room_before_known_campus_building(self):
+        assert detect_noncanonical_campus_locations(
+            "The reception is in Reflections Gallery, ISUB."
+        ) == ["ISUB Reflections Gallery"]
+
+    def test_accepts_canonical_building_before_room(self):
+        assert detect_noncanonical_campus_locations(
+            "The reception is in the ISUB Reflections Gallery."
+        ) == []
+
+    def test_flags_missing_approved_off_campus_address(self):
+        source = "The film is at the Kenworthy Performing Arts Centre."
+        edited = "Watch the film at the Kenworthy Performing Arts Centre."
+
+        assert detect_missing_approved_venue_addresses(source, edited) == [
+            "Kenworthy Performing Arts Centre, 508 S. Main St."
+        ]
+
+    def test_accepts_approved_off_campus_address(self):
+        source = "The film is at the Kenworthy Performing Arts Centre."
+        edited = (
+            "Watch the film at the Kenworthy Performing Arts Centre, "
+            "508 S. Main St."
+        )
+
+        assert detect_missing_approved_venue_addresses(source, edited) == []
 
 
 class TestWeekdayDateConsistency:


### PR DESCRIPTION
## Summary

- add production-derived regression fixtures for the four AI edits reported in #300
- deterministically detect narrowed broad invitations, missing composition-title quotes, noncanonical campus locations, missing approved venue addresses and removed comma-style contact titles
- run one bounded LLM compliance-repair pass when an active mandatory rule is violated
- preserve the initial draft and visible findings when repair fails, and never retry indefinitely

## Root cause

The Aug. 10 style rules were present, active and deployed, but prompt instructions alone did not reliably make the model follow them. Several requirements also lacked deterministic post-edit checks, so ignored active rules could not be distinguished from missing rules or corrected before staff review.

## Impact

The editor now checks the reported rule violations after generation and gives the model one constrained opportunity to repair them. Unresolved violations remain visible to staff, preserving the existing review workflow.

## Validation

- `cd backend && ./.venv/bin/pytest -q` — 299 passed
- `cd backend && ./.venv/bin/ruff check .`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- Alembic reports one migration head

Closes #300
