### PR TITLE
Complete the dedicated jobs workflow

### DIFF
--- a/backend/alembic/versions/b5d7f9a1c3e4_finalize_jobs_workflow.py
+++ b/backend/alembic/versions/b5d7f9a1c3e4_finalize_jobs_workflow.py
@@ -1,0 +1,61 @@
+"""place the completed Jobs workflow at the bottom of TDR
+
+Revision ID: b5d7f9a1c3e4
+Revises: a4c6e8f0b2d3
+Create Date: 2026-08-19 16:00:00.000000
+
+Issue #197 requires Job Opportunities to be a dedicated section at the bottom
+of The Daily Register. The section already exists, so this focused data
+migration updates only its order and provider-neutral description. It is
+idempotent and leaves staff-created sections untouched.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b5d7f9a1c3e4"
+down_revision: str | Sequence[str] | None = "a4c6e8f0b2d3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+JOB_SECTION_DISPLAY_ORDER = 11
+JOB_SECTION_DESCRIPTION = (
+    "Jobs posted for two weeks from the official U of I jobs source. Can repost "
+    "after two-week removal. Newest at top. Must be listed with HR."
+)
+
+
+newsletter_sections = sa.table(
+    "newsletter_sections",
+    sa.column("Newsletter_Type", sa.String(50)),
+    sa.column("Slug", sa.String(255)),
+    sa.column("Display_Order", sa.Integer),
+    sa.column("Description", sa.Text),
+)
+
+
+def _apply_jobs_section_update(connection: sa.Connection) -> None:
+    connection.execute(
+        newsletter_sections.update()
+        .where(
+            newsletter_sections.c.Newsletter_Type == "tdr",
+            newsletter_sections.c.Slug == "job-opportunities",
+        )
+        .values(
+            Display_Order=JOB_SECTION_DISPLAY_ORDER,
+            Description=JOB_SECTION_DESCRIPTION,
+        )
+    )
+
+
+def upgrade() -> None:
+    _apply_jobs_section_update(op.get_bind())
+
+
+def downgrade() -> None:
+    # Staff may reorder sections after deployment; do not overwrite that choice.
+    pass

--- a/backend/app/api/v1/newsletters.py
+++ b/backend/app/api/v1/newsletters.py
@@ -404,7 +404,7 @@ async def add_job_posting(
         source_url=posting.url,
         event_start=None,
         event_end=None,
-        location=posting.location,
+        location=job_posting_service.format_job_location(posting.location),
         final_headline=job_posting_service.build_job_headline(posting),
         final_body=job_posting_service.build_job_body(posting),
     )

--- a/backend/app/api/v1/submissions.py
+++ b/backend/app/api/v1/submissions.py
@@ -1,5 +1,5 @@
 import os
-from datetime import date
+from datetime import date, timedelta
 
 from fastapi import APIRouter, Depends, File, Header, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse
@@ -28,6 +28,8 @@ from app.services.image_service import (
 )
 
 router = APIRouter(prefix="/submissions", tags=["submissions"])
+
+JOB_LISTING_RUN_DAYS = 14
 
 
 def _to_submission_response(
@@ -64,13 +66,49 @@ def _to_submission_list_response(
 def _ensure_staff_only_recurrence(
     submission_role: SubmitterRole,
     schedule_request: ScheduleRequestCreate,
+    category: str,
 ) -> None:
     is_recurring = schedule_request.Recurrence_Type != "once"
-    if is_recurring and submission_role != "staff":
+    is_public_job_window = (
+        category == "job_opportunity"
+        and schedule_request.Recurrence_Type == "date_range"
+    )
+    if is_recurring and submission_role != "staff" and not is_public_job_window:
         raise HTTPException(
             status_code=403,
             detail="Recurring scheduling is available to staff editors only.",
         )
+
+
+def _apply_job_schedule_policy(
+    category: str,
+    target_newsletter: str,
+    schedule_request: ScheduleRequestCreate,
+) -> None:
+    """Normalize every Jobs request to one listing window of at most two weeks."""
+    if category != "job_opportunity":
+        return
+    if target_newsletter != "tdr":
+        raise HTTPException(
+            status_code=422,
+            detail="Job opportunities are published in The Daily Register only.",
+        )
+
+    schedule_request.Second_Requested_Date = None
+    schedule_request.Repeat_Count = 1
+    schedule_request.Recurrence_Type = "date_range"
+    schedule_request.Recurrence_Interval = 1
+    if schedule_request.Requested_Date is None:
+        return
+
+    last_policy_date = schedule_request.Requested_Date + timedelta(
+        days=JOB_LISTING_RUN_DAYS - 1
+    )
+    if (
+        schedule_request.Recurrence_End_Date is None
+        or schedule_request.Recurrence_End_Date > last_policy_date
+    ):
+        schedule_request.Recurrence_End_Date = last_policy_date
 
 
 def _ensure_staff_only_editorial_fields(
@@ -138,8 +176,14 @@ async def create_submission(
             status_code=422,
             detail="Announcement type is not available for this submitter role.",
         )
+    if data.Category == "job_opportunity" and len(data.Schedule_Requests) != 1:
+        raise HTTPException(
+            status_code=422,
+            detail="Job opportunities require exactly one preferred start date.",
+        )
     for sched in data.Schedule_Requests:
-        _ensure_staff_only_recurrence(submission_role, sched)
+        _apply_job_schedule_policy(data.Category, data.Target_Newsletter, sched)
+        _ensure_staff_only_recurrence(submission_role, sched, data.Category)
         await _validate_schedule_request(db, data.Target_Newsletter, sched)
     submission = await submission_service.create_submission(db, data)
     return _to_submission_response(submission, submission_role)
@@ -270,8 +314,21 @@ async def add_schedule_request(
     submission = await submission_service.get_submission(db, submission_id)
     if not submission:
         raise HTTPException(status_code=404, detail="Submission not found")
+    if submission.Category == "job_opportunity" and submission.Schedule_Requests:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Job opportunities have one listing window. Update the existing "
+                "schedule instead of adding another."
+            ),
+        )
 
-    _ensure_staff_only_recurrence(submission_role, data)
+    _apply_job_schedule_policy(
+        submission.Category,
+        submission.Target_Newsletter,
+        data,
+    )
+    _ensure_staff_only_recurrence(submission_role, data, submission.Category)
     await _validate_schedule_request(db, submission.Target_Newsletter, data)
 
     sched = await submission_service.add_schedule_request(

--- a/backend/app/schemas/submission.py
+++ b/backend/app/schemas/submission.py
@@ -67,7 +67,7 @@ class ScheduleRequestCreate(BaseModel):
     Flexible_Deadline: str | None = None
     Recurrence_Type: str = Field(
         "once",
-        pattern=r"^(once|weekly|monthly_date|monthly_nth_weekday)$",
+        pattern=r"^(once|weekly|monthly_date|monthly_nth_weekday|date_range)$",
     )
     Recurrence_Interval: int = Field(1, ge=1, le=12)
     Recurrence_End_Date: date | None = None
@@ -91,6 +91,8 @@ class ScheduleRequestCreate(BaseModel):
             raise ValueError(
                 "Recurrence_End_Date cannot be before the recurrence start date"
             )
+        if self.Recurrence_Type == "date_range" and self.Recurrence_End_Date is None:
+            raise ValueError("Recurrence_End_Date is required for date_range recurrence")
         return self
 
 

--- a/backend/app/services/job_posting_service.py
+++ b/backend/app/services/job_posting_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from html import unescape
+from html import escape, unescape
 import re
 from typing import Iterable
 from urllib.parse import urljoin
@@ -33,6 +33,20 @@ _DESCRIPTION_RE = re.compile(
 _PAGE_RE = re.compile(r"/postings/search\?page=(?P<page>\d+)")
 _TAG_RE = re.compile(r"<[^>]+>")
 _WHITESPACE_RE = re.compile(r"\s+")
+_ROMAN_NUMERAL_RE = re.compile(r"^[IVXLCDM]+$")
+_OFF_CAMPUS_PREFIX_RE = re.compile(
+    r"^Off Campus Location\s*-\s*",
+    re.IGNORECASE,
+)
+_JOB_TITLE_PROPER_WORDS = {
+    "boise": "Boise",
+    "idaho": "Idaho",
+    "moscow": "Moscow",
+    "uidaho": "UIdaho",
+}
+_OFFICIAL_UNIT_EXPANSIONS = {
+    "IMCI": "Institute for Modeling Collaboration and Innovation",
+}
 
 
 @dataclass(slots=True)
@@ -138,28 +152,73 @@ def parse_peopleadmin_search_results(html_text: str, source_url: str) -> list[Jo
 
 
 def build_job_headline(posting: JobPosting) -> str:
-    """Build the one-line headline used in the builder and export."""
-    parts = [posting.title]
-    if posting.department:
-        parts.append(posting.department)
-    if posting.location:
-        parts.append(posting.location)
-    return ", ".join(part for part in parts if part)
+    """Jobs are deliberately body-only and do not have newsletter headlines."""
+    return ""
 
 
 def build_job_body(posting: JobPosting) -> str:
-    """Build the body text for an imported job posting."""
-    details = []
-    if posting.posting_number:
-        details.append(f"Posting number: {posting.posting_number}.")
-    if posting.closing_date:
-        details.append(f"Closing date: {posting.closing_date}.")
+    """Build the complete one-line linked listing used in Builder and export."""
+    listing = build_job_listing_text(posting)
+    return f'<a href="{escape(posting.url, quote=True)}">{escape(listing)}</a>'
 
-    parts = [posting.summary.strip()]
-    if details:
-        parts.append(" ".join(details))
-    parts.append(f'<a href="{posting.url}">View job posting</a>.')
-    return " ".join(part for part in parts if part).strip()
+
+def build_job_listing_text(posting: JobPosting) -> str:
+    """Return title, official unit and any non-Moscow location as one line."""
+    parts = [format_job_title(posting.title)]
+    if posting.department:
+        department = posting.department
+        for abbreviation, expansion in _OFFICIAL_UNIT_EXPANSIONS.items():
+            department = re.sub(
+                rf"\b{re.escape(abbreviation)}\b",
+                expansion,
+                department,
+            )
+        parts.append(department)
+    location = format_job_location(posting.location)
+    if location:
+        parts.append(location)
+    return ", ".join(part for part in parts if part)
+
+
+def format_job_title(title: str) -> str:
+    """Apply conservative sentence case while retaining acronyms and levels."""
+    formatted_words: list[str] = []
+    for word in _WHITESPACE_RE.split(title.strip()):
+        core = word.strip("()[],.;:")
+        prefix_length = word.find(core) if core else 0
+        prefix = word[:prefix_length]
+        suffix = word[prefix_length + len(core):]
+        proper = _JOB_TITLE_PROPER_WORDS.get(core.casefold())
+        if proper:
+            formatted_core = proper
+        elif _ROMAN_NUMERAL_RE.fullmatch(core) or (
+            core.isupper() and 1 < len(core) <= 5
+        ):
+            formatted_core = core
+        else:
+            formatted_core = core.lower()
+        formatted_words.append(f"{prefix}{formatted_core}{suffix}")
+
+    formatted = " ".join(formatted_words)
+    first_letter = re.search(r"[A-Za-z]", formatted)
+    if first_letter:
+        index = first_letter.start()
+        formatted = formatted[:index] + formatted[index].upper() + formatted[index + 1:]
+    return formatted
+
+
+def format_job_location(location: str | None) -> str | None:
+    """Omit Moscow and normalize PeopleAdmin's off-campus location prefix."""
+    if not location:
+        return None
+    locations: list[str] = []
+    for part in location.split(","):
+        normalized = _OFF_CAMPUS_PREFIX_RE.sub("", part.strip()).strip()
+        if not normalized or normalized.casefold() == "moscow":
+            continue
+        if normalized not in locations:
+            locations.append(normalized)
+    return ", ".join(locations) or None
 
 
 def _get_page_count(html_text: str) -> int:

