### PR TITLE
Add guarded SLC calendar workbook importer

### DIFF
--- a/backend/app/services/slc_event_import_service.py
+++ b/backend/app/services/slc_event_import_service.py
@@ -1,0 +1,457 @@
+"""Import Senior Leadership Council calendar events from Excel workbooks.
+
+The SLC calendar is backed by ``Submission`` records whose newsletter target is
+``none``. This module translates the lightweight fiscal-year workbooks used by
+Auxiliary Services into those records while preserving source context and date
+uncertainty. Parsing stays separate from persistence so every import can be
+previewed and tested before it changes a database.
+
+Workbook date cells may be native Excel dates, single month/day strings, or
+date ranges. A trailing question mark is treated as tentative rather than as
+an instruction to invent certainty. Alternative dates joined with "or" are
+reported for human review and are not imported automatically.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import date, datetime, time
+from pathlib import Path
+from typing import Any, Iterable
+
+from openpyxl import load_workbook
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.submission import Submission, SubmissionScheduleRequest
+
+IMPORT_EMAIL = "slc-calendar-import@uidaho.edu"
+IMPORT_NAME = "SLC calendar spreadsheet import"
+IMPORT_KEY_PREFIX = "SLC spreadsheet import key:"
+FISCAL_YEAR_SHEET_PATTERN = re.compile(r"^FY(?P<year>\d{2})$", re.IGNORECASE)
+DATE_TOKEN_PATTERN = r"\d{1,2}/\d{1,2}(?:/\d{2,4})?"
+
+
+class DateParseError(ValueError):
+    """Raised when an event date cannot be mapped safely to calendar dates."""
+
+    def __init__(self, message: str, code: str = "invalid_date") -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class ImportSchedule:
+    """One calendar occurrence or contiguous date range from a workbook row."""
+
+    start_date: date
+    end_date: date | None = None
+
+    @property
+    def effective_end_date(self) -> date:
+        return self.end_date or self.start_date
+
+
+@dataclass(frozen=True)
+class SLCEventImportRecord:
+    """A validated event row ready to become an SLC-only submission."""
+
+    sheet_name: str
+    row_number: int
+    title: str
+    source_date: str
+    schedules: tuple[ImportSchedule, ...]
+    tentative: bool
+    start_time: str | None = None
+    location: str | None = None
+    sponsor: str | None = None
+    detail_label: str | None = None
+    detail_value: str | None = None
+
+    @property
+    def import_key(self) -> str:
+        payload = {
+            "title": self.title.casefold(),
+            "source_date": self.source_date.casefold(),
+            "schedules": [
+                [schedule.start_date.isoformat(), schedule.effective_end_date.isoformat()]
+                for schedule in self.schedules
+            ],
+            "start_time": (self.start_time or "").casefold(),
+            "location": (self.location or "").casefold(),
+            "sponsor": (self.sponsor or "").casefold(),
+        }
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        return hashlib.sha256(encoded).hexdigest()[:24]
+
+
+@dataclass(frozen=True)
+class ImportIssue:
+    """A source event that was intentionally omitted from an import plan."""
+
+    sheet_name: str
+    row_number: int
+    title: str
+    source_date: str
+    code: str
+    message: str
+
+
+@dataclass
+class SLCEventImportPlan:
+    """Validated records and review items produced from one workbook."""
+
+    workbook_name: str
+    records: list[SLCEventImportRecord] = field(default_factory=list)
+    issues: list[ImportIssue] = field(default_factory=list)
+
+    def issue_counts(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for issue in self.issues:
+            counts[issue.code] = counts.get(issue.code, 0) + 1
+        return counts
+
+
+@dataclass(frozen=True)
+class ImportResult:
+    """Persistence result for a validated import plan."""
+
+    inserted: int
+    existing: int
+    would_insert: int
+
+
+def _clean_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, time):
+        hour = value.hour % 12 or 12
+        minute = f":{value.minute:02d}" if value.minute else ""
+        suffix = "A" if value.hour < 12 else "P"
+        return f"{hour}{minute}{suffix}"
+    text = str(value).strip()
+    return text or None
+
+
+def _fiscal_year_bounds(fiscal_year: int) -> tuple[date, date]:
+    return date(fiscal_year - 1, 7, 1), date(fiscal_year, 6, 30)
+
+
+def _parse_date_token(token: str, fiscal_year: int) -> date:
+    parts = [int(part) for part in token.split("/")]
+    month, day = parts[:2]
+    if len(parts) == 3:
+        year = parts[2]
+        if year < 100:
+            year += 2000
+    else:
+        year = fiscal_year - 1 if month >= 7 else fiscal_year
+
+    try:
+        parsed = date(year, month, day)
+    except ValueError as exc:
+        raise DateParseError(f"Invalid calendar date: {token}") from exc
+
+    fiscal_start, fiscal_end = _fiscal_year_bounds(fiscal_year)
+    if not fiscal_start <= parsed <= fiscal_end:
+        raise DateParseError(
+            f"Date {parsed.isoformat()} falls outside FY{fiscal_year % 100:02d}",
+            code="outside_fiscal_year",
+        )
+    return parsed
+
+
+def parse_event_date(
+    value: Any,
+    fiscal_year: int,
+) -> tuple[tuple[ImportSchedule, ...], bool, str]:
+    """Parse one workbook date cell without guessing among alternatives."""
+    if isinstance(value, datetime):
+        value = value.date()
+    if isinstance(value, date):
+        fiscal_start, fiscal_end = _fiscal_year_bounds(fiscal_year)
+        if not fiscal_start <= value <= fiscal_end:
+            raise DateParseError(
+                f"Date {value.isoformat()} falls outside FY{fiscal_year % 100:02d}",
+                code="outside_fiscal_year",
+            )
+        return (ImportSchedule(value),), False, value.strftime("%-m/%-d/%Y")
+
+    text = _clean_text(value)
+    if not text:
+        raise DateParseError("Event has no date", code="missing_date")
+
+    tentative = "?" in text
+    normalized = text.replace("?", "").strip()
+    normalized = normalized.replace("–", "-").replace("—", "-")
+
+    if re.search(r"\bor\b", normalized, flags=re.IGNORECASE):
+        raise DateParseError(
+            "Alternative dates joined with 'or' require confirmation",
+            code="ambiguous_date",
+        )
+
+    and_parts = re.split(r"\s+and\s+", normalized, flags=re.IGNORECASE)
+    if len(and_parts) > 1:
+        if not all(re.fullmatch(DATE_TOKEN_PATTERN, part.strip()) for part in and_parts):
+            raise DateParseError("Could not parse the dates joined with 'and'")
+        schedules = tuple(
+            ImportSchedule(_parse_date_token(part.strip(), fiscal_year))
+            for part in and_parts
+        )
+        return schedules, tentative, text
+
+    range_match = re.fullmatch(
+        rf"(?P<start>{DATE_TOKEN_PATTERN})\s*-\s*(?P<end>{DATE_TOKEN_PATTERN})",
+        normalized,
+    )
+    if range_match:
+        start = _parse_date_token(range_match.group("start"), fiscal_year)
+        end = _parse_date_token(range_match.group("end"), fiscal_year)
+        if end < start:
+            raise DateParseError("Date range ends before it starts")
+        return (ImportSchedule(start, end),), tentative, text
+
+    if re.fullmatch(DATE_TOKEN_PATTERN, normalized):
+        parsed = _parse_date_token(normalized, fiscal_year)
+        return (ImportSchedule(parsed),), tentative, text
+
+    raise DateParseError(f"Unrecognized date format: {text}")
+
+
+def _schedule_intersects_window(
+    schedule: ImportSchedule,
+    from_date: date,
+    through_date: date | None,
+) -> bool:
+    if schedule.effective_end_date < from_date:
+        return False
+    if through_date and schedule.start_date > through_date:
+        return False
+    return True
+
+
+def load_import_plan(
+    workbook_path: Path,
+    *,
+    sheet_names: Iterable[str] | None = None,
+    from_date: date,
+    through_date: date | None = None,
+    include_tentative: bool = True,
+) -> SLCEventImportPlan:
+    """Read fiscal-year worksheets and return a non-mutating import preview."""
+    workbook = load_workbook(workbook_path, read_only=True, data_only=True)
+    requested_sheets = set(sheet_names or [])
+    available_fiscal_sheets = [
+        name for name in workbook.sheetnames if FISCAL_YEAR_SHEET_PATTERN.fullmatch(name)
+    ]
+    selected_sheets = (
+        [name for name in available_fiscal_sheets if name in requested_sheets]
+        if requested_sheets
+        else available_fiscal_sheets
+    )
+    missing_sheets = requested_sheets.difference(workbook.sheetnames)
+    if missing_sheets:
+        missing = ", ".join(sorted(missing_sheets))
+        raise ValueError(f"Workbook does not contain requested sheet(s): {missing}")
+    if not selected_sheets:
+        raise ValueError("Workbook has no fiscal-year sheets named like FY27")
+
+    plan = SLCEventImportPlan(workbook_name=workbook_path.name)
+    for sheet_name in selected_sheets:
+        fiscal_year_match = FISCAL_YEAR_SHEET_PATTERN.fullmatch(sheet_name)
+        assert fiscal_year_match is not None
+        fiscal_year = 2000 + int(fiscal_year_match.group("year"))
+        worksheet = workbook[sheet_name]
+        headers = [_clean_text(cell.value) for cell in worksheet[1][:6]]
+        if len(headers) < 5 or headers[:5] != [
+            "Date",
+            "Start Time",
+            "Event",
+            "Location",
+            "Sponsor",
+        ]:
+            raise ValueError(
+                f"{sheet_name} must start with Date, Start Time, Event, Location, Sponsor"
+            )
+        detail_label = headers[5] if len(headers) > 5 else None
+        if detail_label and detail_label.casefold() == "catatory":
+            detail_label = "Category"
+
+        for row_number, row in enumerate(
+            worksheet.iter_rows(min_row=2, max_col=6, values_only=True),
+            start=2,
+        ):
+            values = tuple(row) + (None,) * (6 - len(row))
+            title = _clean_text(values[2])
+            if not title:
+                continue
+            source_date = _clean_text(values[0]) or ""
+            try:
+                schedules, tentative, source_date = parse_event_date(
+                    values[0], fiscal_year
+                )
+            except DateParseError as exc:
+                plan.issues.append(
+                    ImportIssue(
+                        sheet_name=sheet_name,
+                        row_number=row_number,
+                        title=title,
+                        source_date=source_date,
+                        code=exc.code,
+                        message=str(exc),
+                    )
+                )
+                continue
+
+            schedules_in_window = tuple(
+                schedule
+                for schedule in schedules
+                if _schedule_intersects_window(schedule, from_date, through_date)
+            )
+            if not schedules_in_window:
+                last_date = max(schedule.effective_end_date for schedule in schedules)
+                code = "before_window" if last_date < from_date else "after_window"
+                plan.issues.append(
+                    ImportIssue(
+                        sheet_name=sheet_name,
+                        row_number=row_number,
+                        title=title,
+                        source_date=source_date,
+                        code=code,
+                        message="Event falls outside the requested import window",
+                    )
+                )
+                continue
+
+            if tentative and not include_tentative:
+                plan.issues.append(
+                    ImportIssue(
+                        sheet_name=sheet_name,
+                        row_number=row_number,
+                        title=title,
+                        source_date=source_date,
+                        code="tentative_date",
+                        message="Tentative dates were excluded by request",
+                    )
+                )
+                continue
+
+            plan.records.append(
+                SLCEventImportRecord(
+                    sheet_name=sheet_name,
+                    row_number=row_number,
+                    title=title,
+                    source_date=source_date,
+                    schedules=schedules_in_window,
+                    tentative=tentative,
+                    start_time=_clean_text(values[1]),
+                    location=_clean_text(values[3]),
+                    sponsor=_clean_text(values[4]),
+                    detail_label=detail_label,
+                    detail_value=_clean_text(values[5]),
+                )
+            )
+    return plan
+
+
+def _build_body(record: SLCEventImportRecord) -> str:
+    parts = [f"Source date: {record.source_date}"]
+    if record.tentative:
+        parts.append("Date status: Tentative in source workbook")
+    if record.start_time:
+        parts.append(f"Start time: {record.start_time}")
+    if record.location:
+        parts.append(f"Location: {record.location}")
+    if record.sponsor:
+        parts.append(f"Sponsor: {record.sponsor}")
+    if record.detail_label and record.detail_value:
+        parts.append(f"{record.detail_label}: {record.detail_value}")
+    parts.append(f"Source: {record.sheet_name}, row {record.row_number}")
+    return "\n".join(parts)
+
+
+def _build_notes(record: SLCEventImportRecord, workbook_name: str) -> str:
+    return "\n".join(
+        [
+            f"{IMPORT_KEY_PREFIX} {record.import_key}",
+            f"Source workbook: {workbook_name}",
+            f"Source worksheet: {record.sheet_name}, row {record.row_number}",
+        ]
+    )
+
+
+async def import_records(
+    db: AsyncSession,
+    plan: SLCEventImportPlan,
+    *,
+    apply_changes: bool,
+) -> ImportResult:
+    """Insert non-duplicate records, or report what an apply would insert."""
+    inserted = 0
+    existing = 0
+    for record in plan.records:
+        key_marker = f"{IMPORT_KEY_PREFIX} {record.import_key}"
+        duplicate = await db.execute(
+            select(Submission.Id)
+            .where(
+                Submission.Submitter_Email == IMPORT_EMAIL,
+                Submission.Submitter_Notes.contains(key_marker),
+            )
+            .limit(1)
+        )
+        if duplicate.scalar_one_or_none() is not None:
+            existing += 1
+            continue
+        if not apply_changes:
+            continue
+
+        submission = Submission(
+            Category="slc_event",
+            Target_Newsletter="none",
+            Original_Headline=record.title,
+            Original_Body=_build_body(record),
+            Submitter_Name=IMPORT_NAME,
+            Submitter_Email=IMPORT_EMAIL,
+            Submitter_Notes=_build_notes(record, plan.workbook_name),
+            Show_In_SLC_Calendar=True,
+            Event_Classification=None,
+            Status="pending_info" if record.tentative else "approved",
+        )
+        db.add(submission)
+        await db.flush()
+
+        for schedule in record.schedules:
+            is_range = schedule.effective_end_date > schedule.start_date
+            db.add(
+                SubmissionScheduleRequest(
+                    Submission_Id=submission.Id,
+                    Requested_Date=schedule.start_date,
+                    Repeat_Count=1,
+                    Repeat_Note=(
+                        "Tentative date from source workbook"
+                        if record.tentative
+                        else None
+                    ),
+                    Is_Flexible=record.tentative,
+                    Recurrence_Type="date_range" if is_range else "once",
+                    Recurrence_Interval=1,
+                    Recurrence_End_Date=(
+                        schedule.effective_end_date if is_range else None
+                    ),
+                    Excluded_Dates=[],
+                )
+            )
+        inserted += 1
+
+    if apply_changes:
+        await db.commit()
+
+    return ImportResult(
+        inserted=inserted,
+        existing=existing,
+        would_insert=len(plan.records) - existing,
+    )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "python-multipart>=0.0.9",
     "python-docx>=1.1.0",
+    "openpyxl>=3.1.0",
     "anthropic>=0.39.0",
     "openai>=1.50.0",
     "httpx>=0.27.0",

--- a/backend/scripts/seed_slc_events.py
+++ b/backend/scripts/seed_slc_events.py
@@ -1,157 +1,108 @@
-"""Seed SLC calendar submissions from the Auxiliary Services spreadsheet.
+"""Preview or import an SLC calendar workbook into the configured database."""
 
