### PR TITLE
Fix CTA link synchronization regressions

### DIFF
--- a/frontend/src/components/editor/BodyEditor.tsx
+++ b/frontend/src/components/editor/BodyEditor.tsx
@@ -1,29 +1,29 @@
-import { useState, useEffect } from 'react';
-
 interface BodyEditorProps {
   value: string;
   onChange: (value: string) => void;
+  onCommit?: (previousValue: string, nextValue: string) => void;
   disabled?: boolean;
 }
 
-export default function BodyEditor({ value, onChange, disabled = false }: BodyEditorProps) {
-  const [localValue, setLocalValue] = useState(value);
-
-  useEffect(() => {
-    setLocalValue(value);
-  }, [value]);
-
-  const handleBlur = () => {
-    onChange(localValue);
-  };
-
+export default function BodyEditor({
+  value,
+  onChange,
+  onCommit,
+  disabled = false,
+}: BodyEditorProps) {
   return (
     <div>
       <label className="block text-xs font-medium text-gray-700 mb-1">Body</label>
       <textarea
-        value={localValue}
-        onChange={(e) => setLocalValue(e.target.value)}
-        onBlur={handleBlur}
+        value={value}
+        onFocus={(e) => {
+          e.currentTarget.dataset.initialValue = e.currentTarget.value;
+        }}
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={(e) => onCommit?.(
+          e.currentTarget.dataset.initialValue ?? '',
+          e.currentTarget.value,
+        )}
         disabled={disabled}
         rows={8}
         className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm

--- a/frontend/src/pages/EditPage.test.tsx
+++ b/frontend/src/pages/EditPage.test.tsx
@@ -618,6 +618,72 @@ describe('EditPage', () => {
     });
   });
 
+  it('updates the live link preview while body text is being typed', async () => {
+    const user = userEvent.setup();
+    getSubmissionMock.mockResolvedValue(makeSubmission({
+      Links: [
+        {
+          Id: 'link-1',
+          Url: 'https://example.com/register',
+          Anchor_Text: 'Register now',
+          Display_Order: 0,
+        },
+      ],
+    }));
+    listEditVersionsMock.mockResolvedValue([
+      makeVersion({
+        Version_Type: 'editor_final',
+        Body: 'Reserve a seat. <a href="https://example.com/register">Register now</a>.',
+      }),
+    ]);
+
+    renderEditPage();
+
+    const preview = await screen.findByRole('region', { name: 'Newsletter body preview' });
+    const body = screen.getByPlaceholderText('Enter body text...');
+    await user.type(body, ' Updated');
+
+    expect(preview).toHaveTextContent('Reserve a seat. Register now. Updated');
+  });
+
+  it('does not preserve a removed CTA as hidden link metadata', async () => {
+    const user = userEvent.setup();
+    getSubmissionMock.mockResolvedValue(makeSubmission({
+      Links: [
+        {
+          Id: 'link-1',
+          Url: 'https://example.com/register',
+          Anchor_Text: 'Register now',
+          Display_Order: 0,
+        },
+      ],
+    }));
+    listEditVersionsMock.mockResolvedValue([
+      makeVersion({
+        Version_Type: 'editor_final',
+        Headline: 'Final event headline',
+        Body: 'Reserve a seat. <a href="https://example.com/register">Register now</a>.',
+      }),
+    ]);
+
+    renderEditPage();
+
+    const body = await screen.findByPlaceholderText('Enter body text...');
+    await user.clear(body);
+    await user.type(body, 'Reserve a seat.');
+    await user.click(screen.getByRole('button', { name: /save draft/i }));
+
+    await waitFor(() => {
+      expect(saveEditorFinalMock).toHaveBeenCalledWith('submission-1', {
+        Headline: 'Final event headline',
+        Body: 'Reserve a seat.',
+        Headline_Case: 'sentence_case',
+        Approve_For_Newsletter: false,
+        Links: [],
+      });
+    });
+  });
+
   it('keeps the explicit draft action distinct from approval', async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/pages/EditPage.tsx
+++ b/frontend/src/pages/EditPage.tsx
@@ -249,8 +249,15 @@ export default function EditPage() {
   };
 
   const handleEditBodyChange = (nextBody: string) => {
-    setEditLinks((links) => synchronizeLinksWithBodyChange(editBody, nextBody, links));
     setEditBody(nextBody);
+  };
+
+  const handleEditBodyCommit = (previousBody: string, nextBody: string) => {
+    setEditLinks((links) => synchronizeLinksWithBodyChange(
+      previousBody,
+      nextBody,
+      links,
+    ));
   };
 
   const handleLinkAnchorCommit = (
@@ -277,7 +284,7 @@ export default function EditPage() {
         : finalEditSource === 'saved'
           ? editorVersion
           : undefined;
-      const links = normalizedBodyLinks(editLinks);
+      const links = normalizedBodyLinks(editLinks, editBody);
       await saveEditorFinal(id, {
         Headline: submission?.Category === 'job_opportunity' ? '' : editHeadline,
         Body: buildLinkedBody(editBody, links),
@@ -740,7 +747,11 @@ export default function EditPage() {
                       headlineCase={aiVersion?.Headline_Case || null}
                     />
                   )}
-                  <BodyEditor value={editBody} onChange={handleEditBodyChange} />
+                  <BodyEditor
+                    value={editBody}
+                    onChange={handleEditBodyChange}
+                    onCommit={handleEditBodyCommit}
+                  />
                   <div className="border-t border-gray-100 pt-4">
                     <LinkEditor
                       links={editLinks}

--- a/frontend/src/utils/bodyLinks.test.ts
+++ b/frontend/src/utils/bodyLinks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildLinkedBody,
+  normalizedBodyLinks,
   prepareBodyForEditing,
   synchronizeBodyWithLinkLabel,
   synchronizeLinksWithBodyChange,
@@ -83,7 +84,7 @@ describe('body link editing', () => {
     );
   });
 
-  it('places unmatched stored CTA text into the editable body exactly once', () => {
+  it('does not inject unmatched stored CTA text into the editable body', () => {
     const editable = prepareBodyForEditing(
       'Explore the university sustainability initiatives.',
       [
@@ -95,13 +96,76 @@ describe('body link editing', () => {
       ],
     );
 
-    expect(editable.body).toBe(
-      'Explore the university sustainability initiatives.\nReview the STARS Gold rating',
-    );
+    expect(editable.body).toBe('Explore the university sustainability initiatives.');
     expect(buildLinkedBody(editable.body, editable.links)).toBe(
-      'Explore the university sustainability initiatives.\n'
-        + '<a href="https://example.com/stars">Review the STARS Gold rating</a>',
+      'Explore the university sustainability initiatives.',
     );
+  });
+
+  it('removes a legacy standalone anchor even when its label differs from the prose', () => {
+    const editable = prepareBodyForEditing(
+      'Discover why U of I is an AASHE STARS Gold-rated university.\n'
+        + '<a href="https://example.com/stars">'
+        + 'Association for the Advancement of Sustainability STARS Gold rated university'
+        + '</a>',
+      [
+        {
+          Url: 'https://example.com/stars',
+          Anchor_Text: (
+            'Association for the Advancement of Sustainability '
+            + 'STARS Gold rated university'
+          ),
+          Display_Order: 0,
+        },
+      ],
+    );
+
+    expect(editable.body).toBe(
+      'Discover why U of I is an AASHE STARS Gold-rated university.',
+    );
+  });
+
+  it('uses the stored destination when a CTA keeps its text but its URL changes', () => {
+    const editable = prepareBodyForEditing(
+      'Visit the <a href="https://old.example.com">Inside U of I homepage</a>.',
+      [
+        {
+          Url: 'https://new.example.com',
+          Anchor_Text: 'Inside U of I homepage',
+          Display_Order: 0,
+        },
+      ],
+    );
+
+    expect(editable.links).toEqual([
+      {
+        Url: 'https://new.example.com',
+        Anchor_Text: 'Inside U of I homepage',
+        Display_Order: 0,
+      },
+    ]);
+  });
+
+  it('does not resurrect a CTA that an editor removed from the body', () => {
+    expect(buildLinkedBody(
+      'Reserve a seat.',
+      [{ Url: 'https://example.com/register', Anchor_Text: 'Register now' }],
+    )).toBe('Reserve a seat.');
+  });
+
+  it('drops hidden link metadata when its anchor is absent from the body', () => {
+    expect(normalizedBodyLinks(
+      [{ Url: 'https://example.com/register', Anchor_Text: 'Register now' }],
+      'Reserve a seat.',
+    )).toEqual([]);
+  });
+
+  it('places a newly named link visibly into the body before serialization', () => {
+    expect(synchronizeBodyWithLinkLabel(
+      'Reserve a seat.',
+      '',
+      'Register now',
+    )).toBe('Reserve a seat.\nRegister now');
   });
 
   it('replaces link text in place when its link field is edited', () => {

--- a/frontend/src/utils/bodyLinks.ts
+++ b/frontend/src/utils/bodyLinks.ts
@@ -77,20 +77,34 @@ export function prepareBodyForEditing(
     return anchorText;
   });
 
-  // Older editor builds appended unmatched anchors on their own line. Remove
-  // only those generated duplicates when the same label already exists in the
-  // prose; retain their link metadata so it can be reattached there.
-  const lowerBody = plainBody.toLocaleLowerCase();
-  plainBody = plainBody
-    .split('\n')
-    .filter((line) => {
-      const label = line.trim().toLocaleLowerCase();
-      if (!standaloneAnchorLabels.has(label)) return true;
-      const first = lowerBody.indexOf(label);
-      return first === lowerBody.lastIndexOf(label);
-    })
-    .join('\n')
-    .trimEnd();
+  // Older editor builds silently appended unmatched anchors at the end of the
+  // body. Remove that trailing generated block when real prose precedes it.
+  // The link metadata remains available in the link fields so an editor can
+  // deliberately attach it to wording that actually exists in the body.
+  const bodyLines = plainBody.split('\n');
+  let trailingBlockStart = bodyLines.length;
+  let foundStandaloneAnchor = false;
+  for (let index = bodyLines.length - 1; index >= 0; index -= 1) {
+    const label = bodyLines[index].trim().toLocaleLowerCase();
+    if (!label) {
+      trailingBlockStart = index;
+      continue;
+    }
+    if (standaloneAnchorLabels.has(label)) {
+      foundStandaloneAnchor = true;
+      trailingBlockStart = index;
+      continue;
+    }
+    break;
+  }
+  const hasEarlierProse = bodyLines
+    .slice(0, trailingBlockStart)
+    .some((line) => line.trim());
+  if (foundStandaloneAnchor && hasEarlierProse) {
+    plainBody = bodyLines.slice(0, trailingBlockStart).join('\n').trimEnd();
+  } else {
+    plainBody = plainBody.trimEnd();
+  }
 
   const links = [...bodyLinks];
   for (const link of [...storedLinks].sort(
@@ -103,22 +117,26 @@ export function prepareBodyForEditing(
     if (links.some(
       (candidate) => canonicalLinkDestination(candidate.Url) === canonicalUrl,
     )) continue;
+    const matchingAnchorIndex = anchorText
+      ? links.findIndex(
+        (candidate) => (
+          candidate.Anchor_Text.trim().toLocaleLowerCase()
+          === anchorText.toLocaleLowerCase()
+        ),
+      )
+      : -1;
+    if (matchingAnchorIndex >= 0) {
+      links[matchingAnchorIndex] = {
+        ...links[matchingAnchorIndex],
+        Url: normalizedUrl,
+      };
+      continue;
+    }
     links.push({
       Url: normalizedUrl,
       Anchor_Text: anchorText,
       Display_Order: links.length,
     });
-  }
-
-  // Keep the body and link fields as one editable representation. A stored
-  // link label that is absent from the body would otherwise be appended only
-  // during serialization, making duplicate CTA text invisible until save.
-  for (const link of links) {
-    const label = link.Anchor_Text.trim();
-    if (!label || plainBody.toLocaleLowerCase().includes(label.toLocaleLowerCase())) {
-      continue;
-    }
-    plainBody = [plainBody.trimEnd(), label].filter(Boolean).join('\n');
   }
 
   return { body: plainBody, links: links.slice(0, 3) };
@@ -131,7 +149,11 @@ export function synchronizeBodyWithLinkLabel(
 ): string {
   const previous = previousLabel.trim();
   const next = nextLabel.trim().replace(/[<>]/g, '');
-  if (!previous || !next || previous === next) return body;
+  if (!next || previous === next) return body;
+  if (!previous) {
+    if (body.toLocaleLowerCase().includes(next.toLocaleLowerCase())) return body;
+    return [body.trimEnd(), next].filter(Boolean).join('\n');
+  }
 
   const matchIndex = body.toLocaleLowerCase().indexOf(previous.toLocaleLowerCase());
   if (matchIndex < 0) {
@@ -196,8 +218,6 @@ export function buildLinkedBody(body: string, links: EditableBodyLink[]): string
 
   const occupiedRanges: Array<{ start: number; end: number }> = [];
   const replacements: Array<{ start: number; end: number; markup: string }> = [];
-  const appendedLinks: string[] = [];
-
   for (const link of validLinks) {
     const label = linkLabel(link);
     if (!label) continue;
@@ -223,9 +243,6 @@ export function buildLinkedBody(body: string, links: EditableBodyLink[]): string
         end: matchIndex + label.length,
         markup,
       });
-    } else {
-      const markup = `<a href="${safeAttributeValue(link.Url)}">${label}</a>`;
-      appendedLinks.push(markup);
     }
   }
 
@@ -234,11 +251,15 @@ export function buildLinkedBody(body: string, links: EditableBodyLink[]): string
     linkedBody = `${linkedBody.slice(0, replacement.start)}${replacement.markup}${linkedBody.slice(replacement.end)}`;
   }
 
-  return [linkedBody.trimEnd(), ...appendedLinks].filter(Boolean).join('\n');
+  return linkedBody.trimEnd();
 }
 
-export function normalizedBodyLinks(links: EditableBodyLink[]): EditableBodyLink[] {
+export function normalizedBodyLinks(
+  links: EditableBodyLink[],
+  body?: string,
+): EditableBodyLink[] {
   const seenDestinations = new Set<string>();
+  const searchableBody = body?.toLocaleLowerCase();
   return links
     .map((link, index) => ({
       Url: normalizeEditableLinkUrl(link.Url),
@@ -247,6 +268,13 @@ export function normalizedBodyLinks(links: EditableBodyLink[]): EditableBodyLink
     }))
     .filter((link) => {
       if (!link.Url || !isSafeLinkDestination(link.Url)) return false;
+      if (
+        searchableBody !== undefined
+        && (
+          !link.Anchor_Text
+          || !searchableBody.includes(link.Anchor_Text.toLocaleLowerCase())
+        )
+      ) return false;
       const canonicalUrl = canonicalLinkDestination(link.Url);
       if (seenDestinations.has(canonicalUrl)) return false;
       seenDestinations.add(canonicalUrl);


### PR DESCRIPTION
## Summary

- stop stale CTA metadata from being reinserted into edited body text
- update link destinations without creating duplicate CTA entries
- keep Final Edit preview synchronized while typing and reconcile link metadata on blur
- remove legacy trailing CTA-only blocks during edit preparation

## Verification

- `npm test -- --run` — 94 tests passed
- `npm run build`
- `npm run lint`
- `git diff --check`

Regression follow-up to #326.