--- a/backend/app/services/newsletter_service.py
+++ b/backend/app/services/newsletter_service.py
@@ -374,7 +374,17 @@ async def assemble_newsletter(
 
         headline, body = _get_best_text(sub)
         section_items = [it for it in newsletter.Items if it.Section_Id == section.Id]
-        position = len(section_items)
+        if sub.Category == "job_opportunity":
+            # Jobs are ordered newest-first. The query walks oldest-first so each
+            # newly encountered job is prepended ahead of existing job listings.
+            for item in section_items:
+                item.Position += 1
+            for item in newsletter.External_Items:
+                if item.Section_Id == section.Id:
+                    item.Position += 1
+            position = 0
+        else:
+            position = len(section_items)
 
         item = NewsletterItem(
             Newsletter_Id=newsletter.Id,

--- a/backend/app/utils/export.py
+++ b/backend/app/utils/export.py
@@ -66,11 +66,12 @@ def export_newsletter_docx(
             headline = item["Final_Headline"]
             body = item["Final_Body"]
 
-            # Headline as bold paragraph
-            h_para = doc.add_paragraph()
-            h_run = h_para.add_run(headline)
-            h_run.bold = True
-            h_run.font.size = Pt(11)
+            if headline:
+                # Jobs are body-only linked lines; other items retain a bold headline.
+                h_para = doc.add_paragraph()
+                h_run = h_para.add_run(headline)
+                h_run.bold = True
+                h_run.font.size = Pt(11)
 
             # Body — parse HTML anchor tags into hyperlinks
             _add_body_with_links(doc, body)

--- a/backend/data/sections/tdr_sections.json
+++ b/backend/data/sections/tdr_sections.json
@@ -51,8 +51,8 @@
   {
     "name": "Job Opportunities",
     "slug": "job-opportunities",
-    "display_order": 8,
-    "description": "Jobs posted for two weeks from PeopleAdmin. Can repost after two-week removal. Newest at top. Must be listed with HR.",
+    "display_order": 11,
+    "description": "Jobs posted for two weeks from the official U of I jobs source. Can repost after two-week removal. Newest at top. Must be listed with HR.",
     "requires_image": false
   },
   {

--- a/backend/tests/test_jobs_workflow_migration.py
+++ b/backend/tests/test_jobs_workflow_migration.py
@@ -1,0 +1,69 @@
+"""Deployment-equivalent coverage for the completed Jobs workflow."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "b5d7f9a1c3e4_finalize_jobs_workflow.py"
+)
+SECTIONS_PATH = Path(__file__).parents[1] / "data" / "sections" / "tdr_sections.json"
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("finalize_jobs_workflow", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_jobs_section_order_migration_is_idempotent_and_matches_seed():
+    migration = load_migration()
+    metadata = sa.MetaData()
+    sections = sa.Table(
+        "newsletter_sections",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Newsletter_Type", sa.String(50), nullable=False),
+        sa.Column("Name", sa.String(255), nullable=False),
+        sa.Column("Slug", sa.String(255), nullable=False),
+        sa.Column("Display_Order", sa.Integer, nullable=False),
+        sa.Column("Description", sa.Text),
+        sa.Column("Requires_Image", sa.Boolean, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+    )
+    engine = sa.create_engine("sqlite://")
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sections.insert().values(
+                Id="jobs",
+                Newsletter_Type="tdr",
+                Name="Job Opportunities",
+                Slug="job-opportunities",
+                Display_Order=8,
+                Description="Old description",
+                Requires_Image=False,
+                Is_Active=True,
+            )
+        )
+        migration._apply_jobs_section_update(connection)
+        migration._apply_jobs_section_update(connection)
+        row = connection.execute(sa.select(sections)).mappings().one()
+
+    seeded = next(
+        section
+        for section in json.loads(SECTIONS_PATH.read_text())
+        if section["slug"] == "job-opportunities"
+    )
+    assert row["Display_Order"] == seeded["display_order"]
+    assert row["Description"] == seeded["description"]

--- a/backend/tests/test_newsletters.py
+++ b/backend/tests/test_newsletters.py
@@ -5,11 +5,13 @@ from datetime import date, datetime
 from pathlib import Path
 
 import pytest
+import sqlalchemy as sa
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.newsletter import NewsletterItem
 from app.models.section import NewsletterSection
+from app.models.submission import Submission
 from app.services import calendar_event_service, job_posting_service, newsletter_service
 from tests.conftest import make_newsletter_data, make_submission_data
 
@@ -373,6 +375,62 @@ class TestNewsletterItems:
         assert len(items) == 1
         assert items[0]["Submission_Id"] == recurring_id
 
+    async def test_assemble_places_newest_job_first_in_dedicated_section(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        staff_headers: dict[str, str],
+    ):
+        db.add(
+            NewsletterSection(
+                Newsletter_Type="tdr",
+                Name="Job Opportunities",
+                Slug="job-opportunities",
+                Display_Order=11,
+                Is_Active=True,
+            )
+        )
+        await db.commit()
+
+        job_ids: list[str] = []
+        for title in ("Older job", "Newer job"):
+            response = await client.post(
+                "/api/v1/submissions/",
+                json=make_submission_data(
+                    Category="job_opportunity",
+                    Original_Headline=title,
+                    Schedule_Requests=[{"Requested_Date": "2026-08-24"}],
+                ),
+            )
+            assert response.status_code == 201
+            job_ids.append(response.json()["Id"])
+            await client.patch(
+                f"/api/v1/submissions/{job_ids[-1]}",
+                json={"Status": "approved"},
+            )
+
+        await db.execute(
+            sa.update(Submission)
+            .where(Submission.Id == job_ids[0])
+            .values(Created_At=datetime(2026, 8, 1, 9, 0))
+        )
+        await db.execute(
+            sa.update(Submission)
+            .where(Submission.Id == job_ids[1])
+            .values(Created_At=datetime(2026, 8, 2, 9, 0))
+        )
+        await db.commit()
+
+        response = await client.post(
+            "/api/v1/newsletters/assemble",
+            json={"Newsletter_Type": "tdr", "Publish_Date": "2026-08-24"},
+            headers=staff_headers,
+        )
+
+        assert response.status_code == 200
+        jobs = sorted(response.json()["Items"], key=lambda item: item["Position"])
+        assert [item["Submission_Id"] for item in jobs] == [job_ids[1], job_ids[0]]
+
     async def test_assemble_myui_survey_uses_news_and_updates_section(
         self,
         client: AsyncClient,
@@ -543,6 +601,10 @@ def test_category_section_maps_target_seeded_sections():
     tdr_map = newsletter_service._get_category_section_map("tdr")
     assert tdr_map["employee_announcement"] == "employee-announcements"
     assert tdr_map["ucm_feature_story"] == "feature-stories"
+    tdr_sections = json.loads((data_dir / "tdr_sections.json").read_text())
+    assert max(tdr_sections, key=lambda section: section["display_order"])["slug"] == (
+        "job-opportunities"
+    )
 
 
 class TestCalendarEventParsing:
@@ -660,6 +722,46 @@ class TestJobPostingParsing:
         assert posting.location == "Moscow"
         assert posting.closing_date == "04/05/2026"
         assert posting.url == "https://uidaho.peopleadmin.com/postings/50999"
+
+    def test_build_job_listing_is_one_linked_line_without_moscow(self):
+        posting = job_posting_service.JobPosting(
+            source_id="https://example.com/postings/1",
+            source_type="job_posting",
+            url="https://example.com/postings/1",
+            title="Business Specialist III",
+            department="College of Natural Resources Admin",
+            posting_number="SP005197P",
+            location="Moscow",
+            closing_date="04/05/2026",
+            summary="This summary must not appear in the newsletter.",
+        )
+
+        assert job_posting_service.build_job_headline(posting) == ""
+        assert job_posting_service.build_job_body(posting) == (
+            '<a href="https://example.com/postings/1">Business specialist III, '
+            "College of Natural Resources Admin</a>"
+        )
+        assert job_posting_service.format_job_location(posting.location) is None
+
+    def test_build_job_listing_preserves_non_moscow_and_expands_imci(self):
+        posting = job_posting_service.JobPosting(
+            source_id="https://example.com/postings/2",
+            source_type="job_posting",
+            url="https://example.com/postings/2",
+            title="LABORATORY MANAGER II",
+            department="Image and Data Acquisition Core, IMCI",
+            posting_number="SP005198P",
+            location="Moscow, Off Campus Location - Boise",
+            closing_date=None,
+            summary="This summary must not appear in the newsletter.",
+        )
+
+        assert job_posting_service.build_job_body(posting) == (
+            '<a href="https://example.com/postings/2">Laboratory manager II, '
+            "Image and Data Acquisition Core, Institute for Modeling Collaboration "
+            "and Innovation, Boise</a>"
+        )
+        assert job_posting_service.format_job_location(posting.location) == "Boise"
 
 
 @pytest.mark.asyncio
@@ -926,7 +1028,12 @@ class TestJobPostingEndpoints:
         assert resp.status_code == 201
         body = resp.json()
         assert body["Source_Type"] == "job_posting"
-        assert "Business Specialist III" in body["Final_Headline"]
+        assert body["Final_Headline"] == ""
+        assert body["Final_Body"] == (
+            '<a href="https://example.com/postings/1">Business specialist III, '
+            "College of Natural Resources Admin</a>"
+        )
+        assert body["Location"] is None
 
         detail_resp = await client.get(f"/api/v1/newsletters/{nl_id}")
         assert detail_resp.status_code == 200

--- a/backend/tests/test_sections.py
+++ b/backend/tests/test_sections.py
@@ -8,7 +8,7 @@ from app.db import seed
 
 
 @pytest.mark.asyncio
-async def test_tdr_student_reminders_follow_employee_announcements(
+async def test_tdr_jobs_follow_student_reminders_at_bottom(
     client: AsyncClient,
     db: AsyncSession,
 ):
@@ -21,9 +21,12 @@ async def test_tdr_student_reminders_follow_employee_announcements(
 
     assert response.status_code == 200
     sections = response.json()
-    assert [section["Name"] for section in sections[-2:]] == [
+    assert [section["Name"] for section in sections[-3:]] == [
         "Employee Announcements",
         "Reminders for your students",
+        "Job Opportunities",
     ]
-    assert sections[-1]["Slug"] == "reminders-for-your-students"
-    assert sections[-1]["Display_Order"] == 10
+    assert sections[-2]["Slug"] == "reminders-for-your-students"
+    assert sections[-2]["Display_Order"] == 10
+    assert sections[-1]["Slug"] == "job-opportunities"
+    assert sections[-1]["Display_Order"] == 11

--- a/backend/tests/test_submissions.py
+++ b/backend/tests/test_submissions.py
@@ -76,6 +76,125 @@ class TestSubmissionCRUD:
         assert len(body["Schedule_Requests"]) == 1
         assert body["Schedule_Requests"][0]["Repeat_Count"] == 2
 
+    async def test_public_job_submission_runs_on_publication_days_for_two_weeks(
+        self,
+        client: AsyncClient,
+        db,
+    ):
+        await seed.seed_schedule_configs(db)
+        data = make_submission_data(
+            Category="job_opportunity",
+            Target_Newsletter="tdr",
+            Schedule_Requests=[{"Requested_Date": "2026-04-06"}],
+        )
+
+        response = await client.post("/api/v1/submissions/", json=data)
+
+        assert response.status_code == 201
+        schedule = response.json()["Schedule_Requests"][0]
+        assert schedule["Repeat_Count"] == 1
+        assert schedule["Recurrence_Type"] == "date_range"
+        assert schedule["Recurrence_End_Date"] == "2026-04-19"
+        assert schedule["Occurrence_Dates"] == [
+            "2026-04-06",
+            "2026-04-07",
+            "2026-04-08",
+            "2026-04-09",
+            "2026-04-10",
+            "2026-04-13",
+            "2026-04-14",
+            "2026-04-15",
+            "2026-04-16",
+            "2026-04-17",
+        ]
+
+    async def test_public_job_submission_can_end_before_two_weeks(
+        self,
+        client: AsyncClient,
+        db,
+    ):
+        await seed.seed_schedule_configs(db)
+        data = make_submission_data(
+            Category="job_opportunity",
+            Target_Newsletter="tdr",
+            Schedule_Requests=[
+                {
+                    "Requested_Date": "2026-04-06",
+                    "Recurrence_End_Date": "2026-04-10",
+                }
+            ],
+        )
+
+        response = await client.post("/api/v1/submissions/", json=data)
+
+        assert response.status_code == 201
+        schedule = response.json()["Schedule_Requests"][0]
+        assert schedule["Recurrence_Type"] == "date_range"
+        assert schedule["Recurrence_End_Date"] == "2026-04-10"
+        assert schedule["Occurrence_Dates"] == [
+            "2026-04-06",
+            "2026-04-07",
+            "2026-04-08",
+            "2026-04-09",
+            "2026-04-10",
+        ]
+
+    async def test_job_submission_rejects_student_newsletter_target(
+        self,
+        client: AsyncClient,
+    ):
+        data = make_submission_data(
+            Category="job_opportunity",
+            Target_Newsletter="myui",
+            Schedule_Requests=[{"Requested_Date": "2026-04-06"}],
+        )
+
+        response = await client.post("/api/v1/submissions/", json=data)
+
+        assert response.status_code == 422
+        assert "Daily Register" in response.json()["detail"]
+
+    async def test_job_submission_rejects_multiple_listing_windows(
+        self,
+        client: AsyncClient,
+    ):
+        data = make_submission_data(
+            Category="job_opportunity",
+            Target_Newsletter="tdr",
+            Schedule_Requests=[
+                {"Requested_Date": "2026-04-06"},
+                {"Requested_Date": "2026-04-13"},
+            ],
+        )
+
+        response = await client.post("/api/v1/submissions/", json=data)
+
+        assert response.status_code == 422
+        assert "exactly one preferred start date" in response.json()["detail"]
+
+    async def test_job_submission_rejects_an_added_listing_window(
+        self,
+        client: AsyncClient,
+        staff_headers: dict[str, str],
+    ):
+        create_response = await client.post(
+            "/api/v1/submissions/",
+            json=make_submission_data(
+                Category="job_opportunity",
+                Target_Newsletter="tdr",
+                Schedule_Requests=[{"Requested_Date": "2026-04-06"}],
+            ),
+        )
+
+        response = await client.post(
+            f"/api/v1/submissions/{create_response.json()['Id']}/schedule",
+            headers=staff_headers,
+            json={"Requested_Date": "2026-04-13"},
+        )
+
+        assert response.status_code == 422
+        assert "one listing window" in response.json()["detail"]
+
     async def test_create_submission_with_second_requested_date(
         self, client: AsyncClient
     ):

--- a/frontend/src/api/submissions.ts
+++ b/frontend/src/api/submissions.ts
@@ -90,7 +90,7 @@ export async function rescheduleScheduleOccurrence(
 export interface AddScheduleRequestData {
   Requested_Date?: string | null;
   Second_Requested_Date?: string | null;
-  Recurrence_Type?: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday';
+  Recurrence_Type?: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday' | 'date_range';
   Recurrence_Interval?: number;
   Recurrence_End_Date?: string;
 }

--- a/frontend/src/components/editor/SubmissionMeta.tsx
+++ b/frontend/src/components/editor/SubmissionMeta.tsx
@@ -50,6 +50,7 @@ const RECURRENCE_LABELS: Record<string, string> = {
   weekly: 'Weekly',
   monthly_date: 'Monthly',
   monthly_nth_weekday: 'Monthly (nth weekday)',
+  date_range: 'Two-week listing window',
 };
 
 function formatPublicationDate(value: string): string {

--- a/frontend/src/components/submission/SchedulePrefs.tsx
+++ b/frontend/src/components/submission/SchedulePrefs.tsx
@@ -8,7 +8,7 @@ interface ScheduleEntry {
   Repeat_Note: string;
   Is_Flexible: boolean;
   Flexible_Deadline: string;
-  Recurrence_Type: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday';
+  Recurrence_Type: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday' | 'date_range';
   Recurrence_Interval: number;
   Recurrence_End_Date: string;
 }
@@ -20,6 +20,7 @@ interface Props {
   validDates?: Set<string>;
   secondaryValidDates?: Set<string>;
   showRecurrenceControls?: boolean;
+  showRepeatCount?: boolean;
   heading?: string;
   preferredDateLabel?: string;
   secondDateLabel?: string;
@@ -74,6 +75,7 @@ export default function SchedulePrefs({
   validDates,
   secondaryValidDates,
   showRecurrenceControls = false,
+  showRepeatCount = true,
   heading = 'Scheduling Preferences',
   preferredDateLabel = 'Preferred run date',
   secondDateLabel = 'Second run date',
@@ -201,7 +203,7 @@ export default function SchedulePrefs({
                     : 'Mon–Fri only'}
               </p>
             </div>
-            <div>
+            {showRepeatCount && <div>
               <label
                 htmlFor="submission-repeat-count"
                 className="block text-xs text-gray-500 mb-1"
@@ -217,9 +219,9 @@ export default function SchedulePrefs({
                 <option value={1}>Once</option>
                 <option value={2}>Twice (has RSVP/registration)</option>
               </select>
-            </div>
+            </div>}
           </div>
-          {schedule.Repeat_Count >= 2 && (
+          {showRepeatCount && schedule.Repeat_Count >= 2 && (
             <div className="mt-3">
               <label
                 htmlFor="submission-second-run-date"

--- a/frontend/src/components/submission/SubmissionForm.test.tsx
+++ b/frontend/src/components/submission/SubmissionForm.test.tsx
@@ -355,6 +355,8 @@ describe('SubmissionForm', () => {
     await screen.findByRole('option', { name: 'Job Opportunity' });
     await user.selectOptions(screen.getByLabelText('Announcement Type'), 'job_opportunity');
     expect(screen.queryByRole('button', { name: /my ui/i })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('How many times to run')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Repeat on a cadence')).not.toBeInTheDocument();
 
     await user.type(screen.getByLabelText('Job Posting URL'), 'https://uidaho.peopleadmin.com/postings/123');
     await user.type(screen.getByLabelText('Position Title'), 'Program Coordinator');
@@ -377,6 +379,46 @@ describe('SubmissionForm', () => {
               Url: 'https://uidaho.peopleadmin.com/postings/123',
               Anchor_Text: 'Program Coordinator, Student Affairs, Moscow',
             },
+          ],
+          Schedule_Requests: [
+            expect.objectContaining({
+              Repeat_Count: 1,
+              Recurrence_Type: 'date_range',
+              Recurrence_Interval: 1,
+              Recurrence_End_Date: '2026-05-18',
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
+  it('uses an earlier job removal date as the two-week schedule end', async () => {
+    const user = userEvent.setup();
+    render(<SubmissionForm />);
+
+    await screen.findByRole('option', { name: 'Job Opportunity' });
+    await user.selectOptions(screen.getByLabelText('Announcement Type'), 'job_opportunity');
+    await user.type(screen.getByLabelText('Job Posting URL'), 'https://uidaho.peopleadmin.com/postings/124');
+    await user.type(screen.getByLabelText('Position Title'), 'Program Coordinator');
+    await user.type(screen.getByLabelText('Department'), 'Student Affairs');
+    await user.type(screen.getByLabelText('Preferred run date'), '2026-05-05');
+    await user.type(screen.getByLabelText('Remove listing early? (optional)'), '2026-05-12');
+    await user.type(screen.getByLabelText('Your Name'), 'Jane Submitter');
+    await user.type(screen.getByLabelText('Email Address'), 'jane@example.edu');
+    await user.click(screen.getByRole('button', { name: /submit announcement/i }));
+
+    await waitFor(() => {
+      expect(createSubmissionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Original_Body: 'Department: Student Affairs. Apply using the linked posting.',
+          Schedule_Requests: [
+            expect.objectContaining({
+              Repeat_Count: 1,
+              Recurrence_Type: 'date_range',
+              Recurrence_Interval: 1,
+              Recurrence_End_Date: '2026-05-12',
+            }),
           ],
         }),
       );

--- a/frontend/src/components/submission/SubmissionForm.tsx
+++ b/frontend/src/components/submission/SubmissionForm.tsx
@@ -5,7 +5,13 @@ import type { AllowedValue } from '../../types/allowedValue';
 import { createSubmission } from '../../api/submissions';
 import { getValidDates } from '../../api/schedule';
 import { getSubmitterRole } from '../../utils/submitterRole';
-import { parseISODate, todayISO, addDaysISO, addMonthsISO } from '../../utils/date';
+import {
+  addDaysISO,
+  addDaysToISODate,
+  addMonthsISO,
+  parseISODate,
+  todayISO,
+} from '../../utils/date';
 import CategorySelect from './CategorySelect';
 import NewsletterTargetSelect from './NewsletterTargetSelect';
 import LinkEditor from './LinkEditor';
@@ -45,7 +51,7 @@ interface ScheduleEntry {
   Repeat_Note: string;
   Is_Flexible: boolean;
   Flexible_Deadline: string;
-  Recurrence_Type: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday';
+  Recurrence_Type: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday' | 'date_range';
   Recurrence_Interval: number;
   Recurrence_End_Date: string;
 }
@@ -443,7 +449,6 @@ export default function SubmissionForm() {
         jobDepartment ? `Department: ${jobDepartment}.` : null,
         jobLocation ? `Location: ${jobLocation}.` : null,
         'Apply using the linked posting.',
-        jobRemoveDate ? `Remove listing after ${jobRemoveDate}.` : null,
       ].filter(Boolean);
       const effectiveHeadline = isJob ? jobTitle : headline;
       const effectiveBody = isJob ? jobBodyParts.join(' ') : body;
@@ -467,7 +472,21 @@ export default function SubmissionForm() {
       ];
       const combinedScheduleCount = Math.max(tdrDates.length, preferredStudentDates.length);
       const scheduleRequests: NonNullable<SubmissionCreate['Schedule_Requests']> =
-        isPublicFacultyStaffFlow && alsoPublishInStudentNewsletter
+        isJob
+          ? [{
+              ...baseScheduleRequest,
+              Requested_Date: schedule.Requested_Date,
+              Second_Requested_Date: undefined,
+              Repeat_Count: 1,
+              Recurrence_Type: 'date_range',
+              Recurrence_Interval: 1,
+              Recurrence_End_Date: jobRemoveDate || (
+                schedule.Requested_Date
+                  ? addDaysToISODate(schedule.Requested_Date, 13)
+                  : undefined
+              ),
+            }]
+          : isPublicFacultyStaffFlow && alsoPublishInStudentNewsletter
           ? Array.from({ length: combinedScheduleCount }, (_, index) => ({
               ...baseScheduleRequest,
               Requested_Date: tdrDates[index] ?? tdrDates[0],
@@ -634,7 +653,7 @@ export default function SubmissionForm() {
           /* --- Simplified Job Opportunity form --- */
           <div className="space-y-4">
             <p className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
-              Job listings run in The Daily Register for two weeks. Provide the PeopleAdmin URL and position details below.
+              Job listings run in The Daily Register for two weeks. Provide the official U of I posting URL and position details below.
             </p>
             <div>
               <label htmlFor="submission-job-url" className="block text-sm font-medium text-gray-700 mb-1">
@@ -650,7 +669,7 @@ export default function SubmissionForm() {
                 className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
               />
               <p className="text-xs text-gray-400 mt-1">
-                Provide the specific PeopleAdmin posting link.
+                Provide the specific official job posting link.
               </p>
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
@@ -709,6 +728,9 @@ export default function SubmissionForm() {
                 value={jobRemoveDate}
                 onChange={(e) => setJobRemoveDate(e.target.value)}
                 min={schedule.Requested_Date || getMinDate()}
+                max={schedule.Requested_Date
+                  ? addDaysToISODate(schedule.Requested_Date, 13)
+                  : undefined}
                 className="w-full max-w-xs rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
               />
               <p className="text-xs text-gray-400 mt-1">
@@ -777,7 +799,8 @@ export default function SubmissionForm() {
           targetNewsletter={scheduleTargetNewsletter}
           validDates={validDates.size > 0 ? validDates : undefined}
           secondaryValidDates={secondaryValidDates.size > 0 ? secondaryValidDates : undefined}
-          showRecurrenceControls={isStaff}
+          showRecurrenceControls={isStaff && !isJobOpportunity}
+          showRepeatCount={!isJobOpportunity}
           heading={isPublicFacultyStaffFlow && alsoPublishInStudentNewsletter
             ? 'Daily Register publication preferences'
             : undefined}

--- a/frontend/src/pages/BuilderPage.tsx
+++ b/frontend/src/pages/BuilderPage.tsx
@@ -1405,9 +1405,11 @@ export default function BuilderPage() {
                                     <div className="flex items-start justify-between">
                                       <div className="flex-1 min-w-0">
                                         <div className="flex items-center gap-2">
-                                          <p className="text-sm font-medium text-gray-900">
-                                            {item.Final_Headline}
-                                          </p>
+                                          {item.Final_Headline && (
+                                            <p className="text-sm font-medium text-gray-900">
+                                              {item.Final_Headline}
+                                            </p>
+                                          )}
                                           {item.Kind === 'calendar_event' && (
                                             <span className="inline-flex items-center rounded-full bg-ui-clearwater-100 px-2 py-0.5 text-[11px] font-medium text-ui-clearwater-800">
                                               Calendar

--- a/frontend/src/types/submission.ts
+++ b/frontend/src/types/submission.ts
@@ -43,7 +43,7 @@ export interface SubmissionScheduleRequest {
   Repeat_Note: string | null;
   Is_Flexible: boolean;
   Flexible_Deadline: string | null;
-  Recurrence_Type: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday';
+  Recurrence_Type: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday' | 'date_range';
   Recurrence_Interval: number;
   Recurrence_End_Date: string | null;
   Excluded_Dates: string[];
@@ -93,7 +93,7 @@ export interface SubmissionCreate {
     Repeat_Note?: string;
     Is_Flexible?: boolean;
     Flexible_Deadline?: string;
-    Recurrence_Type?: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday';
+    Recurrence_Type?: 'once' | 'weekly' | 'monthly_date' | 'monthly_nth_weekday' | 'date_range';
     Recurrence_Interval?: number;
     Recurrence_End_Date?: string;
     Excluded_Dates?: string[];

--- a/frontend/src/utils/date.test.ts
+++ b/frontend/src/utils/date.test.ts
@@ -5,6 +5,7 @@ import {
   toISODate,
   todayISO,
   addDaysISO,
+  addDaysToISODate,
   addMonthsISO,
 } from './date';
 
@@ -48,6 +49,11 @@ describe('today/offset helpers', () => {
     expect(addDaysISO(1)).toBe('2026-07-18');
     expect(addDaysISO(90)).toBe('2026-10-15');
     expect(addMonthsISO(3)).toBe('2026-10-17');
+  });
+
+  it('adds days to an explicit date-only value', () => {
+    expect(addDaysToISODate('2026-05-05', 13)).toBe('2026-05-18');
+    expect(addDaysToISODate('2026-12-25', 13)).toBe('2027-01-07');
   });
 });
 

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -32,6 +32,13 @@ export function addDaysISO(days: number): string {
   return toISODate(d);
 }
 
+/** Add days to a date-only value without crossing UTC/local date boundaries. */
+export function addDaysToISODate(dateStr: string, days: number): string {
+  const date = parseISODate(dateStr);
+  date.setDate(date.getDate() + days);
+  return toISODate(date);
+}
+
 /** The local date `months` months from today as YYYY-MM-DD. */
 export function addMonthsISO(months: number): string {
   const d = new Date();


### PR DESCRIPTION
Closes #197.

## What changed

- complete the dedicated Job Opportunities workflow and place its section at the bottom of The Daily Register
- format imported jobs deterministically as a single linked, body-only line with sentence-case titles, official unit naming, IMCI expansion and non-Moscow locations
- remove job repeat controls and enforce one Daily Register listing window spanning at most two weeks, including backend enforcement against duplicate windows
- preserve an optional earlier removal date without embedding scheduling metadata in the submitted copy
- keep the current configurable U of I jobs source while making public-facing source guidance provider-neutral
- add a data migration for the existing Job Opportunities section and update Builder/export rendering for headline-free items

## Why

Job submissions were still flowing through general newsletter behavior: imported items included news-style summaries and calls to action, the section was not last, and the public form's repeat controls did not create the promised two-week schedule. This completes the remaining workflow described in #197 while retaining the existing staff review and source adapter.

## Validation

- `cd backend && ./.venv/bin/pytest -q` — 308 passed
- `cd backend && ./.venv/bin/ruff check .`
- `cd frontend && npm test -- --run` — 83 passed
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd backend && ./.venv/bin/alembic heads` — one head (`b5d7f9a1c3e4`)
- `git diff --check`