-Reads FY26 events (April + May 2026) from AuxServices/Calendar Spreadsheet1.xlsx
-and inserts them as Submissions with Target_Newsletter="none" and
-Show_In_SLC_Calendar=True. Idempotent: skips any submission where the
-Submitter_Email + Original_Headline + Requested_Date combo already exists.
+from __future__ import annotations
 
-Exists as a one-off exploration seed for the feature/slc-calendar-exploration
-branch — not wired into production seed.py.
-"""
-
+import argparse
 import asyncio
-import re
-import sys
 import warnings
-from datetime import date, datetime
+from datetime import date
 from pathlib import Path
 
-from openpyxl import load_workbook
-from sqlalchemy import select
-
 from app.db.engine import async_session_factory
-from app.models.submission import Submission, SubmissionScheduleRequest
-
-warnings.filterwarnings("ignore", category=UserWarning, module="openpyxl")
-
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-SPREADSHEET = REPO_ROOT / "AuxServices" / "Calendar Spreadsheet1.xlsx"
-SEED_EMAIL = "auxservices-seed@example.edu"
-SEED_NAME = "Auxiliary Services (spreadsheet import)"
+from app.services.slc_event_import_service import import_records, load_import_plan
 
 
-def _parse_cell_date(value) -> date | None:
-    """Return a date for a cell that's either a datetime, date, or a m/d range string."""
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value.date()
-    if isinstance(value, date):
-        return value
-    if isinstance(value, str):
-        # Strip trailing "?" and whitespace, keep only the start of a range.
-        cleaned = value.strip().rstrip("?").strip()
-        cleaned = cleaned.split("-")[0].strip()
-        m = re.match(r"^(\d{1,2})/(\d{1,2})$", cleaned)
-        if m:
-            month, day = int(m.group(1)), int(m.group(2))
-            # FY26 Apr–May data all falls in calendar-year 2026.
-            return date(2026, month, day)
-    return None
+def _iso_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("Expected an ISO date such as 2026-08-20") from exc
 
 
-def _build_body(event: str, location: str | None, sponsor: str | None,
-                start_time: str | None, ticketed: str | None) -> str:
-    parts = [f"Event: {event}"]
-    if location:
-        parts.append(f"Location: {location}")
-    if sponsor:
-        parts.append(f"Sponsor: {sponsor}")
-    if start_time:
-        parts.append(f"Start Time: {start_time}")
-    if ticketed:
-        parts.append(f"Ticketed: {ticketed}")
-    return "\n".join(parts)
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate an Auxiliary Services workbook and populate the SLC calendar. "
+            "The command is a dry run unless --apply is provided."
+        )
+    )
+    parser.add_argument("spreadsheet", type=Path, help="Path to the .xlsx workbook")
+    parser.add_argument(
+        "--sheet",
+        action="append",
+        dest="sheets",
+        help="Fiscal-year sheet to import (repeatable; defaults to all FY sheets)",
+    )
+    parser.add_argument(
+        "--from-date",
+        type=_iso_date,
+        default=date.today(),
+        help="Ignore events that end before this date (default: today)",
+    )
+    parser.add_argument(
+        "--through-date",
+        type=_iso_date,
+        help="Ignore events that start after this date",
+    )
+    parser.add_argument(
+        "--confirmed-only",
+        action="store_true",
+        help="Exclude source dates marked with a question mark",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Commit validated, non-duplicate events to the configured database",
+    )
+    return parser
 
 
-async def seed_from_spreadsheet(spreadsheet_path: Path) -> int:
-    if not spreadsheet_path.exists():
-        print(f"Spreadsheet not found: {spreadsheet_path}", file=sys.stderr)
-        return 0
-
-    wb = load_workbook(spreadsheet_path, data_only=True)
-    if "FY26" not in wb.sheetnames:
-        print("FY26 sheet not found in spreadsheet", file=sys.stderr)
-        return 0
-
-    ws = wb["FY26"]
-    rows = list(ws.iter_rows(min_row=2, values_only=True))
-
-    inserted = 0
+async def _run(args: argparse.Namespace) -> int:
+    plan = load_import_plan(
+        args.spreadsheet,
+        sheet_names=args.sheets,
+        from_date=args.from_date,
+        through_date=args.through_date,
+        include_tentative=not args.confirmed_only,
+    )
     async with async_session_factory() as session:
-        for row in rows:
-            if not row or len(row) < 3:
-                continue
-            date_cell, start_time, event, location, sponsor, ticketed = (row + (None,) * 6)[:6]
-            if not event or not str(event).strip():
-                continue
-            event_title = str(event).strip()
-            event_date = _parse_cell_date(date_cell)
-            if event_date is None:
-                # Skip rows without a resolvable date.
-                continue
-            if event_date.year != 2026:
-                # One known row has a 2024 typo for the Boise Commencement.
-                continue
-            if event_date.month not in (4, 5):
-                continue
+        result = await import_records(session, plan, apply_changes=args.apply)
 
-            # Idempotency check
-            existing = await session.execute(
-                select(Submission)
-                .join(Submission.Schedule_Requests)
-                .where(
-                    Submission.Submitter_Email == SEED_EMAIL,
-                    Submission.Original_Headline == event_title,
-                    SubmissionScheduleRequest.Requested_Date == event_date,
-                )
+    confirmed = sum(not record.tentative for record in plan.records)
+    tentative = len(plan.records) - confirmed
+    mode = "APPLY" if args.apply else "DRY RUN"
+    print(f"[{mode}] {plan.workbook_name}")
+    print(f"Validated: {len(plan.records)} events ({confirmed} confirmed, {tentative} tentative)")
+    print(f"Existing: {result.existing}")
+    if args.apply:
+        print(f"Inserted: {result.inserted}")
+    else:
+        print(f"Would insert: {result.would_insert}")
+
+    if plan.issues:
+        counts = ", ".join(
+            f"{code}={count}" for code, count in sorted(plan.issue_counts().items())
+        )
+        print(f"Not imported: {len(plan.issues)} ({counts})")
+        for issue in plan.issues:
+            if issue.code in {"before_window", "after_window"}:
+                continue
+            print(
+                f"  {issue.sheet_name}!{issue.row_number}: {issue.title} "
+                f"[{issue.source_date or 'no date'}] — {issue.message}"
             )
-            if existing.scalar_one_or_none():
-                continue
-
-            body = _build_body(
-                event_title,
-                str(location).strip() if location else None,
-                str(sponsor).strip() if sponsor else None,
-                str(start_time).strip() if start_time else None,
-                str(ticketed).strip() if ticketed else None,
-            )
-
-            submission = Submission(
-                Category="slc_event",
-                Target_Newsletter="none",
-                Original_Headline=event_title,
-                Original_Body=body,
-                Submitter_Name=SEED_NAME,
-                Submitter_Email=SEED_EMAIL,
-                Show_In_SLC_Calendar=True,
-                Event_Classification=None,
-                Status="approved",
-            )
-            session.add(submission)
-            await session.flush()
-
-            session.add(
-                SubmissionScheduleRequest(
-                    Submission_Id=submission.Id,
-                    Requested_Date=event_date,
-                    Repeat_Count=1,
-                    Recurrence_Type="once",
-                    Recurrence_Interval=1,
-                    Excluded_Dates=[],
-                )
-            )
-            inserted += 1
-
-        await session.commit()
-
-    return inserted
+    return 0
 
 
-async def main() -> None:
-    count = await seed_from_spreadsheet(SPREADSHEET)
-    print(f"Inserted {count} SLC events from {SPREADSHEET.name}")
+def main() -> int:
+    warnings.filterwarnings("ignore", category=UserWarning, module="openpyxl")
+    args = _build_parser().parse_args()
+    if not args.spreadsheet.is_file():
+        raise SystemExit(f"Spreadsheet not found: {args.spreadsheet}")
+    if args.through_date and args.through_date < args.from_date:
+        raise SystemExit("--through-date cannot be before --from-date")
+    return asyncio.run(_run(args))
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    raise SystemExit(main())

--- a/backend/tests/test_slc_event_import.py
+++ b/backend/tests/test_slc_event_import.py
@@ -1,0 +1,114 @@
+"""Tests for the guarded SLC calendar spreadsheet importer."""
+
+from datetime import date, datetime
+
+import pytest
+from openpyxl import Workbook
+from sqlalchemy import func, select
+
+from app.models.submission import Submission, SubmissionScheduleRequest
+from app.services.slc_event_import_service import (
+    DateParseError,
+    import_records,
+    load_import_plan,
+    parse_event_date,
+)
+
+
+def test_parse_event_date_infers_fiscal_year_and_preserves_tentative_range():
+    schedules, tentative, source = parse_event_date("2/25-3/7?", 2027)
+
+    assert tentative is True
+    assert source == "2/25-3/7?"
+    assert schedules[0].start_date == date(2027, 2, 25)
+    assert schedules[0].end_date == date(2027, 3, 7)
+
+
+def test_parse_event_date_accepts_native_excel_date():
+    schedules, tentative, _source = parse_event_date(datetime(2026, 8, 26), 2027)
+
+    assert tentative is False
+    assert schedules[0].start_date == date(2026, 8, 26)
+
+
+@pytest.mark.parametrize("source", ["9/17 or 9/24", "3/25 or 4/1 or 4/8?"])
+def test_parse_event_date_rejects_alternatives(source: str):
+    with pytest.raises(DateParseError, match="require confirmation") as error:
+        parse_event_date(source, 2027)
+
+    assert error.value.code == "ambiguous_date"
+
+
+def test_parse_event_date_rejects_year_outside_fiscal_sheet():
+    with pytest.raises(DateParseError, match="outside FY27") as error:
+        parse_event_date("11/5/2025?", 2027)
+
+    assert error.value.code == "outside_fiscal_year"
+
+
+def _write_workbook(path):
+    workbook = Workbook()
+    worksheet = workbook.active
+    worksheet.title = "FY27"
+    worksheet.append(["Date", "Start Time", "Event", "Location", "Sponsor", "Catatory"])
+    worksheet.append([datetime(2026, 8, 19), "8A", "Past event", "Wallace", "AUX", "SLC Leadership"])
+    worksheet.append([datetime(2026, 8, 26), None, "Confirmed event", "Boise SUB", "ACMS", "SLC Leadership"])
+    worksheet.append(["10/18-10/24", None, "Date range", None, None, "SLC Leadership"])
+    worksheet.append(["11/5/26?", "5:30P", "Tentative event", "Ballroom", "Vandals First", "SLC Leadership"])
+    worksheet.append(["11/19 or 11/20", "7P", "Ambiguous event", "Auditorium", "ACMS", "Concert"])
+    workbook.create_sheet("Metadata")
+    workbook.save(path)
+
+
+def test_load_import_plan_filters_past_and_reports_ambiguous_dates(tmp_path):
+    workbook_path = tmp_path / "calendar.xlsx"
+    _write_workbook(workbook_path)
+
+    plan = load_import_plan(workbook_path, from_date=date(2026, 8, 20))
+
+    assert [record.title for record in plan.records] == [
+        "Confirmed event",
+        "Date range",
+        "Tentative event",
+    ]
+    assert plan.records[1].schedules[0].end_date == date(2026, 10, 24)
+    assert plan.records[2].tentative is True
+    assert plan.records[0].detail_label == "Category"
+    assert plan.issue_counts() == {"before_window": 1, "ambiguous_date": 1}
+
+
+@pytest.mark.asyncio
+async def test_import_records_is_idempotent_and_preserves_source_context(tmp_path, db):
+    workbook_path = tmp_path / "calendar.xlsx"
+    _write_workbook(workbook_path)
+    plan = load_import_plan(workbook_path, from_date=date(2026, 8, 20))
+
+    preview = await import_records(db, plan, apply_changes=False)
+    first = await import_records(db, plan, apply_changes=True)
+    second = await import_records(db, plan, apply_changes=True)
+
+    assert preview.would_insert == 3
+    assert first.inserted == 3
+    assert second.inserted == 0
+    assert second.existing == 3
+
+    submissions = list((await db.execute(select(Submission))).scalars())
+    assert len(submissions) == 3
+    tentative = next(item for item in submissions if item.Original_Headline == "Tentative event")
+    assert tentative.Target_Newsletter == "none"
+    assert tentative.Show_In_SLC_Calendar is True
+    assert tentative.Status == "pending_info"
+    assert "Date status: Tentative" in tentative.Original_Body
+    assert "SLC spreadsheet import key:" in tentative.Submitter_Notes
+
+    range_schedule = (
+        await db.execute(
+            select(SubmissionScheduleRequest)
+            .join(Submission)
+            .where(Submission.Original_Headline == "Date range")
+        )
+    ).scalar_one()
+    assert range_schedule.Recurrence_Type == "date_range"
+    assert range_schedule.Requested_Date == date(2026, 10, 18)
+    assert range_schedule.Recurrence_End_Date == date(2026, 10, 24)
+    assert (await db.execute(select(func.count()).select_from(Submission))).scalar_one() == 3


### PR DESCRIPTION
## Summary
- replace the one-off FY26 seed with a reusable fiscal-year workbook importer
- default to dry-run validation, future-date filtering, and duplicate protection
- preserve source context while reporting tentative, ambiguous, and invalid dates
- add focused importer tests and the required Excel dependency

## Validation
- `backend/.venv/bin/ruff check backend/app/services/slc_event_import_service.py backend/scripts/seed_slc_events.py backend/tests/test_slc_event_import.py`
- `backend/.venv/bin/pytest backend/tests -q` (334 passed)
- deployed to dev and verified 32 confirmed FY27 events through the SLC API
- repeated dry run reported all 32 as existing and zero new inserts