### PR TITLE
Fix Joy editorial and Final Edit regressions

### DIFF
--- a/backend/alembic/versions/c7e9a1b3d5f2_align_august_20_editorial_rules.py
+++ b/backend/alembic/versions/c7e9a1b3d5f2_align_august_20_editorial_rules.py
@@ -1,0 +1,170 @@
+"""align managed editorial rules with Aug. 20 production feedback
+
+Revision ID: c7e9a1b3d5f2
+Revises: b5d7f9a1c3e4
+Create Date: 2026-08-20 14:00:00.000000
+
+Joy's production review clarified that newsletter audience metadata must not
+enter the copy, ampersands are replaced even in official names, cross-period
+time ranges use ``to``, event details begin with the time, and relative dates
+must retain their explicit calendar dates. This focused upsert aligns existing
+databases with the shared seed while leaving unrelated staff-managed rules
+untouched.
+"""
+
+from collections.abc import Sequence
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "c7e9a1b3d5f2"
+down_revision: str | Sequence[str] | None = "b5d7f9a1c3e4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+STYLE_RULE_UPDATES = [
+    {
+        "category": "formatting",
+        "rule_key": "today_tomorrow",
+        "rule_text": (
+            "When a source pairs a relative date such as 'today' or 'tomorrow' "
+            "with a specific calendar date, retain both in the edited copy. "
+            "Never replace or remove the calendar date. Write the relative "
+            "reference followed by the date, such as 'today, Aug. 24,' so the "
+            "item remains accurate after publication."
+        ),
+        "severity": "error",
+    },
+    {
+        "category": "formatting",
+        "rule_key": "ap_style_times",
+        "rule_text": (
+            "Use AP style for times: lowercase a.m. and p.m. with periods. Use "
+            "noon and midnight instead of 12 p.m. and 12 a.m. Use figures: 1 "
+            "p.m., 3:30 p.m. Use a hyphen for same-period time ranges: '3-4 "
+            "p.m.' Use 'to' instead of a hyphen when a range crosses a.m. and "
+            "p.m.: '11 a.m. to 2 p.m.' Use 'from' only when the sentence "
+            "grammar requires a from/to construction. Avoid 'o'clock'. Remove "
+            "redundant time phrases such as 'this morning' or 'tonight'."
+        ),
+        "severity": "error",
+    },
+    {
+        "category": "formatting",
+        "rule_key": "event_detail_ordering",
+        "rule_text": (
+            "Start event-detail constructions with the time, then give the day, "
+            "date and location in that order. Example: '3-4 p.m. Wednesday, Feb. "
+            "12, in the Pitman Center Vandal Ballroom.' Never place the day or "
+            "date before the time. Do not omit these elements. If the event is "
+            "more than one month away, omit the day of the week."
+        ),
+        "severity": "error",
+    },
+    {
+        "category": "formatting",
+        "rule_key": "ampersand_to_and",
+        "rule_text": (
+            "Replace '&' with 'and' everywhere in published plain text, including "
+            "official names, titles, departments, programs and event names, "
+            "except Q&A. HTML entities used by markup are not editorial ampersands."
+        ),
+        "severity": "error",
+    },
+    {
+        "category": "formatting",
+        "rule_key": "preserve_event_title_case",
+        "rule_text": (
+            "Do not change the wording or capitalization of event titles. Keep "
+            "event titles in title case exactly as submitted, even when the "
+            "surrounding text uses sentence case. This applies everywhere the "
+            "name appears, including inside sentence-case headlines: official "
+            "event, program and organization names are proper nouns, and "
+            "preserving their official capitalization takes precedence over "
+            "sentence-casing. Example: 'Fraternity and Sorority Life Bid Day' "
+            "stays fully capitalized inside an otherwise sentence-case headline, "
+            "never 'fraternity and sorority Bid Day'. The ampersand rule is the "
+            "sole wording exception: replace '&' with 'and' while preserving all "
+            "other title wording and capitalization. When an event title is "
+            "itself a composition title, such as a film, play or lecture title, "
+            "format it under the composition-title rule instead."
+        ),
+        "severity": "error",
+    },
+    {
+        "category": "content_filtering",
+        "rule_key": "preserve_audience_scope",
+        "rule_text": (
+            "Do not narrow, broaden or genericize the intended audience, and "
+            "never invent it. "
+            "Newsletter channel context such as TDR faculty and staff or My UI "
+            "students is distribution metadata, never source content, so do not "
+            "add an audience group from the selected newsletter. A submission "
+            "sent to both newsletters must remain audience-neutral unless its "
+            "source explicitly names a group. Preserve broad audience meaning "
+            "such as 'all are welcome,' 'everyone is invited' or 'the public is "
+            "welcome.' Also preserve the most specific accurate source "
+            "description, such as donors, breastfeeding or lactating women, "
+            "volunteers, faculty members, first-year students or alumni, instead "
+            "of replacing it with 'participants,' 'individuals' or 'people.' For "
+            "recruitment announcements, include the specific group in the first "
+            "sentence whenever possible and surface important eligibility "
+            "qualifiers early enough that the offer is not misleading. For "
+            "concise event invitations, replace broad wording with a direct "
+            "invitation such as 'Attend the workshop,' never with a narrower "
+            "group unless the original explicitly limits attendance."
+        ),
+        "severity": "error",
+    },
+]
+
+
+style_rules = sa.table(
+    "style_rules",
+    sa.column("Id", sa.String(36)),
+    sa.column("Rule_Set", sa.String(50)),
+    sa.column("Category", sa.String(100)),
+    sa.column("Rule_Key", sa.String(100)),
+    sa.column("Rule_Text", sa.Text),
+    sa.column("Is_Active", sa.Boolean),
+    sa.column("Severity", sa.String(50)),
+)
+
+
+def _apply_style_rule_updates(connection: sa.Connection) -> None:
+    for rule in STYLE_RULE_UPDATES:
+        values = {
+            "Category": rule["category"],
+            "Rule_Text": rule["rule_text"],
+            "Is_Active": True,
+            "Severity": rule["severity"],
+        }
+        result = connection.execute(
+            style_rules.update()
+            .where(
+                style_rules.c.Rule_Set == "shared",
+                style_rules.c.Rule_Key == rule["rule_key"],
+            )
+            .values(**values)
+        )
+        if result.rowcount == 0:
+            connection.execute(
+                style_rules.insert().values(
+                    Id=str(uuid.uuid4()),
+                    Rule_Set="shared",
+                    Rule_Key=rule["rule_key"],
+                    **values,
+                )
+            )
+
+
+def upgrade() -> None:
+    _apply_style_rule_updates(op.get_bind())
+
+
+def downgrade() -> None:
+    # Text-only updates of managed rules; prior wording is not restored.
+    pass

--- a/backend/app/services/ai/editor.py
+++ b/backend/app/services/ai/editor.py
@@ -33,6 +33,9 @@ from app.utils.style_checks import (
     detect_abbreviated_months_without_date,
     detect_nonstandard_meridiems,
     detect_twelve_oclock_meridiems,
+    detect_cross_period_hyphen_ranges,
+    detect_event_detail_order_violations,
+    detect_disallowed_ampersands,
     detect_platform_names,
     detect_undefined_acronyms,
     detect_repeated_cta_phrases,
@@ -50,10 +53,12 @@ from app.utils.style_checks import (
     detect_missing_protected_organizations,
     detect_missing_specific_audience_lead,
     detect_missing_broad_audience,
+    detect_introduced_audience_groups,
     detect_unformatted_composition_titles,
     detect_noncanonical_campus_locations,
     detect_missing_approved_venue_addresses,
     detect_weekday_date_mismatches,
+    detect_missing_relative_date_components,
 )
 
 logger = logging.getLogger(__name__)
@@ -227,6 +232,24 @@ class AIEditor:
             add("ap_style_times", f"Time should use lowercase a.m./p.m. with periods: '{found}'")
         for found in detect_twelve_oclock_meridiems(text):
             add("ap_style_times", f"Use noon or midnight instead of '{found}'")
+        for found in detect_cross_period_hyphen_ranges(text):
+            add(
+                "ap_style_times",
+                f"Use 'to' for a time range that crosses a.m./p.m.: '{found}'",
+            )
+
+        for sentence in detect_event_detail_order_violations(body):
+            add(
+                "event_detail_ordering",
+                f"Event details must put the time before the day and date: '{sentence}'",
+            )
+
+        ampersands = detect_disallowed_ampersands(text)
+        if ampersands:
+            add(
+                "ampersand_to_and",
+                "Replace '&' with 'and'; Q&A is the only exception",
+            )
 
         platforms = detect_platform_names(text)
         if platforms:
@@ -373,6 +396,22 @@ class AIEditor:
                 add(
                     "preserve_audience_scope",
                     f"Broad source invitation was narrowed or removed: '{broad_audience}'",
+                )
+
+            for audience in detect_introduced_audience_groups(source_text, body):
+                add(
+                    "preserve_audience_scope",
+                    f"AI edit introduced an audience not stated in the source: '{audience}'",
+                )
+
+            for date_reference in detect_missing_relative_date_components(
+                body_source,
+                body,
+            ):
+                add(
+                    "today_tomorrow",
+                    "Retain both the relative date and its explicit calendar date: "
+                    f"'{date_reference}'",
                 )
 
             for title in detect_unformatted_composition_titles(

--- a/backend/app/services/ai/prompts.py
+++ b/backend/app/services/ai/prompts.py
@@ -54,6 +54,11 @@ Your task is to edit submissions to comply with the university's editorial style
 ## Headline Style: {headline_case}
 ## Submission Category: {category}
 
+The newsletter audience above is distribution context only, not submitted
+content. Never add or narrow an audience based on the selected newsletter.
+If an item may run in both newsletters, keep its audience neutral unless the
+source explicitly names a group.
+
 ## Editorial Rules
 {rules_text}
 
@@ -79,13 +84,13 @@ Your task is to edit submissions to comply with the university's editorial style
 - Abbreviate months with six or more letters when used with a specific date: Jan., Feb., Aug., Sept., Oct., Nov., Dec. Do NOT abbreviate March, April, May, June, July.
 - Format: "Monday, Feb. 3" not "Monday, February 3, 2025". Omit the year for events within 12 months of the publication date, even if the event is in the next calendar year. Include the year only for events more than 12 months out.
 - Times: lowercase "a.m." and "p.m." with periods. Use "noon" and "midnight" instead of "12 p.m." and "12 a.m.".
-- Same-period time ranges use a hyphen: "3-4 p.m." not "3 to 4 p.m." Use "from" with "to" only when crossing a.m./p.m.: "from 9 a.m. to 3 p.m."
+- Same-period time ranges use a hyphen: "3-4 p.m." not "3 to 4 p.m." Ranges that cross a.m./p.m. use "to": "9 a.m. to 3 p.m." Use "from" only when the sentence grammar requires a from/to construction.
 - Spell out numbers one through nine; use numerals for 10 and above. Exception: always use numerals with a.m./p.m.
 - Use "more than" instead of "over" for numerical comparisons.
 
 ### Event Details
 - Ensure events include date, time and location. Flag if any are missing.
-- REQUIRED ORDER: write event details as time, day, date, then location. Never put the day or date before the time.
+- REQUIRED ORDER: start the event-detail construction with the time, then write the day, date and location. Never put the day or date before the time.
 - Example: "3-4 p.m. Wednesday, Feb. 12, in the Bruce M. Pitman Center Vandal Ballroom"
 
 ### Links

--- a/backend/app/utils/style_checks.py
+++ b/backend/app/utils/style_checks.py
@@ -33,6 +33,16 @@ _ABBREV_WITHOUT_DATE = re.compile(rf"\b(?:{_MONTH_ABBREV})\.(?!\s*\d)")
 
 _BAD_MERIDIEM = re.compile(r"\b\d{1,2}(?::\d{2})?\s*(?:AM|PM|A\.M\.|P\.M\.|am\b|pm\b)")
 _TWELVE_MERIDIEM = re.compile(r"\b12(?::00)?\s*(?:a\.m\.|p\.m\.)", re.IGNORECASE)
+_TIME_WITH_PERIOD = re.compile(
+    r"\b\d{1,2}(?::\d{2})?\s*(?P<period>a\.m\.|p\.m\.)",
+    re.IGNORECASE,
+)
+_CROSS_PERIOD_HYPHEN_RANGE = re.compile(
+    r"\b(?P<start>\d{1,2}(?::\d{2})?\s*(?P<start_period>a\.m\.|p\.m\.))"
+    r"\s*[-–—]\s*"
+    r"(?P<end>\d{1,2}(?::\d{2})?\s*(?P<end_period>a\.m\.|p\.m\.))",
+    re.IGNORECASE,
+)
 
 _PLATFORM_NAMES = re.compile(r"\b(?:Zoom|Webex|Microsoft Teams|Google Meet|Skype)\b")
 
@@ -142,6 +152,17 @@ _BROAD_AUDIENCE_PHRASES = (
         re.compile(r"\bthe\s+public\s+is\s+welcome\b", re.IGNORECASE),
     ),
 )
+_AUDIENCE_GROUPS = (
+    ("employees", re.compile(r"\bemployees?\b", re.IGNORECASE)),
+    ("faculty", re.compile(r"\bfaculty\b", re.IGNORECASE)),
+    ("staff", re.compile(r"\bstaff\b", re.IGNORECASE)),
+    ("students", re.compile(r"\bstudents?\b", re.IGNORECASE)),
+    (
+        "campus community",
+        re.compile(r"\bcampus\s+community\b", re.IGNORECASE),
+    ),
+    ("public", re.compile(r"\b(?:the\s+)?public\b", re.IGNORECASE)),
+)
 _DIRECT_INVITATION_LEAD = re.compile(
     r"^(?:Attend|Join|Visit|Watch|Come|Participate|Register|Explore|Learn)\b",
     re.IGNORECASE,
@@ -206,6 +227,10 @@ _MONTH_DAY = re.compile(
     r"Dec(?:ember)?)\.?\s+(?P<day>\d{1,2})(?:,\s*(?P<year>\d{4}))?\b",
     re.IGNORECASE,
 )
+_RELATIVE_DATE_REFERENCE = re.compile(
+    r"\b(?:today|tomorrow|this\s+(?:week|month)|next\s+(?:week|month))\b",
+    re.IGNORECASE,
+)
 _WEEKDAY_PREFIX = re.compile(
     r"\b(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),?\s*$",
     re.IGNORECASE,
@@ -249,6 +274,38 @@ def detect_nonstandard_meridiems(text: str) -> list[str]:
 def detect_twelve_oclock_meridiems(text: str) -> list[str]:
     """Find '12 p.m.'/'12 a.m.', which AP replaces with noon and midnight."""
     return _TWELVE_MERIDIEM.findall(text)
+
+
+def detect_cross_period_hyphen_ranges(text: str) -> list[str]:
+    """Find hyphenated time ranges whose endpoints use different periods."""
+    findings: list[str] = []
+    for match in _CROSS_PERIOD_HYPHEN_RANGE.finditer(strip_html(text)):
+        if match.group("start_period").casefold() == match.group("end_period").casefold():
+            continue
+        findings.append(match.group())
+    return findings
+
+
+def detect_event_detail_order_violations(text: str) -> list[str]:
+    """Find event sentences that place a calendar date before the first time."""
+    findings: list[str] = []
+    for sentence in re.split(r"(?<=[!?])\s+|(?<=\.)\s+(?=[A-Z])", strip_html(text)):
+        sentence = sentence.strip()
+        if not sentence:
+            continue
+        date_match = _MONTH_DAY.search(sentence)
+        time_match = _TIME_WITH_PERIOD.search(sentence)
+        if date_match and time_match and date_match.start() < time_match.start():
+            findings.append(sentence)
+    return findings
+
+
+def detect_disallowed_ampersands(text: str) -> list[str]:
+    """Find literal ampersands outside the sole editorial exception, Q&A."""
+    visible = strip_html(text)
+    visible = re.sub(r"\bQ\s*&\s*A\b", "", visible, flags=re.IGNORECASE)
+    visible = re.sub(r"&(?:#\d+|#x[0-9a-f]+|[a-z][a-z0-9]+);", "", visible, flags=re.IGNORECASE)
+    return [match.group() for match in re.finditer(r"&", visible)]
 
 
 def detect_platform_names(text: str) -> list[str]:
@@ -376,6 +433,20 @@ def detect_missing_broad_audience(source_body: str, edited_body: str) -> list[st
         findings.append(display)
 
     return findings
+
+
+def detect_introduced_audience_groups(
+    source_body: str,
+    edited_body: str,
+) -> list[str]:
+    """Find explicit audience groups introduced only by the edited copy."""
+    source = strip_html(source_body)
+    edited = strip_html(edited_body)
+    return [
+        display
+        for display, pattern in _AUDIENCE_GROUPS
+        if pattern.search(edited) and not pattern.search(source)
+    ]
 
 
 def _composition_titles(source_text: str) -> list[str]:
@@ -685,11 +756,56 @@ def _official_name_candidates(source_text: str) -> list[str]:
 def detect_changed_official_names(source_text: str, edited_text: str) -> list[str]:
     """Find protected official/branded source spans no longer present exactly."""
     edited = strip_html(edited_text)
-    return [
-        candidate
-        for candidate in _official_name_candidates(source_text)
-        if candidate not in edited
-    ]
+    findings: list[str] = []
+    for candidate in _official_name_candidates(source_text):
+        allowed_variants = {candidate}
+        if "&" in candidate:
+            allowed_variants.add(re.sub(r"\s*&\s*", " and ", candidate))
+        if not any(variant in edited for variant in allowed_variants):
+            findings.append(candidate)
+    return findings
+
+
+def detect_missing_relative_date_components(
+    source_text: str,
+    edited_text: str,
+) -> list[str]:
+    """Find source relative-date + calendar-date pairs not retained together."""
+    edited = strip_html(edited_text)
+    edited_relative = {
+        match.group().casefold()
+        for match in _RELATIVE_DATE_REFERENCE.finditer(edited)
+    }
+    edited_dates = {
+        (_MONTH_NUMBERS[match.group("month").lower().rstrip(".")], int(match.group("day")))
+        for match in _MONTH_DAY.finditer(edited)
+        if match.group("month").lower().rstrip(".") in _MONTH_NUMBERS
+    }
+    findings: list[str] = []
+
+    for sentence in re.split(
+        r"\n+|(?<=[!?])\s+|(?<=\.)\s+(?=[A-Z])",
+        strip_html(source_text),
+    ):
+        relatives = list(_RELATIVE_DATE_REFERENCE.finditer(sentence))
+        dates = list(_MONTH_DAY.finditer(sentence))
+        if not relatives or not dates:
+            continue
+        for relative in relatives:
+            for date_match in dates:
+                month = _MONTH_NUMBERS.get(date_match.group("month").lower().rstrip("."))
+                if month is None:
+                    continue
+                date_key = (month, int(date_match.group("day")))
+                if (
+                    relative.group().casefold() not in edited_relative
+                    or date_key not in edited_dates
+                ):
+                    finding = f"{relative.group()}, {date_match.group().rstrip('.')}"
+                    if finding not in findings:
+                        findings.append(finding)
+
+    return findings
 
 
 def detect_weekday_date_mismatches(

--- a/backend/data/style_rules/shared_rules.json
+++ b/backend/data/style_rules/shared_rules.json
@@ -26,8 +26,8 @@
   {
     "category": "formatting",
     "rule_key": "today_tomorrow",
-    "rule_text": "Use 'Today' and 'Tomorrow' instead of the specific date when appropriate. This applies to dates in both headlines and body text.",
-    "severity": "info"
+    "rule_text": "When a source pairs a relative date such as 'today' or 'tomorrow' with a specific calendar date, retain both in the edited copy. Never replace or remove the calendar date. Write the relative reference followed by the date, such as 'today, Aug. 24,' so the item remains accurate after publication.",
+    "severity": "error"
   },
   {
     "category": "formatting",
@@ -44,7 +44,7 @@
   {
     "category": "formatting",
     "rule_key": "ap_style_times",
-    "rule_text": "Use AP style for times: lowercase a.m. and p.m. with periods. Use noon and midnight instead of 12 p.m. and 12 a.m. Use figures: 1 p.m., 3:30 p.m. Use a hyphen for same-period time ranges: '3-4 p.m.' Use 'from' with 'to' only when spanning a.m. to p.m.: 'from 9 a.m. to 3 p.m.' Avoid 'o'clock'. Remove redundant time phrases such as 'this morning' or 'tonight'.",
+    "rule_text": "Use AP style for times: lowercase a.m. and p.m. with periods. Use noon and midnight instead of 12 p.m. and 12 a.m. Use figures: 1 p.m., 3:30 p.m. Use a hyphen for same-period time ranges: '3-4 p.m.' Use 'to' instead of a hyphen when a range crosses a.m. and p.m.: '11 a.m. to 2 p.m.' Use 'from' only when the sentence grammar requires a from/to construction. Avoid 'o'clock'. Remove redundant time phrases such as 'this morning' or 'tonight'.",
     "severity": "error"
   },
   {
@@ -188,7 +188,7 @@
   {
     "category": "formatting",
     "rule_key": "event_detail_ordering",
-    "rule_text": "Order event details as: time, day, date, location. Example: '3-4 p.m. Wednesday, Feb. 12, in the Pitman Center Vandal Ballroom'. Do not reorder or omit these elements. If the event is more than one month away, omit the day of the week.",
+    "rule_text": "Start event-detail constructions with the time, then give the day, date and location in that order. Example: '3-4 p.m. Wednesday, Feb. 12, in the Pitman Center Vandal Ballroom.' Never place the day or date before the time. Do not omit these elements. If the event is more than one month away, omit the day of the week.",
     "severity": "error"
   },
   {
@@ -278,13 +278,13 @@
   {
     "category": "formatting",
     "rule_key": "ampersand_to_and",
-    "rule_text": "Replace '&' with 'and' in plain text. Keep '&' only when it is part of an official title or event name that uses it.",
-    "severity": "warning"
+    "rule_text": "Replace '&' with 'and' everywhere in published plain text, including official names, titles, departments, programs and event names, except Q&A. HTML entities used by markup are not editorial ampersands.",
+    "severity": "error"
   },
   {
     "category": "formatting",
     "rule_key": "preserve_event_title_case",
-    "rule_text": "Do not change event titles. Keep event titles in title case exactly as submitted, even when the surrounding text uses sentence case. This applies everywhere the name appears, including inside sentence-case headlines: official event, program and organization names are proper nouns, and preserving their official capitalization takes precedence over sentence-casing. Example: 'Fraternity and Sorority Life Bid Day' stays fully capitalized inside an otherwise sentence-case headline, never 'fraternity and sorority Bid Day'. Exception: when an event title is itself a composition title, such as a film, play or lecture title, format it under the composition-title rule instead.",
+    "rule_text": "Do not change the wording or capitalization of event titles. Keep event titles in title case exactly as submitted, even when the surrounding text uses sentence case. This applies everywhere the name appears, including inside sentence-case headlines: official event, program and organization names are proper nouns, and preserving their official capitalization takes precedence over sentence-casing. Example: 'Fraternity and Sorority Life Bid Day' stays fully capitalized inside an otherwise sentence-case headline, never 'fraternity and sorority Bid Day'. The ampersand rule is the sole wording exception: replace '&' with 'and' while preserving all other title wording and capitalization. When an event title is itself a composition title, such as a film, play or lecture title, format it under the composition-title rule instead.",
     "severity": "error"
   },
   {
@@ -356,7 +356,7 @@
   {
     "category": "content_filtering",
     "rule_key": "preserve_audience_scope",
-    "rule_text": "Do not narrow, broaden or genericize the intended audience. Preserve broad audience meaning such as 'all are welcome,' 'everyone is invited' or 'the public is welcome.' Also preserve the most specific accurate source description, such as donors, breastfeeding or lactating women, volunteers, faculty members, first-year students or alumni, instead of replacing it with 'participants,' 'individuals' or 'people.' For recruitment announcements, include the specific group in the first sentence whenever possible and surface important eligibility qualifiers early enough that the offer is not misleading. For concise event invitations, replace broad wording with a direct invitation such as 'Attend the workshop,' never with a narrower group unless the original explicitly limits attendance.",
+    "rule_text": "Do not narrow, broaden or genericize the intended audience, and never invent it. Newsletter channel context such as TDR faculty and staff or My UI students is distribution metadata, never source content, so do not add an audience group from the selected newsletter. A submission sent to both newsletters must remain audience-neutral unless its source explicitly names a group. Preserve broad audience meaning such as 'all are welcome,' 'everyone is invited' or 'the public is welcome.' Also preserve the most specific accurate source description, such as donors, breastfeeding or lactating women, volunteers, faculty members, first-year students or alumni, instead of replacing it with 'participants,' 'individuals' or 'people.' For recruitment announcements, include the specific group in the first sentence whenever possible and surface important eligibility qualifiers early enough that the offer is not misleading. For concise event invitations, replace broad wording with a direct invitation such as 'Attend the workshop,' never with a narrower group unless the original explicitly limits attendance.",
     "severity": "error"
   },
   {

--- a/backend/tests/test_ai_edits.py
+++ b/backend/tests/test_ai_edits.py
@@ -1532,6 +1532,99 @@ class TestDeterministicPostValidation:
         assert any("ages 18-50" in flag["message"] for flag in flags)
         assert any("Interested participants should contact" in flag["message"] for flag in flags)
 
+    async def test_channel_derived_employee_audience_is_flagged(self):
+        source_body = (
+            "Looking for a job on campus or in Moscow? U of I departments and local "
+            "businesses will recruit freshman through graduate students."
+        )
+        flags = AIEditor(SuccessfulProvider()).post_analyze(
+            "Attend the job fair",
+            "Employees seeking on-campus or Moscow employment can attend the job fair.",
+            "faculty_staff",
+            [
+                {
+                    "category": "content_filtering",
+                    "rule_key": "preserve_audience_scope",
+                    "rule_text": "Managed audience rule.",
+                    "severity": "error",
+                }
+            ],
+            source_text=source_body,
+            source_body=source_body,
+        )
+
+        assert {flag["rule_key"] for flag in flags} == {"preserve_audience_scope"}
+        assert "employees" in flags[0]["message"].lower()
+
+    async def test_disallowed_ampersand_is_flagged(self):
+        flags = AIEditor(SuccessfulProvider()).post_analyze(
+            "Attend the Campus & Community Job Fair",
+            "Attend the Campus & Community Job Fair.",
+            "faculty_staff",
+            [
+                {
+                    "category": "formatting",
+                    "rule_key": "ampersand_to_and",
+                    "rule_text": "Managed ampersand rule.",
+                    "severity": "error",
+                }
+            ],
+        )
+
+        assert {flag["rule_key"] for flag in flags} == {"ampersand_to_and"}
+
+    async def test_event_order_and_cross_period_hyphen_are_flagged(self):
+        flags = AIEditor(SuccessfulProvider()).post_analyze(
+            "Attend the job fair",
+            (
+                "Attend the fair on Thursday, Aug. 27, from 11 a.m.-2 p.m. "
+                "in the ISUB Summit Conference Center."
+            ),
+            "faculty_staff",
+            [
+                {
+                    "category": "formatting",
+                    "rule_key": "event_detail_ordering",
+                    "rule_text": "Managed event order rule.",
+                    "severity": "error",
+                },
+                {
+                    "category": "formatting",
+                    "rule_key": "ap_style_times",
+                    "rule_text": "Managed time rule.",
+                    "severity": "error",
+                },
+            ],
+        )
+
+        assert {flag["rule_key"] for flag in flags} == {
+            "event_detail_ordering",
+            "ap_style_times",
+        }
+
+    async def test_relative_word_cannot_replace_source_calendar_date(self):
+        source_body = (
+            "Regular business hours of 8 a.m. to 5 p.m. resume today, Aug. 24."
+        )
+        flags = AIEditor(SuccessfulProvider()).post_analyze(
+            "Regular hours resume today",
+            "Regular business hours of 8 a.m. to 5 p.m. resume today.",
+            "faculty_staff",
+            [
+                {
+                    "category": "formatting",
+                    "rule_key": "today_tomorrow",
+                    "rule_text": "Managed relative-date rule.",
+                    "severity": "error",
+                }
+            ],
+            source_text=source_body,
+            source_body=source_body,
+        )
+
+        assert {flag["rule_key"] for flag in flags} == {"today_tomorrow"}
+        assert "Aug. 24" in flags[0]["message"]
+
     async def test_compliant_output_produces_no_post_validation_flags(
         self,
         client: AsyncClient,

--- a/backend/tests/test_august_10_joy_style_rules.py
+++ b/backend/tests/test_august_10_joy_style_rules.py
@@ -63,6 +63,22 @@ def test_canonical_addresses_are_an_explicit_no_fabrication_exception():
     assert "approved canonical expansions or addresses" in rule["rule_text"]
 
 
+def test_ampersand_rule_covers_official_names_with_only_qa_exempt():
+    rule = seeded_rules()["ampersand_to_and"]
+
+    assert "official names" in rule["rule_text"]
+    assert "except Q&A" in rule["rule_text"]
+    assert rule["severity"] == "error"
+
+
+def test_relative_date_rule_preserves_the_specific_calendar_date():
+    rule = seeded_rules()["today_tomorrow"]
+
+    assert "retain both" in rule["rule_text"]
+    assert "Never replace or remove the calendar date" in rule["rule_text"]
+    assert rule["severity"] == "error"
+
+
 def test_migration_is_idempotent_and_matches_shared_seed():
     migration = load_migration()
     metadata = sa.MetaData()
@@ -90,11 +106,14 @@ def test_migration_is_idempotent_and_matches_shared_seed():
     # Later focused migrations supersede these original texts; their own
     # migration tests verify the latest seed values.
     superseded = {
+        "ap_style_times",
+        "ampersand_to_and",
         "cta_structure",
         "no_fabricated_content",
         "composition_title_format",
         "preserve_audience_scope",
         "preserve_purpose_contact_titles",
+        "today_tomorrow",
     }
     for row in rows:
         seed = seeded[row["Rule_Key"]]

--- a/backend/tests/test_august_20_editorial_rules.py
+++ b/backend/tests/test_august_20_editorial_rules.py
@@ -1,0 +1,88 @@
+"""Regression coverage for Joy's Aug. 20 editorial-rule clarifications."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+
+
+SEED_PATH = Path(__file__).parents[1] / "data" / "style_rules" / "shared_rules.json"
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "c7e9a1b3d5f2_align_august_20_editorial_rules.py"
+)
+
+
+def seeded_rules() -> dict[str, dict]:
+    return {rule["rule_key"]: rule for rule in json.loads(SEED_PATH.read_text())}
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("august_20_rules", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_clarified_rules_are_mandatory_and_unambiguous():
+    rules = seeded_rules()
+    required_fragments = {
+        "today_tomorrow": "Never replace or remove the calendar date",
+        "ap_style_times": "when a range crosses a.m. and p.m.",
+        "event_detail_ordering": "Never place the day or date before the time",
+        "ampersand_to_and": "except Q&A",
+        "preserve_event_title_case": "ampersand rule is the sole wording exception",
+        "preserve_audience_scope": "distribution metadata, never source content",
+    }
+
+    for rule_key, fragment in required_fragments.items():
+        assert fragment in rules[rule_key]["rule_text"]
+        assert rules[rule_key]["severity"] == "error"
+
+
+def test_migration_is_idempotent_and_matches_shared_seed():
+    migration = load_migration()
+    metadata = sa.MetaData()
+    rules = sa.Table(
+        "style_rules",
+        metadata,
+        sa.Column("Id", sa.String(36), primary_key=True),
+        sa.Column("Rule_Set", sa.String(50), nullable=False),
+        sa.Column("Category", sa.String(100), nullable=False),
+        sa.Column("Rule_Key", sa.String(100), nullable=False),
+        sa.Column("Rule_Text", sa.Text, nullable=False),
+        sa.Column("Is_Active", sa.Boolean, nullable=False),
+        sa.Column("Severity", sa.String(50), nullable=False),
+    )
+    engine = sa.create_engine("sqlite://")
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            rules.insert().values(
+                Id="stale-rule",
+                Rule_Set="shared",
+                Category="formatting",
+                Rule_Key="ampersand_to_and",
+                Rule_Text="Old text",
+                Is_Active=False,
+                Severity="warning",
+            )
+        )
+        for _ in range(2):
+            migration._apply_style_rule_updates(connection)
+        rows = connection.execute(sa.select(rules)).mappings().all()
+
+    seeded = seeded_rules()
+    assert len(rows) == len(migration.STYLE_RULE_UPDATES)
+    for row in rows:
+        seed = seeded[row["Rule_Key"]]
+        assert row["Rule_Text"] == seed["rule_text"]
+        assert row["Category"] == seed["category"]
+        assert row["Severity"] == seed["severity"]
+        assert row["Is_Active"] is True

--- a/backend/tests/test_august_joy_style_rule_migration.py
+++ b/backend/tests/test_august_joy_style_rule_migration.py
@@ -105,7 +105,13 @@ def test_migration_values_match_shared_style_rule_seed():
     seed_path = Path(__file__).parents[1] / "data" / "style_rules" / "shared_rules.json"
     seeded = {rule["rule_key"]: rule for rule in json.loads(seed_path.read_text())}
 
-    assert seeded["event_detail_ordering"]["rule_text"] == migration.EVENT_RULE_TEXT
+    # The Aug. 20 clarification supersedes this wording and makes the
+    # time-first constraint explicit. Its focused migration test verifies
+    # exact seed parity.
+    assert seeded["event_detail_ordering"]["rule_text"] != migration.EVENT_RULE_TEXT
+    assert "Never place the day or date before the time" in (
+        seeded["event_detail_ordering"]["rule_text"]
+    )
     assert seeded["event_detail_ordering"]["severity"] == "error"
     assert seeded["vandal_gear_capitalization"]["rule_text"] == (
         migration.VANDAL_GEAR_RULE_TEXT

--- a/backend/tests/test_editorial_rule_conflicts_migration.py
+++ b/backend/tests/test_editorial_rule_conflicts_migration.py
@@ -93,7 +93,11 @@ def test_migration_matches_shared_seed_values():
 
     for rule in migration.STYLE_RULE_UPDATES:
         seed = seeded[rule["rule_key"]]
-        assert rule["rule_text"] == seed["rule_text"]
+        if rule["rule_key"] == "preserve_event_title_case":
+            # The Aug. 20 clarification adds the mandatory ampersand exception.
+            assert rule["rule_text"] != seed["rule_text"]
+        else:
+            assert rule["rule_text"] == seed["rule_text"]
         assert rule["category"] == seed["category"]
         assert rule["severity"] == seed["severity"]
 

--- a/backend/tests/test_event_name_precedence_migration.py
+++ b/backend/tests/test_event_name_precedence_migration.py
@@ -137,12 +137,14 @@ def test_migration_values_match_style_rule_seeds():
         for rule in json.loads((seed_dir / "tdr_rules.json").read_text())
     }
 
-    # The rule-conflict resolution migration supersedes this text with a
-    # composition-title exception; test_editorial_rule_conflicts_migration
-    # verifies the latest seed value.
+    # Later rule-conflict and Aug. 20 migrations add the composition-title and
+    # ampersand exceptions; their focused tests verify exact seed parity.
     assert seeded_shared["preserve_event_title_case"]["rule_text"] != migration.PRESERVE_EVENT_TITLE_RULE_TEXT
-    assert seeded_shared["preserve_event_title_case"]["rule_text"].startswith(
-        migration.PRESERVE_EVENT_TITLE_RULE_TEXT
+    assert "preserving their official capitalization takes precedence" in (
+        seeded_shared["preserve_event_title_case"]["rule_text"]
+    )
+    assert "ampersand rule is the sole wording exception" in (
+        seeded_shared["preserve_event_title_case"]["rule_text"]
     )
     assert seeded_shared["preserve_event_title_case"]["severity"] == "error"
     assert seeded_shared["preserve_event_title_case"]["category"] == "formatting"

--- a/backend/tests/test_joy_style_rule_migration.py
+++ b/backend/tests/test_joy_style_rule_migration.py
@@ -115,12 +115,16 @@ def test_migration_values_match_the_style_rule_seed_files():
     for rule in migration.STYLE_RULE_UPDATES:
         key = (rule["rule_set"], rule["rule_key"])
         assert seeded[key]["category"] == rule["category"]
-        # August follow-up migrations supersede the recurring event-order,
-        # acronym, short-sentence, CTA-structure, event-name, and sentence-case rules.
+        # August follow-up migrations supersede the time, event-order,
+        # ampersand, acronym, short-sentence, CTA-structure, event-name, and
+        # sentence-case rules.
         # Dedicated regression tests verify their latest seed values; all
         # other July values remain exact.
         if key not in {
             ("shared", "short_sentences"),
+            ("shared", "ap_style_times"),
+            ("shared", "event_detail_ordering"),
+            ("shared", "ampersand_to_and"),
             ("shared", "spell_out_acronyms"),
             ("shared", "cta_structure"),
             ("shared", "preserve_event_title_case"),
@@ -131,6 +135,7 @@ def test_migration_values_match_the_style_rule_seed_files():
         if key not in {
             ("shared", "event_detail_ordering"),
             ("shared", "ap_style_times"),
+            ("shared", "ampersand_to_and"),
             ("shared", "spell_out_acronyms"),
             ("shared", "short_sentences"),
             ("shared", "cta_structure"),

--- a/backend/tests/test_specific_audience_rule_migration.py
+++ b/backend/tests/test_specific_audience_rule_migration.py
@@ -95,5 +95,9 @@ def test_migration_matches_seeded_rules():
     for category, rule_key, rule_text, severity in migration.RULES:
         rule = seeded[rule_key]
         assert rule["category"] == category
-        assert rule["rule_text"] == rule_text
+        if rule_key == "preserve_audience_scope":
+            # The Aug. 20 clarification adds the channel-metadata prohibition.
+            assert rule["rule_text"] != rule_text
+        else:
+            assert rule["rule_text"] == rule_text
         assert rule["severity"] == severity

--- a/backend/tests/test_style_checks.py
+++ b/backend/tests/test_style_checks.py
@@ -8,6 +8,9 @@ from app.utils.style_checks import (
     detect_abbreviated_months_without_date,
     detect_nonstandard_meridiems,
     detect_twelve_oclock_meridiems,
+    detect_cross_period_hyphen_ranges,
+    detect_event_detail_order_violations,
+    detect_disallowed_ampersands,
     detect_platform_names,
     detect_undefined_acronyms,
     detect_repeated_cta_phrases,
@@ -19,6 +22,7 @@ from app.utils.style_checks import (
     detect_missing_information_options,
     detect_missing_protected_organizations,
     detect_missing_broad_audience,
+    detect_introduced_audience_groups,
     detect_unformatted_composition_titles,
     detect_noncanonical_campus_locations,
     detect_missing_approved_venue_addresses,
@@ -27,6 +31,7 @@ from app.utils.style_checks import (
     detect_new_contact_channels,
     detect_new_contact_names,
     detect_changed_official_names,
+    detect_missing_relative_date_components,
     detect_missing_near_term_weekdays,
     detect_weekday_date_mismatches,
 )
@@ -67,6 +72,33 @@ class TestMeridiems:
 
     def test_accepts_noon(self):
         assert detect_twelve_oclock_meridiems("Lunch begins at noon.") == []
+
+    def test_flags_hyphenated_range_that_crosses_periods(self):
+        assert detect_cross_period_hyphen_ranges("Open 11 a.m.-2 p.m.") == [
+            "11 a.m.-2 p.m."
+        ]
+
+    def test_accepts_hyphenated_range_within_one_period(self):
+        assert detect_cross_period_hyphen_ranges("Open 1-2 p.m.") == []
+
+
+class TestEventDetailsAndAmpersands:
+    def test_flags_date_before_time(self):
+        sentence = "The workshop is Wednesday, Aug. 26, at 2 p.m. in IRIC 352."
+        assert detect_event_detail_order_violations(sentence) == [sentence]
+
+    def test_accepts_time_before_date(self):
+        assert detect_event_detail_order_violations(
+            "The workshop is at 2 p.m. Wednesday, Aug. 26, in IRIC 352."
+        ) == []
+
+    def test_flags_ampersand_in_official_name_but_allows_qa(self):
+        assert detect_disallowed_ampersands(
+            "The Research & Faculty Development Q&A starts soon."
+        ) == ["&"]
+
+    def test_ignores_html_entities(self):
+        assert detect_disallowed_ampersands("Research &amp; scholarship") == []
 
 
 class TestPlatformNames:
@@ -189,6 +221,12 @@ class TestSourceFidelity:
         text = "Audition for UIdaho Dance Ensemble and manage details in VandalStar."
 
         assert detect_changed_official_names(text, text) == []
+
+    def test_accepts_ampersand_replaced_with_and_in_official_name(self):
+        source = "The Research & Faculty Development Office hosts a workshop."
+        edited = "The Research and Faculty Development Office hosts a workshop."
+
+        assert detect_changed_official_names(source, edited) == []
 
     def test_official_names_do_not_merge_across_headline_body_boundary(self):
         source = (
@@ -346,6 +384,36 @@ class TestSourceFidelity:
         edited = "Attend the gallery reception from 4-6 p.m. Wednesday."
 
         assert detect_missing_broad_audience(source, edited) == []
+
+    def test_flags_audience_group_introduced_by_edit(self):
+        assert detect_introduced_audience_groups(
+            "Attend the workshop online.",
+            "Employees can attend the workshop online.",
+        ) == ["employees"]
+
+    def test_accepts_audience_group_present_in_source(self):
+        assert detect_introduced_audience_groups(
+            "Employees can attend the workshop online.",
+            "The workshop is open to employees online.",
+        ) == []
+
+    def test_flags_relative_date_or_calendar_date_removed(self):
+        source = "Apply today, Aug. 20, for the fellowship."
+
+        assert detect_missing_relative_date_components(
+            source,
+            "Apply today for the fellowship.",
+        ) == ["today, Aug. 20"]
+        assert detect_missing_relative_date_components(
+            source,
+            "Apply Aug. 20 for the fellowship.",
+        ) == ["today, Aug. 20"]
+
+    def test_accepts_relative_and_calendar_date_preserved(self):
+        assert detect_missing_relative_date_components(
+            "Apply today, Aug. 20, for the fellowship.",
+            "Apply today, Aug. 20, for the fellowship.",
+        ) == []
 
 
 class TestCompositionAndLocations:

--- a/frontend/src/components/submission/LinkEditor.tsx
+++ b/frontend/src/components/submission/LinkEditor.tsx
@@ -6,6 +6,7 @@ export interface LinkEntry {
 interface Props {
   links: LinkEntry[];
   onChange: (links: LinkEntry[]) => void;
+  onAnchorCommit?: (index: number, previousValue: string, nextValue: string) => void;
   label?: string;
   description?: string;
 }
@@ -23,6 +24,7 @@ function ensureSlots(links: LinkEntry[]): LinkEntry[] {
 export default function LinkEditor({
   links,
   onChange,
+  onAnchorCommit,
   label = 'Links to Embed',
   description = `Add up to ${MAX_LINKS} web URLs or email addresses to embed in your announcement.`,
 }: Props) {
@@ -122,7 +124,15 @@ export default function LinkEditor({
                     type="text"
                     placeholder={emailMode ? "e.g., Jane Smith" : "e.g., Learn more"}
                     value={link.Anchor_Text}
+                    onFocus={(e) => {
+                      e.currentTarget.dataset.initialValue = e.currentTarget.value;
+                    }}
                     onChange={(e) => updateLink(index, 'Anchor_Text', e.target.value)}
+                    onBlur={(e) => onAnchorCommit?.(
+                      index,
+                      e.currentTarget.dataset.initialValue ?? '',
+                      e.currentTarget.value,
+                    )}
                     autoComplete="off"
                     className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-ui-gold-500 focus:ring-1 focus:ring-ui-gold-500"
                   />

--- a/frontend/src/pages/EditPage.test.tsx
+++ b/frontend/src/pages/EditPage.test.tsx
@@ -556,13 +556,61 @@ describe('EditPage', () => {
     await waitFor(() => {
       expect(saveEditorFinalMock).toHaveBeenCalledWith('submission-1', {
         Headline: 'Final event headline',
-        Body: 'Reserve a seat. Register now.\n<a href="mailto:events@uidaho.edu">UCM events</a>',
+        Body: 'Reserve a seat. <a href="mailto:events@uidaho.edu">UCM events</a>.',
         Headline_Case: 'sentence_case',
         Approve_For_Newsletter: false,
         Links: [
           {
             Url: 'mailto:events@uidaho.edu',
             Anchor_Text: 'UCM events',
+            Display_Order: 0,
+          },
+        ],
+      });
+    });
+  });
+
+  it('keeps link metadata synchronized when CTA text is edited in the body', async () => {
+    const user = userEvent.setup();
+    getSubmissionMock.mockResolvedValue(makeSubmission({
+      Links: [
+        {
+          Id: 'link-1',
+          Url: 'https://example.com/register',
+          Anchor_Text: 'Register now',
+          Display_Order: 0,
+        },
+      ],
+    }));
+    listEditVersionsMock.mockResolvedValue([
+      makeVersion({
+        Version_Type: 'editor_final',
+        Headline: 'Final event headline',
+        Body: 'Reserve a seat. <a href="https://example.com/register">Register now</a>.',
+      }),
+    ]);
+
+    renderEditPage();
+
+    const body = await screen.findByPlaceholderText('Enter body text...');
+    await user.clear(body);
+    await user.type(body, 'Reserve a seat. Sign up today.');
+    await user.tab();
+    await user.click(screen.getByRole('button', { name: /save draft/i }));
+
+    await waitFor(() => {
+      expect(saveEditorFinalMock).toHaveBeenCalledWith('submission-1', {
+        Headline: 'Final event headline',
+        Body: (
+          'Reserve a seat. '
+          + '<a href="https://example.com/register">Sign up today</a>.'
+        ),
+        Headline_Case: 'sentence_case',
+        Approve_For_Newsletter: false,
+        Links: [
+          {
+            Url: 'https://example.com/register',
+            Anchor_Text: 'Sign up today',
             Display_Order: 0,
           },
         ],

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -26,6 +26,8 @@ import {
   buildLinkedBody,
   normalizedBodyLinks,
   prepareBodyForEditing,
+  synchronizeBodyWithLinkLabel,
+  synchronizeLinksWithBodyChange,
 } from '../utils/bodyLinks';
 import { buildEditorScheduleRequest } from '../utils/editorSchedule';
 import { Button, SegmentedToggle, Toast, useToast } from '../components/common';
@@ -244,6 +246,23 @@ export default function EditPage() {
     }
     setFinalEditSource(source);
     setActiveTab('editor');
+  };
+
+  const handleEditBodyChange = (nextBody: string) => {
+    setEditLinks((links) => synchronizeLinksWithBodyChange(editBody, nextBody, links));
+    setEditBody(nextBody);
+  };
+
+  const handleLinkAnchorCommit = (
+    _index: number,
+    previousValue: string,
+    nextValue: string,
+  ) => {
+    setEditBody((body) => synchronizeBodyWithLinkLabel(
+      body,
+      previousValue,
+      nextValue,
+    ));
   };
 
   const handleFinalize = async (approveForNewsletter: boolean) => {
@@ -721,11 +740,12 @@ export default function EditPage() {
                       headlineCase={aiVersion?.Headline_Case || null}
                     />
                   )}
-                  <BodyEditor value={editBody} onChange={setEditBody} />
+                  <BodyEditor value={editBody} onChange={handleEditBodyChange} />
                   <div className="border-t border-gray-100 pt-4">
                     <LinkEditor
                       links={editLinks}
                       onChange={setEditLinks}
+                      onAnchorCommit={handleLinkAnchorCommit}
                       label="Links and CTA text"
                       description="Link text stays readable in the body while its destination is edited here. Add a secure web URL or an email address."
                     />

--- a/frontend/src/utils/bodyLinks.test.ts
+++ b/frontend/src/utils/bodyLinks.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { buildLinkedBody, prepareBodyForEditing } from './bodyLinks';
+import {
+  buildLinkedBody,
+  prepareBodyForEditing,
+  synchronizeBodyWithLinkLabel,
+  synchronizeLinksWithBodyChange,
+} from './bodyLinks';
 
 describe('body link editing', () => {
   it('repairs the duplicated anchor pattern from Joy\'s dev submission', () => {
@@ -76,5 +81,44 @@ describe('body link editing', () => {
       'Additional details are available on the '
         + '<a href="https://example.com/Inside%20UI/details">committee page</a>.',
     );
+  });
+
+  it('places unmatched stored CTA text into the editable body exactly once', () => {
+    const editable = prepareBodyForEditing(
+      'Explore the university sustainability initiatives.',
+      [
+        {
+          Url: 'https://example.com/stars',
+          Anchor_Text: 'Review the STARS Gold rating',
+          Display_Order: 0,
+        },
+      ],
+    );
+
+    expect(editable.body).toBe(
+      'Explore the university sustainability initiatives.\nReview the STARS Gold rating',
+    );
+    expect(buildLinkedBody(editable.body, editable.links)).toBe(
+      'Explore the university sustainability initiatives.\n'
+        + '<a href="https://example.com/stars">Review the STARS Gold rating</a>',
+    );
+  });
+
+  it('replaces link text in place when its link field is edited', () => {
+    expect(synchronizeBodyWithLinkLabel(
+      'Reserve a seat. Register now.',
+      'Register now',
+      'UCM events',
+    )).toBe('Reserve a seat. UCM events.');
+  });
+
+  it('updates link metadata when its exact body segment is edited', () => {
+    expect(synchronizeLinksWithBodyChange(
+      'Reserve a seat. Register now.',
+      'Reserve a seat. Sign up today.',
+      [{ Url: 'https://example.com/register', Anchor_Text: 'Register now' }],
+    )).toEqual([
+      { Url: 'https://example.com/register', Anchor_Text: 'Sign up today' },
+    ]);
   });
 });

--- a/frontend/src/utils/bodyLinks.ts
+++ b/frontend/src/utils/bodyLinks.ts
@@ -110,7 +110,59 @@ export function prepareBodyForEditing(
     });
   }
 
+  // Keep the body and link fields as one editable representation. A stored
+  // link label that is absent from the body would otherwise be appended only
+  // during serialization, making duplicate CTA text invisible until save.
+  for (const link of links) {
+    const label = link.Anchor_Text.trim();
+    if (!label || plainBody.toLocaleLowerCase().includes(label.toLocaleLowerCase())) {
+      continue;
+    }
+    plainBody = [plainBody.trimEnd(), label].filter(Boolean).join('\n');
+  }
+
   return { body: plainBody, links: links.slice(0, 3) };
+}
+
+export function synchronizeBodyWithLinkLabel(
+  body: string,
+  previousLabel: string,
+  nextLabel: string,
+): string {
+  const previous = previousLabel.trim();
+  const next = nextLabel.trim().replace(/[<>]/g, '');
+  if (!previous || !next || previous === next) return body;
+
+  const matchIndex = body.toLocaleLowerCase().indexOf(previous.toLocaleLowerCase());
+  if (matchIndex < 0) {
+    if (body.toLocaleLowerCase().includes(next.toLocaleLowerCase())) return body;
+    return [body.trimEnd(), next].filter(Boolean).join('\n');
+  }
+
+  return `${body.slice(0, matchIndex)}${next}${body.slice(matchIndex + previous.length)}`;
+}
+
+export function synchronizeLinksWithBodyChange(
+  previousBody: string,
+  nextBody: string,
+  links: EditableBodyLink[],
+): EditableBodyLink[] {
+  return links.map((link) => {
+    const label = link.Anchor_Text.trim();
+    if (!label) return link;
+
+    const labelIndex = previousBody.toLocaleLowerCase().indexOf(label.toLocaleLowerCase());
+    if (labelIndex < 0) return link;
+
+    const before = previousBody.slice(0, labelIndex);
+    const after = previousBody.slice(labelIndex + label.length);
+    if (!nextBody.startsWith(before) || !nextBody.endsWith(after)) return link;
+
+    const replacementEnd = nextBody.length - after.length;
+    const replacement = nextBody.slice(before.length, replacementEnd).trim().replace(/[<>]/g, '');
+    if (!replacement || replacement === label) return link;
+    return { ...link, Anchor_Text: replacement };
+  });
 }
 
 function linkLabel(link: EditableBodyLink): string {


### PR DESCRIPTION
## Summary

- add deterministic post-edit validation for inferred audiences, disallowed ampersands, event-detail order, cross-period time ranges, and explicit dates paired with relative references
- align the shared style-rule seed, AI prompt, and an idempotent Alembic migration with the clarified editorial requirements
- keep Final Edit body text and link metadata synchronized so CTA labels are edited and serialized exactly once
- add backend, migration, utility, and page-level regression coverage

## Validation

- Backend tests: 327 passed
- Frontend tests: 87 passed
- Ruff: passed
- Frontend build: passed
- Frontend lint: passed
- Alembic head: c7e9a1b3d5f2

Closes #322
Closes #323
Closes #324
Closes #325
Closes #326